### PR TITLE
fix(sprites): fallback map for custom mega/regional forms

### DIFF
--- a/poke-sim/data.js
+++ b/poke-sim/data.js
@@ -758,13 +758,62 @@ const POKEMON_TYPES_DB = {
   'Torkoal':['Fire'],
 };
 
+// Explicit sprite overrides for custom / regional / special forms that either
+// have no PokeAPI dex entry or use a numeric form-ID file.
+// Keys are the exact member.name strings we ship in TEAMS.
+// Values are the raw PokeAPI sprite URL (ends in NUMBER.png).
+//
+// Added during sprite audit after Phase 3 - every entry here was a 404 before.
+const SPRITE_URL_BASE = 'https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon';
+const CUSTOM_FORM_SPRITES = {
+  // Custom megas (Champions 2026 format) - no PokeAPI entry, fall back to base dex sprite.
+  'Froslass-Mega':                  SPRITE_URL_BASE + '/478.png',
+  'Meganium-Mega':                  SPRITE_URL_BASE + '/154.png',
+  'Golurk-Mega':                    SPRITE_URL_BASE + '/623.png',
+  'Floette (Eternal Flower)-Mega':  SPRITE_URL_BASE + '/670.png',
+  // Form variants stored under numeric form IDs on the CDN.
+  'Ursaluna-Bloodmoon':             SPRITE_URL_BASE + '/10272.png'
+};
+
+// Suffixes we strip when falling back to the base-form dex sprite.
+// Order matters: longer / more specific variants first (Mega-X before Mega).
+const SPRITE_STRIP_SUFFIXES = [
+  '-Mega-X', '-Mega-Y', '-Mega',
+  '-Alola', '-Galar', '-Hisui', '-Paldea',
+  '-Gmax'
+];
+
 function getSpriteUrl(name) {
-  // Direct lookup in expanded dex map
+  if (!name) return SPRITE_URL_BASE + '/0.png';
+
+  // 1. Explicit override wins every time (custom megas, numeric form IDs).
+  if (CUSTOM_FORM_SPRITES[name]) return CUSTOM_FORM_SPRITES[name];
+
+  // 2. Direct lookup by exact name.
   const num = DEX_NUM_MAP[name];
-  if (num) return `https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/${num}.png`;
-  // Fallback: slugify and hit PokeAPI (async resolution via onerror)
-  const slug = name.toLowerCase().replace(/[^a-z0-9-]/g, '-').replace(/-+/g, '-').replace(/-(mega|alola|galar|hisui)$/i, '').replace(/^-|-$/g, '');
-  return `https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/${slug}.png`;
+  if (num) return SPRITE_URL_BASE + '/' + num + '.png';
+
+  // 3. Strip a known form suffix and retry the dex lookup.
+  //    Example: Golurk-Mega -> Golurk -> 623. Prevents the bad slug-URL path
+  //    that was producing 404s before the sprite audit.
+  for (let i = 0; i < SPRITE_STRIP_SUFFIXES.length; i++) {
+    const suffix = SPRITE_STRIP_SUFFIXES[i];
+    if (name.endsWith(suffix)) {
+      const base = name.slice(0, -suffix.length);
+      if (DEX_NUM_MAP[base]) return SPRITE_URL_BASE + '/' + DEX_NUM_MAP[base] + '.png';
+    }
+  }
+
+  // 4. Strip a parenthetical form tag: 'Floette (Eternal Flower)' -> 'Floette'.
+  //    Covers compound form names that still fail the stripped-suffix retry.
+  const parenStripped = name.replace(/\s*\([^)]*\)\s*/g, '').trim();
+  if (parenStripped !== name && DEX_NUM_MAP[parenStripped]) {
+    return SPRITE_URL_BASE + '/' + DEX_NUM_MAP[parenStripped] + '.png';
+  }
+
+  // 5. Last-ditch slug path (preserves legacy behavior for anything unknown).
+  const slug = name.toLowerCase().replace(/[^a-z0-9-]/g, '-').replace(/-+/g, '-').replace(/^-|-$/g, '');
+  return SPRITE_URL_BASE + '/' + slug + '.png';
 }
 
 // ============================================================

--- a/poke-sim/index.html
+++ b/poke-sim/index.html
@@ -43,7 +43,7 @@
         <path d="M 21 6 L 16.5 16 L 19.5 16 L 15.5 28 L 21.5 15.5 L 18.5 15.5 L 22 6 Z" fill="url(#hBolt)" stroke="#ecfeff" stroke-width="0.5" stroke-linejoin="round"/>
       </svg>
       <div>
