### PR TITLE
fix(coach): exclude Ghost types and Inner Focus from Fake Out pressure mistake

### DIFF
--- a/poke-sim/index.html
+++ b/poke-sim/index.html
@@ -43,7 +43,7 @@
         <path d="M 21 6 L 16.5 16 L 19.5 16 L 15.5 28 L 21.5 15.5 L 18.5 15.5 L 22 6 Z" fill="url(#hBolt)" stroke="#ecfeff" stroke-width="0.5" stroke-linejoin="round"/>
       </svg>
       <div>
-        <h1 class="site-title">Pokémon Champion 2026 <span class="build-version" id="build-version" title="Build version - bumps on every commit so you can confirm which build you are testing">v2.1.1-sprite.1</span></h1>
+        <h1 class="site-title">Pokémon Champion 2026 <span class="build-version" id="build-version" title="Build version - bumps on every commit so you can confirm which build you are testing">v2.1.2-fakeout.1</span></h1>
         <p class="site-sub">April 2026 Meta · VGC Doubles Simulator</p>
       </div>
     </div>

--- a/poke-sim/pokemon-champion-2026.html
+++ b/poke-sim/pokemon-champion-2026.html
@@ -1147,7 +1147,7 @@ table{border-collapse:collapse;width:100%}
         <path d="M 21 6 L 16.5 16 L 19.5 16 L 15.5 28 L 21.5 15.5 L 18.5 15.5 L 22 6 Z" fill="url(#hBolt)" stroke="#ecfeff" stroke-width="0.5" stroke-linejoin="round"/>
       </svg>
       <div>
-        <h1 class="site-title">Pokémon Champion 2026 <span class="build-version" id="build-version" title="Build version - bumps on every commit so you can confirm which build you are testing">v2.1.1-sprite.1</span></h1>
+        <h1 class="site-title">Pokémon Champion 2026 <span class="build-version" id="build-version" title="Build version - bumps on every commit so you can confirm which build you are testing">v2.1.2-fakeout.1</span></h1>
         <p class="site-sub">April 2026 Meta · VGC Doubles Simulator</p>
       </div>
     </div>
