### PR TITLE
feat(pdf): progressive reveal - PDF button shows after first sim, updates count as more matchups run

### DIFF
--- a/poke-sim/pokemon-champion-2026.html
+++ b/poke-sim/pokemon-champion-2026.html
@@ -9626,6 +9626,45 @@ function displayResults(res, oppKey) {
 
   // Auto-show inline pilot card after every single sim
   showInlinePilotCard(oppKey, res);
+
+  // PDF progressive reveal (Refs #57) - after ANY single sim, stash the
+  // result so the PDF button can build a fresh packet. Each new sim either
+  // adds a new matchup entry or replaces the prior one for the same
+  // opponent, so the button always regenerates from the latest data.
+  if (!window.lastSimResults) window.lastSimResults = {};
+  window.lastSimResults[oppKey] = res;
+  revealPdfButton();
+}
+
+// PDF progressive reveal (Refs #57) - show the Download PDF Report button
+// as soon as there is at least one matchup in lastSimResults, and relabel
+// it so users know how many matchups the next PDF click will include.
+function revealPdfButton() {
+  var btn = document.getElementById('pdf-report-btn');
+  if (!btn) return;
+  var count = Object.keys(window.lastSimResults || {}).length;
+  if (count < 1) return;
+  btn.style.display = '';
+  var label = btn.querySelector('.pdf-btn-label');
+  if (!label) {
+    // First reveal - wrap the text node so we can update the count later
+    // without clobbering the icon SVG.
+    var textNode = Array.from(btn.childNodes).find(function(n){
+      return n.nodeType === 3 && n.textContent.trim().length > 0;
+    });
+    if (textNode) {
+      label = document.createElement('span');
+      label.className = 'pdf-btn-label';
+      label.textContent = textNode.textContent.trim();
+      btn.replaceChild(label, textNode);
+    }
+  }
+  if (label) {
+    label.textContent = count === 1
+      ? 'Download PDF Report (1 matchup)'
+      : 'Download PDF Report (' + count + ' matchups)';
+  }
+  btn.title = 'Generates a fresh PDF packet from the latest simulation data (' + count + ' matchup' + (count === 1 ? '' : 's') + ' included). Run another sim to refresh.';
 }
 
 // ============================================================
@@ -10037,8 +10076,9 @@ document.getElementById('run-all-btn')?.addEventListener('click', async function
   });
 
   document.getElementById('progress-wrap').style.display='none';
-  const pdfBtn = document.getElementById('pdf-report-btn');
-  if (pdfBtn) pdfBtn.style.display = '';
+  // Refs #57 - progressive reveal helper relabels with the correct matchup
+  // count and binds the tooltip. Replaces the old hardcoded display='' line.
+  revealPdfButton();
   // T9j.16 (Refs #65) - auto-save Strategy Report after Run All Matchups completes.
   // Persists to localStorage keyed on teamSignature so any imported team gets continuity.
   try { if (typeof t9j16AutoSave === 'function') t9j16AutoSave(); } catch(e) { console.warn('[T9j.16] autosave skipped:', e && e.message); }

--- a/poke-sim/ui.js
+++ b/poke-sim/ui.js
@@ -1554,6 +1554,45 @@ function displayResults(res, oppKey) {
 
   // Auto-show inline pilot card after every single sim
   showInlinePilotCard(oppKey, res);
+
+  // PDF progressive reveal (Refs #57) - after ANY single sim, stash the
+  // result so the PDF button can build a fresh packet. Each new sim either
+  // adds a new matchup entry or replaces the prior one for the same
+  // opponent, so the button always regenerates from the latest data.
+  if (!window.lastSimResults) window.lastSimResults = {};
+  window.lastSimResults[oppKey] = res;
+  revealPdfButton();
+}
+
+// PDF progressive reveal (Refs #57) - show the Download PDF Report button
+// as soon as there is at least one matchup in lastSimResults, and relabel
+// it so users know how many matchups the next PDF click will include.
+function revealPdfButton() {
+  var btn = document.getElementById('pdf-report-btn');
+  if (!btn) return;
+  var count = Object.keys(window.lastSimResults || {}).length;
+  if (count < 1) return;
+  btn.style.display = '';
+  var label = btn.querySelector('.pdf-btn-label');
+  if (!label) {
+    // First reveal - wrap the text node so we can update the count later
+    // without clobbering the icon SVG.
+    var textNode = Array.from(btn.childNodes).find(function(n){
+      return n.nodeType === 3 && n.textContent.trim().length > 0;
+    });
+    if (textNode) {
+      label = document.createElement('span');
+      label.className = 'pdf-btn-label';
+      label.textContent = textNode.textContent.trim();
+      btn.replaceChild(label, textNode);
+    }
+  }
+  if (label) {
+    label.textContent = count === 1
+      ? 'Download PDF Report (1 matchup)'
+      : 'Download PDF Report (' + count + ' matchups)';
+  }
+  btn.title = 'Generates a fresh PDF packet from the latest simulation data (' + count + ' matchup' + (count === 1 ? '' : 's') + ' included). Run another sim to refresh.';
 }
 
 // ============================================================
