### PR TITLE
infra: bump CACHE_NAME to champions-sim-v5-phase3

### DIFF
--- a/poke-sim/sw.js
+++ b/poke-sim/sw.js
@@ -4,7 +4,7 @@
 // MUST be bumped on every release that changes engine.js, data.js, ui.js, or style.css
 // Phase 2 automation tracked in #95 (tools/release.sh)
 
-const CACHE_NAME = 'champions-sim-v4-t9j16';
+const CACHE_NAME = 'champions-sim-v5-phase3';
 const SPRITE_CACHE = 'champions-sprites-v1';
 
 const APP_ASSETS = [


### PR DESCRIPTION
## Bump CACHE_NAME for Phase 2 + Phase 3 release

Per [MASTER_PROMPT.md L132](https://github.com/alfredocox/Pokemon-Champions-Sim-Planner/blob/main/MASTER_PROMPT.md#L132):

> CACHE_NAME bump rule: Must be updated on every release that changes engine.js, data.js, ui.js, or style.css. Format: champions-sim-v{major}-{release-tag}.

PRs #106 and #108 both changed `ui.js`, and #106 also changed `style.css` and `index.html`, but neither bumped CACHE_NAME. Returning users on the old service worker will be served stale cache and will not see the Strategy tab or persistence until they hard-reload.

### Bump
- `champions-sim-v4-t9j16` -> `champions-sim-v5-phase3`
- Major bumped (v4 -> v5) because Phase 2 + 3 added a whole new tab (Strategy) and persistence layer — meets the spec's "breaking engine change" bar in spirit.
- Tag `phase3` matches the release naming we used in the version chip (`v2.1.0-phase3.1`).

### How
Ran `./tools/release.sh phase3 --bump-major` per Phase 2 of #95. Tool worked as designed:
- Detected current major (v4)
- Computed new name
- Single sed rewrite, staged for review

### Files
- `poke-sim/sw.js` (1 line)

### Validation
```
$ grep CACHE_NAME poke-sim/sw.js
const CACHE_NAME = 'champions-sim-v5-phase3';
```

Refs #95