@@ -12833,11 +12833,30 @@ function csMistakes(team, identity, format) {
   var rules = [];
 
   // Lead-trap rules (highest severity)
+  // Fake Out is a Normal-type move. Ghost types are 0x immune, and Inner Focus
+  // / Own Tempo / Oblivious ignore the flinch. So a Ghost lead or an
+  // Inner-Focus lead is NOT vulnerable to Fake Out pressure and this rule
+  // should not fire for them. Bug caught in Froslass's Team build v2.1.1:
+  // coach was warning "do not lead Froslass-Mega into Fake Out pressure" even
+  // though Froslass is Ice/Ghost and cannot be touched by Fake Out at all.
+  // Cite: https://bulbapedia.bulbagarden.net/wiki/Fake_Out_(move) (Normal-type)
+  // Cite: https://www.serebii.net/abilitydex/innerfocus.shtml (flinch immune)
+  var FAKE_OUT_IMMUNE_ABILITIES = ['Inner Focus', 'Own Tempo', 'Oblivious'];
+  function _fakeOutVulnerable(m) {
+    // Ghost types: Normal move does 0 damage -> no flinch roll either.
+    var types = (typeof getPokemonTypes === 'function') ? getPokemonTypes(m.name) : [];
+    if (types.indexOf('Ghost') >= 0) return false;
+    // Inner Focus / Own Tempo / Oblivious mons: take the chip damage but no
+    // flinch, so Fake Out "pressure" loses its tempo value on them.
+    if (FAKE_OUT_IMMUNE_ABILITIES.indexOf(m.ability || '') >= 0) return false;
+    return true;
+  }
   var fragileLeaders = members.filter(function(m){
     var stats = (typeof BASE_STATS !== 'undefined' && BASE_STATS[m.name]) ? BASE_STATS[m.name] : null;
     if (!stats) return false;
     var bulk = (stats.hp||0) * Math.max(stats.def||0, stats.spd||0);
-    return bulk < 12000;
+    if (bulk >= 12000) return false;
+    return _fakeOutVulnerable(m);
   });
   if (fragileLeaders.length && members.some(function(m){ return _pdfHasAny(m, PDF_FAKE_OUT); })) {
     rules.push({

--- a/poke-sim/sw.js
+++ b/poke-sim/sw.js
@@ -4,7 +4,7 @@
 // MUST be bumped on every release that changes engine.js, data.js, ui.js, or style.css
 // Phase 2 automation tracked in #95 (tools/release.sh)
 
-const CACHE_NAME = 'champions-sim-v5-sprite1';
+const CACHE_NAME = 'champions-sim-v5-fakeout1';
 const SPRITE_CACHE = 'champions-sprites-v1';
 
 const APP_ASSETS = [

--- a/poke-sim/ui.js
+++ b/poke-sim/ui.js
@@ -4361,11 +4361,30 @@ function csMistakes(team, identity, format) {
   var rules = [];
 
   // Lead-trap rules (highest severity)
+  // Fake Out is a Normal-type move. Ghost types are 0x immune, and Inner Focus
+  // / Own Tempo / Oblivious ignore the flinch. So a Ghost lead or an
+  // Inner-Focus lead is NOT vulnerable to Fake Out pressure and this rule
+  // should not fire for them. Bug caught in Froslass's Team build v2.1.1:
+  // coach was warning "do not lead Froslass-Mega into Fake Out pressure" even
+  // though Froslass is Ice/Ghost and cannot be touched by Fake Out at all.
+  // Cite: https://bulbapedia.bulbagarden.net/wiki/Fake_Out_(move) (Normal-type)
+  // Cite: https://www.serebii.net/abilitydex/innerfocus.shtml (flinch immune)
+  var FAKE_OUT_IMMUNE_ABILITIES = ['Inner Focus', 'Own Tempo', 'Oblivious'];
+  function _fakeOutVulnerable(m) {
+    // Ghost types: Normal move does 0 damage -> no flinch roll either.
+    var types = (typeof getPokemonTypes === 'function') ? getPokemonTypes(m.name) : [];
+    if (types.indexOf('Ghost') >= 0) return false;
+    // Inner Focus / Own Tempo / Oblivious mons: take the chip damage but no
+    // flinch, so Fake Out "pressure" loses its tempo value on them.
+    if (FAKE_OUT_IMMUNE_ABILITIES.indexOf(m.ability || '') >= 0) return false;
+    return true;
+  }
   var fragileLeaders = members.filter(function(m){
     var stats = (typeof BASE_STATS !== 'undefined' && BASE_STATS[m.name]) ? BASE_STATS[m.name] : null;
     if (!stats) return false;
     var bulk = (stats.hp||0) * Math.max(stats.def||0, stats.spd||0);
-    return bulk < 12000;
+    if (bulk >= 12000) return false;
+    return _fakeOutVulnerable(m);
   });
   if (fragileLeaders.length && members.some(function(m){ return _pdfHasAny(m, PDF_FAKE_OUT); })) {
     rules.push({


### PR DESCRIPTION
## Bug
Coach was warning 'do not lead Froslass-Mega into Fake Out pressure' despite Froslass being Ice/Ghost (Normal move = 0x, no flinch roll).

## Fix (coach layer only)
- Added `_fakeOutVulnerable(m)` helper in `csMistakes` (ui.js ~L4361-4390)
- Excludes Ghost types (Normal immune, verified against engine TYPE_CHART)
- Excludes Inner Focus / Own Tempo / Oblivious (flinch immune)
- Cited Bulbapedia + Serebii in source comments

## Engine audit (no changes needed)
- `engine.js:823-854` TYPE_CHART has `Normal:{Ghost:0}`
- `engine.js:1774` flinch roll gated behind `if (dmg > 0)`
- Engine already correctly handles Fake Out vs Ghost

## Versioning
- Chip: v2.1.1-sprite.1 -> v2.1.2-fakeout.1
- CACHE_NAME: v5-sprite1 -> v5-fakeout1

## Test
- `node --check` all 3 JS files OK
- aurora_veil_froslass: now flags Dragonite (was Froslass-Mega)
- benny_v_mega_froslass: now flags Rotom-Heat (was Froslass-Mega + Basculegion)
- Control (player team): Incineroar still flagged correctly

Refs #46 #49