-        <h1 class="site-title">Pokémon Champion 2026 <span class="build-version" id="build-version" title="Build version - bumps on every commit so you can confirm which build you are testing">v2.1.0-phase3.1</span></h1>
+        <h1 class="site-title">Pokémon Champion 2026 <span class="build-version" id="build-version" title="Build version - bumps on every commit so you can confirm which build you are testing">v2.1.1-sprite.1</span></h1>
         <p class="site-sub">April 2026 Meta · VGC Doubles Simulator</p>
       </div>
     </div>

--- a/poke-sim/pokemon-champion-2026.html
+++ b/poke-sim/pokemon-champion-2026.html
@@ -1147,7 +1147,7 @@ table{border-collapse:collapse;width:100%}
         <path d="M 21 6 L 16.5 16 L 19.5 16 L 15.5 28 L 21.5 15.5 L 18.5 15.5 L 22 6 Z" fill="url(#hBolt)" stroke="#ecfeff" stroke-width="0.5" stroke-linejoin="round"/>
       </svg>
       <div>
-        <h1 class="site-title">Pokémon Champion 2026 <span class="build-version" id="build-version" title="Build version - bumps on every commit so you can confirm which build you are testing">v2.1.0-phase3.1</span></h1>
+        <h1 class="site-title">Pokémon Champion 2026 <span class="build-version" id="build-version" title="Build version - bumps on every commit so you can confirm which build you are testing">v2.1.1-sprite.1</span></h1>
         <p class="site-sub">April 2026 Meta · VGC Doubles Simulator</p>
       </div>
     </div>
@@ -2419,13 +2419,62 @@ const POKEMON_TYPES_DB = {
   'Torkoal':['Fire'],
 };
 
+// Explicit sprite overrides for custom / regional / special forms that either
+// have no PokeAPI dex entry or use a numeric form-ID file.
+// Keys are the exact member.name strings we ship in TEAMS.
+// Values are the raw PokeAPI sprite URL (ends in NUMBER.png).
+//
+// Added during sprite audit after Phase 3 - every entry here was a 404 before.
+const SPRITE_URL_BASE = 'https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon';
+const CUSTOM_FORM_SPRITES = {
+  // Custom megas (Champions 2026 format) - no PokeAPI entry, fall back to base dex sprite.
+  'Froslass-Mega':                  SPRITE_URL_BASE + '/478.png',
+  'Meganium-Mega':                  SPRITE_URL_BASE + '/154.png',
+  'Golurk-Mega':                    SPRITE_URL_BASE + '/623.png',
+  'Floette (Eternal Flower)-Mega':  SPRITE_URL_BASE + '/670.png',
+  // Form variants stored under numeric form IDs on the CDN.
+  'Ursaluna-Bloodmoon':             SPRITE_URL_BASE + '/10272.png'
+};
+
+// Suffixes we strip when falling back to the base-form dex sprite.
+// Order matters: longer / more specific variants first (Mega-X before Mega).
+const SPRITE_STRIP_SUFFIXES = [
+  '-Mega-X', '-Mega-Y', '-Mega',
+  '-Alola', '-Galar', '-Hisui', '-Paldea',
+  '-Gmax'
+];
+
 function getSpriteUrl(name) {
-  // Direct lookup in expanded dex map
+  if (!name) return SPRITE_URL_BASE + '/0.png';
+
+  // 1. Explicit override wins every time (custom megas, numeric form IDs).
+  if (CUSTOM_FORM_SPRITES[name]) return CUSTOM_FORM_SPRITES[name];
+
+  // 2. Direct lookup by exact name.
   const num = DEX_NUM_MAP[name];
-  if (num) return `https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/${num}.png`;
-  // Fallback: slugify and hit PokeAPI (async resolution via onerror)
-  const slug = name.toLowerCase().replace(/[^a-z0-9-]/g, '-').replace(/-+/g, '-').replace(/-(mega|alola|galar|hisui)$/i, '').replace(/^-|-$/g, '');
-  return `https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/${slug}.png`;
+  if (num) return SPRITE_URL_BASE + '/' + num + '.png';
+
+  // 3. Strip a known form suffix and retry the dex lookup.
+  //    Example: Golurk-Mega -> Golurk -> 623. Prevents the bad slug-URL path
+  //    that was producing 404s before the sprite audit.
+  for (let i = 0; i < SPRITE_STRIP_SUFFIXES.length; i++) {
+    const suffix = SPRITE_STRIP_SUFFIXES[i];
+    if (name.endsWith(suffix)) {
+      const base = name.slice(0, -suffix.length);
+      if (DEX_NUM_MAP[base]) return SPRITE_URL_BASE + '/' + DEX_NUM_MAP[base] + '.png';
+    }
+  }
+
+  // 4. Strip a parenthetical form tag: 'Floette (Eternal Flower)' -> 'Floette'.
+  //    Covers compound form names that still fail the stripped-suffix retry.
+  const parenStripped = name.replace(/\s*\([^)]*\)\s*/g, '').trim();
+  if (parenStripped !== name && DEX_NUM_MAP[parenStripped]) {
+    return SPRITE_URL_BASE + '/' + DEX_NUM_MAP[parenStripped] + '.png';
+  }
+
+  // 5. Last-ditch slug path (preserves legacy behavior for anything unknown).
+  const slug = name.toLowerCase().replace(/[^a-z0-9-]/g, '-').replace(/-+/g, '-').replace(/^-|-$/g, '');
+  return SPRITE_URL_BASE + '/' + slug + '.png';
 }
 
 // ============================================================