@@ -1965,8 +2004,9 @@ document.getElementById('run-all-btn')?.addEventListener('click', async function
   });
 
   document.getElementById('progress-wrap').style.display='none';
-  const pdfBtn = document.getElementById('pdf-report-btn');
-  if (pdfBtn) pdfBtn.style.display = '';
+  // Refs #57 - progressive reveal helper relabels with the correct matchup
+  // count and binds the tooltip. Replaces the old hardcoded display='' line.
+  revealPdfButton();
   // T9j.16 (Refs #65) - auto-save Strategy Report after Run All Matchups completes.
   // Persists to localStorage keyed on teamSignature so any imported team gets continuity.
   try { if (typeof t9j16AutoSave === 'function') t9j16AutoSave(); } catch(e) { console.warn('[T9j.16] autosave skipped:', e && e.message); }


### PR DESCRIPTION
## Summary

Makes the **Download PDF Report** button appear after the user's
**first single sim** instead of only after Run All Matchups, and
refreshes the packet contents every time another sim runs. Replacing
the prior sim for the same opponent does not double-count.

Closes the discoverability gap where users who only ran a single
matchup never knew the PDF feature existed.

## Behavior

| Action | Button state | Label |
|---|---|---|
| Page load | Hidden | (hidden) |
| Run sim vs Opp A | Shown | Download PDF Report (1 matchup) |
| Run sim vs Opp B | Shown | Download PDF Report (2 matchups) |
| Re-run sim vs Opp A | Shown | Download PDF Report (2 matchups) |
| Click button | Triggers print dialog with the latest packet | (unchanged) |
| Run All Matchups | Shown | Download PDF Report (13 matchups) |

Hovering the button shows a tooltip:
> Generates a fresh PDF packet from the latest simulation data
> (N matchups included). Run another sim to refresh.

## What changed

`poke-sim/ui.js`:

1. `displayResults` (single-sim path) now stores `res` into
   `window.lastSimResults[oppKey]` after every successful sim.
   Same opponent overwrites; new opponent adds an entry.
2. New `revealPdfButton()` helper:
   - Unhides the button the first time at least one matchup exists.
   - Wraps the button text in `<span class="pdf-btn-label">` on first
     reveal so subsequent updates do not clobber the file icon SVG.
   - Relabels with the matchup count.
   - Sets the explanatory tooltip.
3. `Run All Matchups` handler now calls `revealPdfButton()` instead
   of hardcoding `display=''` so both flows share the same labeling
   logic.

`poke-sim/pokemon-champion-2026.html`:

- Rebuilt offline bundle (507,912 bytes).

## Non-coder summary

Run a single matchup and the **Download PDF Report** button now shows
up. Run more matchups and the button label updates to tell you how
many are included. Click whenever you want the PDF - it always reflects
the freshest data. Re-running the same opponent overwrites that prior
result rather than adding a duplicate.

## Validation

Headless browser smoke test on the deployed preview:

- INITIAL: `{display:"none", text:"Download PDF Report"}`
- AFTER 1 SIM: `{display:"", text:"Download PDF Report (1 matchup)", count:1}`
- AFTER 2 SIMS (different opp): `{text:"Download PDF Report (2 matchups)", count:2}`
- AFTER 3 SIMS (repeat opp): `{text:"Download PDF Report (2 matchups)", count:2}` (replace not add)
- PDF CLICK: `{contentLen:6642, printed:true}` (no errors thrown)

`node --check` clean on data.js, engine.js, ui.js.

Refs #57