--- a/poke-sim/sw.js
+++ b/poke-sim/sw.js
@@ -4,7 +4,7 @@
 // MUST be bumped on every release that changes engine.js, data.js, ui.js, or style.css
 // Phase 2 automation tracked in #95 (tools/release.sh)
 
-const CACHE_NAME = 'champions-sim-v5-phase3';
+const CACHE_NAME = 'champions-sim-v5-sprite1';
 const SPRITE_CACHE = 'champions-sprites-v1';
 
 const APP_ASSETS = [


### PR DESCRIPTION
## Sprite fallback for custom mega / regional forms

Fixes the blank-sprite bug you caught in the Set Editor (Golurk-Mega screenshot). Audit revealed **5 of 49 unique sprite URLs 404** across the 22 loaded teams; all 5 now resolve to valid PokeAPI sprites.

### Audit results

| Member | Team | Before | After |
|--------|------|--------|-------|
| Froslass-Mega | aurora_veil_froslass, benny_v_mega_froslass | 404 | `/478.png` (200) |
| Ursaluna-Bloodmoon | chuppa_balance | 404 | `/10272.png` (200) |
| Meganium-Mega | rain_offense | 404 | `/154.png` (200) |
| Golurk-Mega | trick_room_golurk | 404 | `/623.png` (200) |
| Floette (Eternal Flower)-Mega | z2r_feitosa_mega_floette | 404 | `/670.png` (200) |

Post-fix: **0 failures across all 132 team members.**

### Root cause
`getSpriteUrl()` looked up `DEX_NUM_MAP` by exact name, then fell through to a slug path that produced URLs like `/froslass-mega.png` and `/floette-eternal-flower.png` which don't exist on the PokeAPI sprite CDN. Custom Champions-format megas (Froslass-Mega, Golurk-Mega, etc.) have no PokeAPI dex entry at all, so no slug would ever work.

### Fix
Five-step resolver pipeline in `getSpriteUrl()`:

1. `CUSTOM_FORM_SPRITES[name]` explicit override (wins every time)
2. `DEX_NUM_MAP[name]` exact lookup (unchanged)
3. Strip known form suffix and retry dex lookup: `-Mega-X`, `-Mega-Y`, `-Mega`, `-Alola`, `-Galar`, `-Hisui`, `-Paldea`, `-Gmax`
4. Strip parenthetical form tag: `Floette (Eternal Flower)` -> `Floette`
5. Legacy slug path (preserved so no regression for anything currently working)

Example: `Golurk-Mega` hits step 1 (explicit override to `/623.png`) but would also succeed at step 3 (`-Mega` stripped -> `Golurk` -> 623). Two layers of defense.

### CUSTOM_FORM_SPRITES entries (all HTTP-verified 200)
```javascript
'Froslass-Mega':                  '/478.png',
'Meganium-Mega':                  '/154.png',
'Golurk-Mega':                    '/623.png',
'Floette (Eternal Flower)-Mega':  '/670.png',
'Ursaluna-Bloodmoon':             '/10272.png'  // numeric form ID
```

### Files (4)
- `poke-sim/data.js` — new resolver pipeline + override map
- `poke-sim/index.html` — version chip `v2.1.0-phase3.1` -> `v2.1.1-sprite.1`
- `poke-sim/sw.js` — CACHE_NAME `champions-sim-v5-phase3` -> `champions-sim-v5-sprite1` (via `tools/release.sh sprite1`)
- `poke-sim/pokemon-champion-2026.html` — bundle rebuild (647,634 bytes)

### Validation
- `node --check` clean on data.js, engine.js, ui.js
- Full 132-member sprite audit: 0 HTTP failures
- Each override URL individually curl'd: all 200
- Suffix-strip fallback verified by tracing `Golurk-Mega` through all 5 resolver steps

### Resolves
- MASTER_PROMPT "Sprite Gaps — known" section (added in PR #110) — all confirmed misses closed

Refs #95
