### PR TITLE
feat(phase4a): sim log foundation - koEvents + champions_sim_log_v1

### DIFF
--- a/poke-sim/PHASE4_DYNAMIC_ADVICE_SPEC.md
+++ b/poke-sim/PHASE4_DYNAMIC_ADVICE_SPEC.md
@@ -1,0 +1,249 @@
+# Phase 4 — Dynamic, Data-Driven Coaching Layer
+
+**Status:** DRAFT (for alfredocox review)
+**Author:** Computer (on behalf of alfredocox)
+**Base branch:** `main` @ `81083fe`
+**Target version:** `v2.2.0-phase4.1` (minor bump — new feature surface)
+**Target CACHE_NAME:** `champions-sim-v6-phase4`
+**Related:** Refs #52 #53 #54 #55 (Phase 4 Trend Analysis hook)
+
+---
+
+## Why
+
+The coaching layer today is **static rule-based** — e.g., "Do not lead Froslass into Fake Out pressure" fires from a type/BST heuristic, not from what actually happened in your sims. The user wants:
+
+> "real analitical feed back and dynamic advice that is tailored off the rating and more battle you sim with that team"
+
+Translation: coach should get **smarter the more you sim**, and surface patterns from **your actual battle history**, not just archetype rules.
+
+---
+
+## Scope (4 deliverables approved by user)
+
+1. **Confidence badges on existing static tips** — "High confidence · 18/20 sims"
+2. **Loss-pattern generated tips** — mined from sim history
+3. **Rating-driven overall team grade** — single letter grade with breakdown
+4. **Per-matchup postgame debriefs** — auto-generated after any Bo-series
+
+Each is independently shippable. Recommended merge order below.
+
+---
+
+## Architecture
+
+### New storage key: `champions_sim_log_v1`
+
+Separate from `champions_strategy_report_v1` (Phase 3) because:
+- Strategy reports are **computed/snapshot** data (re-derivable)
+- Sim log is **raw event history** (append-only, source-of-truth for Phase 4 analytics)
+
+**Schema:**
+```json
+{
+  "version": 1,
+  "entries": [
+    {
+      "id": "sim_<timestamp>_<rand>",
+      "ts": 1714000000000,
+      "playerKey": "aurora_veil_froslass",
+      "oppKey": "rin_sand",
+      "format": "doubles",
+      "bo": 3,
+      "games": [
+        {
+          "result": "win",
+          "turns": 14,
+          "leads": { "player": ["Froslass-Mega","Tapu Koko"], "opponent": ["Tyranitar","Excadrill"] },
+          "bring": { "player": [...4], "opponent": [...4] },
+          "playerSurvivors": 2,
+          "oppSurvivors": 0,
+          "winCondition": "Sweep",
+          "trTurns": 0,
+          "twTurns": 4,
+          "koEvents": [
+            { "turn": 2, "victim": "Tyranitar", "side": "opp", "byMove": "Moonblast", "byAttacker": "Tapu Koko" }
+          ]
+        }
+      ],
+      "seriesResult": "win"
+    }
+  ]
+}
+```
+
+**Storage strategy:**
+- Cap at **500 entries total** (LRU eviction). At ~1 KB/entry worst case = 500 KB, well under 5 MB localStorage budget.
+- Separate cap of **100 entries per (playerKey, oppKey) pair** to prevent one heavy matchup from crowding out others.
+- QuotaExceededError → purge oldest 25% (same pattern as Phase 3).
+
+### New engine return field: `koEvents[]`
+
+To avoid log-string parsing (fragile), extend `simulateBattle` return with structured KO events:
+
+```js
+koEvents: [
+  { turn: 2, victim: 'Tyranitar', side: 'opp', byMove: 'Moonblast', byAttacker: 'Tapu Koko' },
+  { turn: 5, victim: 'Whimsicott', side: 'player', byMove: 'Rock Slide', byAttacker: 'Excadrill' }
+]
+```
+
+Plumb from the existing faint hooks at `engine.js:1523/1839/1999/2009/2020/2028/2040`. Already tracking `attacker` + `move` at those sites; just need to push structured event alongside log line.
+
+**Risk:** Non-attack faints (hazards, weather, recoil) need special casing — `byAttacker: null, byMove: "Stealth Rock"` or `"Sandstorm"`.
+
+### Phase 4 UI surface: `#strategy-tab` additions
+
+New subsection **after** the existing Section 7 ("Mistakes to Avoid"):
+
+```
+┌─ Team Rating ─────────────────────────────────────┐
+│  B+     Win rate 67% (16W-8L)  ·  24 games logged │
+│         Breakdown:                                 │
+│         • Win rate ........... B  (67%)           │
+│         • Lead survival ...... A  (88% alive T3)  │
+│         • KO differential .... B+ (+1.2 avg)      │
+│         • Closing speed ..... C  (avg 13.2 turns) │
+└────────────────────────────────────────────────────┘
+
+┌─ Learned from your sims ─────────────────────────┐
+│  ⚠ Whimsicott dies turn ≤2 in 71% of your losses │
+│     Suggested: Focus Sash or Misty Seed          │
+│     (observed 5/7 losses · 3 to Rock Slide)      │
+│                                                    │
+│  ⚠ You average 14.8 turns vs Rin Sand (tied 3-3) │
+│     You're grinding — consider Trick Room break  │
+│     (observed across 6 Bo3s)                      │
+└────────────────────────────────────────────────────┘
+
+┌─ Recent matchups ─────────────────────────────────┐
+│  ✓ vs Rin Sand (Bo3)        2-1    [Debrief ▸]   │
+│  ✗ vs Chuppa Balance (Bo5)  2-3    [Debrief ▸]   │
+│  ✓ vs Mega Dragonite (Bo1)  1-0    [Debrief ▸]   │
+└────────────────────────────────────────────────────┘
+```
+
+---
+
+## Feature Details
+
+### 1. Confidence badges (cheapest, ~1 day)
+
+**For each existing `csMistakes` rule,** if the team has ≥5 logged sims, compute how often the rule's predicted-bad-thing actually happened.
+
+**Example — the Fake Out rule we just fixed:**
+- Rule fires when fragile vulnerable leader + Fake Out in opp team
+- Badge logic: of last 20 sims where opponent had Fake Out, how many times was that fragile leader KO'd by turn 2?
+- Render: `High · 14/20` (green), `Medium · 8/20` (amber), `Low · 2/20` (red — rule may not apply to this user's playstyle)
+
+**Min sample:** 5 sims. Below that, show neutral "Static rule" pill (no color).
+
+**Storage:** computed at render time from sim log, no new persistence.
+
+### 2. Loss-pattern generated tips (meat of the work, ~2-3 days)
+
+**Pattern detectors** (each returns 0..N tips):
+
+| Detector | Signal | Example output |
+|----------|--------|----------------|
+| Early-KO victim | Member KO'd by turn ≤2 in >50% of losses, min 5 losses | "Whimsicott dies turn ≤2 in 71% of losses. Try Focus Sash." |
+| Repeat killer | Same opp move/mon KOs you ≥3 times across sims | "Rock Slide from Excadrill KO'd your leads 4 times." |
+| Grind games | Avg turns >13 in wins vs a specific opp | "You're closing slow vs Rin Sand (avg 14.8 turns)." |
+| Lead-trap | Your same lead pair loses T1 momentum ≥3 times | "Your Incineroar/Arcanine lead loses Fake Out war 60% vs Fake Out users." |
+| Survivor gap | You finish with avg ≤1 survivor while losing | "You're trading 1-for-1 instead of 2-for-1." |
+
+**Scoring:** Each tip gets a severity (`critical`/`warning`/`info`) based on frequency × cost. Cap 3 tips shown (expand to see more).
+
+**Threshold:** Minimum **10 sims total** for this section to render. Below that, show "Keep simming — dynamic advice unlocks at 10 games."
+
+### 3. Rating-driven team grade (~1 day after 1+2)
+
+Single letter grade (A+ / A / A- / B+ / ... / D) computed as weighted average:
+
+```
+grade_score =
+  0.40 * norm(win_rate, 0.30, 0.80)          // 30% = F, 80% = A+
+  + 0.20 * norm(lead_survival_t3_pct, 0.50, 0.90)
+  + 0.20 * norm(ko_diff_avg, -2.0, +2.0)
+  + 0.10 * norm(inv(turns_to_win_avg), 10, 20)  // fewer turns = better
+  + 0.10 * norm(closeout_rate_in_wins, 0.60, 1.0)
+```
+
+`norm()` clamps to [0,1], then maps linearly to 0..100. Letter grade bands: A+ ≥ 93, A ≥ 87, A- ≥ 83, B+ ≥ 77, B ≥ 73, B- ≥ 70, C+ ≥ 65, C ≥ 60, D ≥ 50, F < 50.
+
+**Min sample:** 15 sims. Below that, show "Rating available at 15 games (X more)."
+
+**Breakdown card** shows each component's grade so the user knows what to improve.
+
+### 4. Per-matchup postgame debrief (~1-2 days)
+
+After any Bo-series completes, auto-append an entry. Clicking "Debrief" shows:
+
+```
+vs Rin Sand · Bo3 · 14 Apr 2026 9:41pm
+Result: 2-1 (W-L-W)
+
+Game 1 (W, 12 turns): Swept with Froslass-Mega Aurora Veil
+Game 2 (L, 18 turns): Tyranitar set sand, you lost tempo — Whimsicott KO'd T2
+Game 3 (W, 9 turns): Tapu Koko Terrain flip closed fast
+
+Key turning points:
+  • T2 Whimsicott KO in G2 (Rock Slide, Excadrill)
+  • T1 Protect read in G3 (Froslass-Mega survived Fake Out chip)
+
+Across series:
+  • Your avg turns: 13.0 (league avg 11.2 — slightly slow)
+  • KO diff: +0.7 (positive)
+  • Recommend: bring Focus Sash on Whimsicott for G2-style openings
+```
+
+**Data source:** the 3 games in the last sim_log entry. Debrief is deterministic — no LLM, all template + data.
+
+---
+
+## Recommended rollout order
+
+Ship as **4 separate PRs**, each mergeable independently:
+
+| PR | Scope | Version chip | Estimated effort |
+|----|-------|--------------|-------------------|
+| 4a | `champions_sim_log_v1` storage + `koEvents` engine plumbing + log capture in `runBoSeries` handler | v2.1.3-simlog.1 | 1 day |
+| 4b | Confidence badges on existing mistakes | v2.1.4-confidence.1 | 1 day |
+| 4c | Loss-pattern detectors + "Learned from your sims" section | v2.1.5-patterns.1 | 2-3 days |
+| 4d | Team grade + per-matchup debrief | v2.2.0-phase4.1 (minor bump — feature complete) | 2 days |
+
+**Why this order:** 4a is foundation (no user-visible change but required). 4b is the smallest user-visible win and validates the data flow. 4c+4d build on it.
+
+---
+
+## Open questions for alfredocox
+
+1. **Do losses in a `Bo3` count as 1 entry or 1-3 entries in the sim log?** My recommendation: **1 entry per series, containing N game sub-records**. Cleaner for per-matchup debrief; still allows per-game stats.
+2. **Should the sim log track sims run with swapped sides** (user as opp)? My recommendation: **No** — only log when the team in question is `playerKey`. Keeps stats honest.
+3. **Should static rules that contradict history be suppressed** (e.g., if a static warning has fired 20 times but the predicted bad thing never happened, hide it)? My recommendation: **Demote, don't hide** — show it with "Low confidence · this rule rarely applies to your playstyle" so the user can still see what the archetypic rule is.
+4. **Grade letter vs numeric**: current spec shows `B+`. Alternatives: 0-100 number, star rating (★★★★☆), or both. My recommendation: **letter + number-in-tooltip** (e.g., `B+ (78)`).
+5. **Reset controls**: should there be a "Clear sim history for this team" button? My recommendation: **Yes**, in the Strategy tab footer alongside existing clear controls.
+
+---
+
+## Out of scope for Phase 4
+
+- Cross-team aggregate stats ("your overall record across all teams")
+- Social/shareable stat cards
+- LLM-generated prose advice (current plan is 100% deterministic templates)
+- Live in-battle coaching (still postgame only)
+
+---
+
+## Success criteria
+
+- [ ] User can sim 10+ battles with a team and see at least one dynamically-generated tip referencing their specific loss pattern
+- [ ] Team grade reflects actual performance (validate: simulate 20 stomps → grade ≥A; simulate 20 losses → grade ≤D)
+- [ ] Existing static tips get badges that match observed frequency
+- [ ] Per-matchup debrief renders in <100ms for any logged series
+- [ ] Zero new `pageerror`/`console.error` across all 22 teams
+- [ ] localStorage usage stays under 1 MB after 100 sims
+
+---
+
+**Review checkpoints:** alfredocox sign-off required before each of the 4 PRs is cut.

--- a/poke-sim/engine.js
+++ b/poke-sim/engine.js
@@ -1521,6 +1521,7 @@ function simulateBattle(playerTeam, oppTeam, opts = {}) {
         if (attacker.hp === 0) {
           attacker.alive = false;
           log.push(`${attacker.name} fainted from Struggle recoil!`);
+          _recordKO(attacker, { move: 'Struggle', attacker: attacker, reason: 'recoil' });
         }
         return;
       }
@@ -1836,7 +1837,7 @@ function simulateBattle(playerTeam, oppTeam, opts = {}) {
     if (berryMsg) log.push(berryMsg);
     // Multiscale: deactivate after first hit
     target.multiscaleActive = false;
-    if (target.hp === 0) { target.alive = false; log.push(`${target.name} fainted!`); }
+    if (target.hp === 0) { target.alive = false; log.push(`${target.name} fainted!`); _recordKO(target, { move: move, attacker: attacker, reason: 'attack' }); }
     // T9j.8 (Refs #30) onDamageTaken hook: Spicy Spray burns attacker.
     // Fires only if target still alive AND damage > 0.
     if (target.alive && finalDmg > 0) {
@@ -1852,6 +1853,26 @@ function simulateBattle(playerTeam, oppTeam, opts = {}) {
   // MAIN BATTLE LOOP
   // ============================================================
   let turn = 0;
+  // Phase 4a (Refs #52) — structured KO event log for dynamic coaching.
+  // Populated at every faint site below. UI reads this instead of parsing
+  // log strings (fragile). Shape:
+  //   { turn, victim, side: 'player'|'opp', byMove, byAttacker, reason }
+  // reason: 'attack' | 'recoil' | 'sandstorm' | 'burn' | 'frostbite'
+  //       | 'poison' | 'toxic'
+  const koEvents = [];
+  const _recordKO = function(mon, cause) {
+    try {
+      const side = (playerPokemon.indexOf(mon) >= 0) ? 'player' : 'opp';
+      koEvents.push({
+        turn: turn,
+        victim: mon.name,
+        side: side,
+        byMove: (cause && cause.move) || null,
+        byAttacker: (cause && cause.attacker) ? cause.attacker.name : null,
+        reason: (cause && cause.reason) || 'unknown'
+      });
+    } catch (_e) { /* never let logging kill the sim */ }
+  };
   // T9j.3 (#39): raised from 25 → 30 so timer-draw (28-turn budget at 15s/turn)
   // can actually resolve before the hard cap. Stall mirrors will now reach timer.
   const MAX_TURNS = 30;
@@ -1996,7 +2017,7 @@ function simulateBattle(playerTeam, oppTeam, opts = {}) {
           const sandDmg = Math.floor(mon.maxHp / 16);
           mon.hp = Math.max(0, mon.hp - sandDmg);
           log.push(`${mon.name} is buffeted by the sandstorm! [${sandDmg} dmg]`);
-          if (mon.hp === 0) { mon.alive = false; log.push(`${mon.name} fainted!`); }
+          if (mon.hp === 0) { mon.alive = false; log.push(`${mon.name} fainted!`); _recordKO(mon, { reason: 'sandstorm' }); }
         }
       }
     }
@@ -2006,7 +2027,7 @@ function simulateBattle(playerTeam, oppTeam, opts = {}) {
       const burnDmg = Math.floor(mon.maxHp / 16);
       mon.hp = Math.max(0, mon.hp - burnDmg);
       log.push(`${mon.name} is hurt by its burn! [${burnDmg} dmg]`);
-      if (mon.hp === 0) { mon.alive = false; log.push(`${mon.name} fainted!`); }
+      if (mon.hp === 0) { mon.alive = false; log.push(`${mon.name} fainted!`); _recordKO(mon, { reason: 'burn' }); }
     }
 
     // T9j.17 (Refs #101) -- Frostbite residual (1/16 max HP). Mirrors burn chip.
@@ -2017,7 +2038,7 @@ function simulateBattle(playerTeam, oppTeam, opts = {}) {
       const frostDmg = Math.max(1, Math.floor(mon.maxHp / 16));
       mon.hp = Math.max(0, mon.hp - frostDmg);
       log.push(`${mon.name} is hurt by frostbite! [${frostDmg} dmg]`);
-      if (mon.hp === 0) { mon.alive = false; log.push(`${mon.name} fainted!`); }
+      if (mon.hp === 0) { mon.alive = false; log.push(`${mon.name} fainted!`); _recordKO(mon, { reason: 'frostbite' }); }
     }
 
     // T9j.4 (#41) — Poison residual (1/8 max HP). Cite: Bulbapedia Status; Spec §1.6.
@@ -2025,7 +2046,7 @@ function simulateBattle(playerTeam, oppTeam, opts = {}) {
       const poisonDmg = Math.max(1, Math.floor(mon.maxHp / 8));
       mon.hp = Math.max(0, mon.hp - poisonDmg);
       log.push(`${mon.name} is hurt by poison! [${poisonDmg} dmg]`);
-      if (mon.hp === 0) { mon.alive = false; log.push(`${mon.name} fainted!`); }
+      if (mon.hp === 0) { mon.alive = false; log.push(`${mon.name} fainted!`); _recordKO(mon, { reason: 'poison' }); }
     }
 
     // T9j.4 (#41) — Toxic residual (N/16 escalating, cap N=15; counter increments post-tick).
@@ -2037,7 +2058,7 @@ function simulateBattle(playerTeam, oppTeam, opts = {}) {
       mon.hp = Math.max(0, mon.hp - toxicDmg);
       log.push(`${mon.name} is hurt by toxic! [${toxicDmg} dmg] (tick ${n}/16)`);
       mon.toxicCounter++;
-      if (mon.hp === 0) { mon.alive = false; log.push(`${mon.name} fainted!`); }
+      if (mon.hp === 0) { mon.alive = false; log.push(`${mon.name} fainted!`); _recordKO(mon, { reason: 'toxic' }); }
     }
     // Note: Snow intentionally has no chip damage (Champions Gen-IX). Hail is absent.
 
@@ -2178,7 +2199,9 @@ function simulateBattle(playerTeam, oppTeam, opts = {}) {
       opponent: oppPokemon.slice(0,    field._format === 'singles' ? 3 : 4).map(p => p.name)
     },
     // #5 — attach legality verdict so UI can surface warnings on team/match cards.
-    legality: { player: playerLegality, opp: oppLegality }
+    legality: { player: playerLegality, opp: oppLegality },
+    // Phase 4a (Refs #52) — structured KO event log. See _recordKO site above.
+    koEvents: koEvents
   };
 }
 

--- a/poke-sim/index.html
+++ b/poke-sim/index.html
@@ -43,7 +43,7 @@
         <path d="M 21 6 L 16.5 16 L 19.5 16 L 15.5 28 L 21.5 15.5 L 18.5 15.5 L 22 6 Z" fill="url(#hBolt)" stroke="#ecfeff" stroke-width="0.5" stroke-linejoin="round"/>
       </svg>
       <div>
-        <h1 class="site-title">Pokémon Champion 2026 <span class="build-version" id="build-version" title="Build version - bumps on every commit so you can confirm which build you are testing">v2.1.2-fakeout.1</span></h1>
+        <h1 class="site-title">Pokémon Champion 2026 <span class="build-version" id="build-version" title="Build version - bumps on every commit so you can confirm which build you are testing">v2.1.3-simlog.1</span></h1>
         <p class="site-sub">April 2026 Meta · VGC Doubles Simulator</p>
       </div>
     </div>

--- a/poke-sim/pokemon-champion-2026.html
+++ b/poke-sim/pokemon-champion-2026.html
@@ -1147,7 +1147,7 @@ table{border-collapse:collapse;width:100%}
         <path d="M 21 6 L 16.5 16 L 19.5 16 L 15.5 28 L 21.5 15.5 L 18.5 15.5 L 22 6 Z" fill="url(#hBolt)" stroke="#ecfeff" stroke-width="0.5" stroke-linejoin="round"/>
       </svg>
       <div>
-        <h1 class="site-title">Pokémon Champion 2026 <span class="build-version" id="build-version" title="Build version - bumps on every commit so you can confirm which build you are testing">v2.1.2-fakeout.1</span></h1>
+        <h1 class="site-title">Pokémon Champion 2026 <span class="build-version" id="build-version" title="Build version - bumps on every commit so you can confirm which build you are testing">v2.1.3-simlog.1</span></h1>
         <p class="site-sub">April 2026 Meta · VGC Doubles Simulator</p>
       </div>
     </div>
@@ -7513,6 +7513,7 @@ function simulateBattle(playerTeam, oppTeam, opts = {}) {
         if (attacker.hp === 0) {
           attacker.alive = false;
           log.push(`${attacker.name} fainted from Struggle recoil!`);
+          _recordKO(attacker, { move: 'Struggle', attacker: attacker, reason: 'recoil' });
         }
         return;
       }
@@ -7828,7 +7829,7 @@ function simulateBattle(playerTeam, oppTeam, opts = {}) {
     if (berryMsg) log.push(berryMsg);
     // Multiscale: deactivate after first hit
     target.multiscaleActive = false;
-    if (target.hp === 0) { target.alive = false; log.push(`${target.name} fainted!`); }
+    if (target.hp === 0) { target.alive = false; log.push(`${target.name} fainted!`); _recordKO(target, { move: move, attacker: attacker, reason: 'attack' }); }
     // T9j.8 (Refs #30) onDamageTaken hook: Spicy Spray burns attacker.
     // Fires only if target still alive AND damage > 0.
     if (target.alive && finalDmg > 0) {
@@ -7844,6 +7845,26 @@ function simulateBattle(playerTeam, oppTeam, opts = {}) {
   // MAIN BATTLE LOOP
   // ============================================================
   let turn = 0;
+  // Phase 4a (Refs #52) — structured KO event log for dynamic coaching.
+  // Populated at every faint site below. UI reads this instead of parsing
+  // log strings (fragile). Shape:
+  //   { turn, victim, side: 'player'|'opp', byMove, byAttacker, reason }
+  // reason: 'attack' | 'recoil' | 'sandstorm' | 'burn' | 'frostbite'
+  //       | 'poison' | 'toxic'
+  const koEvents = [];
+  const _recordKO = function(mon, cause) {
+    try {
+      const side = (playerPokemon.indexOf(mon) >= 0) ? 'player' : 'opp';
+      koEvents.push({
+        turn: turn,
+        victim: mon.name,
+        side: side,
+        byMove: (cause && cause.move) || null,
+        byAttacker: (cause && cause.attacker) ? cause.attacker.name : null,
+        reason: (cause && cause.reason) || 'unknown'
+      });
+    } catch (_e) { /* never let logging kill the sim */ }
+  };
   // T9j.3 (#39): raised from 25 → 30 so timer-draw (28-turn budget at 15s/turn)
   // can actually resolve before the hard cap. Stall mirrors will now reach timer.
   const MAX_TURNS = 30;
@@ -7988,7 +8009,7 @@ function simulateBattle(playerTeam, oppTeam, opts = {}) {
           const sandDmg = Math.floor(mon.maxHp / 16);
           mon.hp = Math.max(0, mon.hp - sandDmg);
           log.push(`${mon.name} is buffeted by the sandstorm! [${sandDmg} dmg]`);
-          if (mon.hp === 0) { mon.alive = false; log.push(`${mon.name} fainted!`); }
+          if (mon.hp === 0) { mon.alive = false; log.push(`${mon.name} fainted!`); _recordKO(mon, { reason: 'sandstorm' }); }
         }
       }
     }
@@ -7998,7 +8019,7 @@ function simulateBattle(playerTeam, oppTeam, opts = {}) {
       const burnDmg = Math.floor(mon.maxHp / 16);
       mon.hp = Math.max(0, mon.hp - burnDmg);
       log.push(`${mon.name} is hurt by its burn! [${burnDmg} dmg]`);
-      if (mon.hp === 0) { mon.alive = false; log.push(`${mon.name} fainted!`); }
+      if (mon.hp === 0) { mon.alive = false; log.push(`${mon.name} fainted!`); _recordKO(mon, { reason: 'burn' }); }
     }
 
     // T9j.17 (Refs #101) -- Frostbite residual (1/16 max HP). Mirrors burn chip.
@@ -8009,7 +8030,7 @@ function simulateBattle(playerTeam, oppTeam, opts = {}) {
       const frostDmg = Math.max(1, Math.floor(mon.maxHp / 16));
       mon.hp = Math.max(0, mon.hp - frostDmg);
       log.push(`${mon.name} is hurt by frostbite! [${frostDmg} dmg]`);
-      if (mon.hp === 0) { mon.alive = false; log.push(`${mon.name} fainted!`); }
+      if (mon.hp === 0) { mon.alive = false; log.push(`${mon.name} fainted!`); _recordKO(mon, { reason: 'frostbite' }); }
     }
 
     // T9j.4 (#41) — Poison residual (1/8 max HP). Cite: Bulbapedia Status; Spec §1.6.
@@ -8017,7 +8038,7 @@ function simulateBattle(playerTeam, oppTeam, opts = {}) {
       const poisonDmg = Math.max(1, Math.floor(mon.maxHp / 8));
       mon.hp = Math.max(0, mon.hp - poisonDmg);
       log.push(`${mon.name} is hurt by poison! [${poisonDmg} dmg]`);
-      if (mon.hp === 0) { mon.alive = false; log.push(`${mon.name} fainted!`); }
+      if (mon.hp === 0) { mon.alive = false; log.push(`${mon.name} fainted!`); _recordKO(mon, { reason: 'poison' }); }
     }
 
     // T9j.4 (#41) — Toxic residual (N/16 escalating, cap N=15; counter increments post-tick).
@@ -8029,7 +8050,7 @@ function simulateBattle(playerTeam, oppTeam, opts = {}) {
       mon.hp = Math.max(0, mon.hp - toxicDmg);
       log.push(`${mon.name} is hurt by toxic! [${toxicDmg} dmg] (tick ${n}/16)`);
       mon.toxicCounter++;
-      if (mon.hp === 0) { mon.alive = false; log.push(`${mon.name} fainted!`); }
+      if (mon.hp === 0) { mon.alive = false; log.push(`${mon.name} fainted!`); _recordKO(mon, { reason: 'toxic' }); }
     }
     // Note: Snow intentionally has no chip damage (Champions Gen-IX). Hail is absent.
 
@@ -8170,7 +8191,9 @@ function simulateBattle(playerTeam, oppTeam, opts = {}) {
       opponent: oppPokemon.slice(0,    field._format === 'singles' ? 3 : 4).map(p => p.name)
     },
     // #5 — attach legality verdict so UI can surface warnings on team/match cards.
-    legality: { player: playerLegality, opp: oppLegality }
+    legality: { player: playerLegality, opp: oppLegality },
+    // Phase 4a (Refs #52) — structured KO event log. See _recordKO site above.
+    koEvents: koEvents
   };
 }
 
@@ -10351,6 +10374,10 @@ async function runBoSeries(numSeries, playerTeamKey, oppTeamKey, bo, onProgress)
       const playerBring   = manualPlayerBring   || randomBringFor(playerTeamKey);
       const opponentBring = manualOpponentBring || randomBringFor(oppTeamKey);
 
+      // Phase 4a (Refs #52) — capture every game of this series so we can
+      // append one sim-log entry per series at the end.
+      const seriesBattles = [];
+
       while (seriesW<gamesNeeded && seriesL<gamesNeeded && gamesPlayed<bo) {
         const battle = simulateBattle(TEAMS[playerTeamKey], TEAMS[oppTeamKey], { format: currentFormat, playerBring, opponentBring });
         if (battle.result==='win') seriesW++;
@@ -10362,6 +10389,7 @@ async function runBoSeries(numSeries, playerTeamKey, oppTeamKey, bo, onProgress)
         results.turnDist[battle.turns]=(results.turnDist[battle.turns]||0)+1;
         if (battle.winCondition) results.winConditions[battle.winCondition]=(results.winConditions[battle.winCondition]||0)+1;
         if (results.allLogs.length<50) results.allLogs.push({...battle, oppKey:oppTeamKey});
+        seriesBattles.push(battle);
       }
 
       const seriesResult = seriesW>seriesL?'wins':seriesW<seriesL?'losses':'draws';
@@ -10370,6 +10398,27 @@ async function runBoSeries(numSeries, playerTeamKey, oppTeamKey, bo, onProgress)
       if (seriesResult==='losses') liveL++;
       results.totalTurns += seriesTurns/gamesPlayed;
       results.totalTrTurns += seriesTrTurns/gamesPlayed;
+
+      // Phase 4a — append one entry per series to the sim log. Wrapped in
+      // try so a storage failure never kills the sim run.
+      try {
+        if (typeof csSimLogAppendSeries === 'function') {
+          // Map plural 'wins'/'losses'/'draws' to singular for storage.
+          const srOut = seriesResult === 'wins' ? 'win'
+                      : seriesResult === 'losses' ? 'loss'
+                      : 'draw';
+          csSimLogAppendSeries({
+            playerKey: playerTeamKey,
+            oppKey: oppTeamKey,
+            format: currentFormat,
+            bo: bo,
+            battleResults: seriesBattles,
+            seriesResult: srOut
+          });
+        }
+      } catch (e) {
+        console.warn('[Phase4a] simlog append in runBoSeries failed:', e && e.message);
+      }
     }
     if (onProgress) onProgress(i+bSize, numSeries, liveW, liveL);
     await new Promise(r=>setTimeout(r,0));
@@ -13874,6 +13923,172 @@ function csClearReport(teamKey) {
 function csClearAllReports() {
   return _csPersistWrite({ schema_version: CS_PERSIST_SCHEMA, reports: {} });
 }
+
+// =========================================================================
+// Phase 4a (Refs #52) — Sim Log: raw append-only history of series results.
+// Lives in its own storage key (champions_sim_log_v1) so it can evolve
+// independently from the Phase 3 strategy snapshot store.
+//
+// Why separate key:
+//  - Strategy reports are COMPUTED / snapshot data (re-derivable)
+//  - Sim log is RAW event history (source of truth for Phase 4 analytics)
+//
+// Caps:
+//  - 500 entries total (LRU evict oldest)
+//  - 100 entries per (playerKey, oppKey) pair (prevents one heavy matchup
+//    from crowding others out)
+//
+// QuotaExceededError fallback: purge oldest 25%, retry once. Mirrors
+// Phase 3's recovery pattern.
+// =========================================================================
+var CS_SIMLOG_KEY = 'champions_sim_log_v1';
+var CS_SIMLOG_SCHEMA = 1;
+var CS_SIMLOG_MAX_TOTAL = 500;
+var CS_SIMLOG_MAX_PER_PAIR = 100;
+
+function _csSimLogRead() {
+  try {
+    var raw = localStorage.getItem(CS_SIMLOG_KEY);
+    if (!raw) return { schema_version: CS_SIMLOG_SCHEMA, entries: [] };
+    var parsed = JSON.parse(raw);
+    if (!parsed || parsed.schema_version !== CS_SIMLOG_SCHEMA) {
+      return { schema_version: CS_SIMLOG_SCHEMA, entries: [] };
+    }
+    if (!Array.isArray(parsed.entries)) parsed.entries = [];
+    return parsed;
+  } catch (e) {
+    console.warn('[Phase4a] simlog read failed, resetting:', e && e.message);
+    return { schema_version: CS_SIMLOG_SCHEMA, entries: [] };
+  }
+}
+
+function _csSimLogWrite(store) {
+  try {
+    localStorage.setItem(CS_SIMLOG_KEY, JSON.stringify(store));
+    return true;
+  } catch (e) {
+    if (e && (e.name === 'QuotaExceededError' || e.code === 22)) {
+      // Purge oldest 25% and retry once.
+      try {
+        var cut = Math.floor(store.entries.length * 0.25);
+        if (cut > 0) store.entries = store.entries.slice(cut);
+        localStorage.setItem(CS_SIMLOG_KEY, JSON.stringify(store));
+        console.warn('[Phase4a] simlog: purged oldest 25% after quota error');
+        return true;
+      } catch (e2) {
+        console.error('[Phase4a] simlog write failed even after purge:', e2 && e2.message);
+        return false;
+      }
+    }
+    console.warn('[Phase4a] simlog write failed:', e && e.message);
+    return false;
+  }
+}
+
+// Shape a single simulateBattle result into the compact sim-log game form.
+// Keeps the essentials (result/turns/leads/bring/survivors/winCondition
+// /TR+TW turns/koEvents). Drops the big "log" string array — not needed
+// for analytics and blows up storage.
+function _csGameFromBattle(battle) {
+  if (!battle) return null;
+  return {
+    result: battle.result || null,
+    turns: battle.turns || 0,
+    leads: battle.leads || { player: [], opponent: [] },
+    bring: battle.bring || { player: [], opponent: [] },
+    playerSurvivors: (typeof battle.playerSurvivors === 'number') ? battle.playerSurvivors : null,
+    oppSurvivors:    (typeof battle.oppSurvivors === 'number')    ? battle.oppSurvivors    : null,
+    winCondition: battle.winCondition || null,
+    trTurns: battle.trTurns || 0,
+    twTurns: battle.twTurns || 0,
+    koEvents: Array.isArray(battle.koEvents) ? battle.koEvents : []
+  };
+}
+
+// Apply the 100-per-pair cap to `entries` (newest kept).
+function _csSimLogCapPerPair(entries) {
+  var buckets = {};
+  for (var i = 0; i < entries.length; i++) {
+    var e = entries[i];
+    var key = (e.playerKey || '?') + '::' + (e.oppKey || '?');
+    if (!buckets[key]) buckets[key] = [];
+    buckets[key].push(i);
+  }
+  var drop = {};
+  Object.keys(buckets).forEach(function(k){
+    var idxs = buckets[k];
+    if (idxs.length > CS_SIMLOG_MAX_PER_PAIR) {
+      // entries are append-ordered so lowest indices = oldest. Drop oldest.
+      var overflow = idxs.length - CS_SIMLOG_MAX_PER_PAIR;
+      for (var j = 0; j < overflow; j++) drop[idxs[j]] = true;
+    }
+  });
+  return entries.filter(function(_, i){ return !drop[i]; });
+}
+
+// Append a series entry.
+//   playerKey, oppKey: TEAMS keys
+//   format: 'doubles' | 'singles'
+//   bo: 1/3/5/10
+//   battleResults: array of simulateBattle return objects from the series
+//   seriesResult: 'win' | 'loss' | 'draw' (series-level outcome)
+function csSimLogAppendSeries(opts) {
+  try {
+    if (!opts || !opts.playerKey || !opts.oppKey) return false;
+    var battles = Array.isArray(opts.battleResults) ? opts.battleResults : [];
+    var entry = {
+      id: 'sim_' + Date.now() + '_' + Math.floor(Math.random() * 1e6).toString(36),
+      ts: Date.now(),
+      playerKey: opts.playerKey,
+      oppKey:    opts.oppKey,
+      format:    opts.format || 'doubles',
+      bo:        opts.bo || 1,
+      games:     battles.map(_csGameFromBattle).filter(Boolean),
+      seriesResult: opts.seriesResult || null
+    };
+    var store = _csSimLogRead();
+    store.entries.push(entry);
+    // Apply per-pair cap first (usually the tighter of the two).
+    store.entries = _csSimLogCapPerPair(store.entries);
+    // Then the total cap.
+    if (store.entries.length > CS_SIMLOG_MAX_TOTAL) {
+      store.entries = store.entries.slice(store.entries.length - CS_SIMLOG_MAX_TOTAL);
+    }
+    return _csSimLogWrite(store);
+  } catch (e) {
+    console.warn('[Phase4a] simlog append failed:', e && e.message);
+    return false;
+  }
+}
+
+// Read helpers for Phase 4b/c/d.
+function csSimLogGetAll() { return _csSimLogRead().entries.slice(); }
+function csSimLogForTeam(teamKey) {
+  return _csSimLogRead().entries.filter(function(e){ return e.playerKey === teamKey; });
+}
+function csSimLogForMatchup(playerKey, oppKey) {
+  return _csSimLogRead().entries.filter(function(e){
+    return e.playerKey === playerKey && e.oppKey === oppKey;
+  });
+}
+function csSimLogClearTeam(teamKey) {
+  var store = _csSimLogRead();
+  store.entries = store.entries.filter(function(e){ return e.playerKey !== teamKey; });
+  return _csSimLogWrite(store);
+}
+function csSimLogClearAll() {
+  return _csSimLogWrite({ schema_version: CS_SIMLOG_SCHEMA, entries: [] });
+}
+
+// Expose to window so console/debug and Phase 4b/c/d code can reach them.
+try {
+  window.csSimLogAppendSeries = csSimLogAppendSeries;
+  window.csSimLogGetAll       = csSimLogGetAll;
+  window.csSimLogForTeam      = csSimLogForTeam;
+  window.csSimLogForMatchup   = csSimLogForMatchup;
+  window.csSimLogClearTeam    = csSimLogClearTeam;
+  window.csSimLogClearAll     = csSimLogClearAll;
+} catch (_e) { /* non-browser env (node --check) */ }
 
 // Paint cached report immediately if available. Used as the fast-path on
 // team-select change so the user never sees a blank tab between switches.

--- a/poke-sim/sw.js
+++ b/poke-sim/sw.js
@@ -4,7 +4,7 @@
 // MUST be bumped on every release that changes engine.js, data.js, ui.js, or style.css
 // Phase 2 automation tracked in #95 (tools/release.sh)
 
-const CACHE_NAME = 'champions-sim-v5-fakeout1';
+const CACHE_NAME = 'champions-sim-v5-simlog1';
 const SPRITE_CACHE = 'champions-sprites-v1';
 
 const APP_ASSETS = [

--- a/poke-sim/ui.js
+++ b/poke-sim/ui.js
@@ -1879,6 +1879,10 @@ async function runBoSeries(numSeries, playerTeamKey, oppTeamKey, bo, onProgress)
       const playerBring   = manualPlayerBring   || randomBringFor(playerTeamKey);
       const opponentBring = manualOpponentBring || randomBringFor(oppTeamKey);
 
+      // Phase 4a (Refs #52) — capture every game of this series so we can
+      // append one sim-log entry per series at the end.
+      const seriesBattles = [];
+
       while (seriesW<gamesNeeded && seriesL<gamesNeeded && gamesPlayed<bo) {
         const battle = simulateBattle(TEAMS[playerTeamKey], TEAMS[oppTeamKey], { format: currentFormat, playerBring, opponentBring });
         if (battle.result==='win') seriesW++;
@@ -1890,6 +1894,7 @@ async function runBoSeries(numSeries, playerTeamKey, oppTeamKey, bo, onProgress)
         results.turnDist[battle.turns]=(results.turnDist[battle.turns]||0)+1;
         if (battle.winCondition) results.winConditions[battle.winCondition]=(results.winConditions[battle.winCondition]||0)+1;
         if (results.allLogs.length<50) results.allLogs.push({...battle, oppKey:oppTeamKey});
+        seriesBattles.push(battle);
       }
 
       const seriesResult = seriesW>seriesL?'wins':seriesW<seriesL?'losses':'draws';
@@ -1898,6 +1903,27 @@ async function runBoSeries(numSeries, playerTeamKey, oppTeamKey, bo, onProgress)
       if (seriesResult==='losses') liveL++;
       results.totalTurns += seriesTurns/gamesPlayed;
       results.totalTrTurns += seriesTrTurns/gamesPlayed;
+
+      // Phase 4a — append one entry per series to the sim log. Wrapped in
+      // try so a storage failure never kills the sim run.
+      try {
+        if (typeof csSimLogAppendSeries === 'function') {
+          // Map plural 'wins'/'losses'/'draws' to singular for storage.
+          const srOut = seriesResult === 'wins' ? 'win'
+                      : seriesResult === 'losses' ? 'loss'
+                      : 'draw';
+          csSimLogAppendSeries({
+            playerKey: playerTeamKey,
+            oppKey: oppTeamKey,
+            format: currentFormat,
+            bo: bo,
+            battleResults: seriesBattles,
+            seriesResult: srOut
+          });
+        }
+      } catch (e) {
+        console.warn('[Phase4a] simlog append in runBoSeries failed:', e && e.message);
+      }
     }
     if (onProgress) onProgress(i+bSize, numSeries, liveW, liveL);
     await new Promise(r=>setTimeout(r,0));
@@ -5402,6 +5428,172 @@ function csClearReport(teamKey) {
 function csClearAllReports() {
   return _csPersistWrite({ schema_version: CS_PERSIST_SCHEMA, reports: {} });
 }
+
+// =========================================================================
+// Phase 4a (Refs #52) — Sim Log: raw append-only history of series results.
+// Lives in its own storage key (champions_sim_log_v1) so it can evolve
+// independently from the Phase 3 strategy snapshot store.
+//
+// Why separate key:
+//  - Strategy reports are COMPUTED / snapshot data (re-derivable)
+//  - Sim log is RAW event history (source of truth for Phase 4 analytics)
+//
+// Caps:
+//  - 500 entries total (LRU evict oldest)
+//  - 100 entries per (playerKey, oppKey) pair (prevents one heavy matchup
+//    from crowding others out)
+//
+// QuotaExceededError fallback: purge oldest 25%, retry once. Mirrors
+// Phase 3's recovery pattern.
+// =========================================================================
+var CS_SIMLOG_KEY = 'champions_sim_log_v1';
+var CS_SIMLOG_SCHEMA = 1;
+var CS_SIMLOG_MAX_TOTAL = 500;
+var CS_SIMLOG_MAX_PER_PAIR = 100;
+
+function _csSimLogRead() {
+  try {
+    var raw = localStorage.getItem(CS_SIMLOG_KEY);
+    if (!raw) return { schema_version: CS_SIMLOG_SCHEMA, entries: [] };
+    var parsed = JSON.parse(raw);
+    if (!parsed || parsed.schema_version !== CS_SIMLOG_SCHEMA) {
+      return { schema_version: CS_SIMLOG_SCHEMA, entries: [] };
+    }
+    if (!Array.isArray(parsed.entries)) parsed.entries = [];
+    return parsed;
+  } catch (e) {
+    console.warn('[Phase4a] simlog read failed, resetting:', e && e.message);
+    return { schema_version: CS_SIMLOG_SCHEMA, entries: [] };
+  }
+}
+
+function _csSimLogWrite(store) {
+  try {
+    localStorage.setItem(CS_SIMLOG_KEY, JSON.stringify(store));
+    return true;
+  } catch (e) {
+    if (e && (e.name === 'QuotaExceededError' || e.code === 22)) {
+      // Purge oldest 25% and retry once.
+      try {
+        var cut = Math.floor(store.entries.length * 0.25);
+        if (cut > 0) store.entries = store.entries.slice(cut);
+        localStorage.setItem(CS_SIMLOG_KEY, JSON.stringify(store));
+        console.warn('[Phase4a] simlog: purged oldest 25% after quota error');
+        return true;
+      } catch (e2) {
+        console.error('[Phase4a] simlog write failed even after purge:', e2 && e2.message);
+        return false;
+      }
+    }
+    console.warn('[Phase4a] simlog write failed:', e && e.message);
+    return false;
+  }
+}
+
+// Shape a single simulateBattle result into the compact sim-log game form.
+// Keeps the essentials (result/turns/leads/bring/survivors/winCondition
+// /TR+TW turns/koEvents). Drops the big "log" string array — not needed
+// for analytics and blows up storage.
+function _csGameFromBattle(battle) {
+  if (!battle) return null;
+  return {
+    result: battle.result || null,
+    turns: battle.turns || 0,
+    leads: battle.leads || { player: [], opponent: [] },
+    bring: battle.bring || { player: [], opponent: [] },
+    playerSurvivors: (typeof battle.playerSurvivors === 'number') ? battle.playerSurvivors : null,
+    oppSurvivors:    (typeof battle.oppSurvivors === 'number')    ? battle.oppSurvivors    : null,
+    winCondition: battle.winCondition || null,
+    trTurns: battle.trTurns || 0,
+    twTurns: battle.twTurns || 0,
+    koEvents: Array.isArray(battle.koEvents) ? battle.koEvents : []
+  };
+}
+
+// Apply the 100-per-pair cap to `entries` (newest kept).
+function _csSimLogCapPerPair(entries) {
+  var buckets = {};
+  for (var i = 0; i < entries.length; i++) {
+    var e = entries[i];
+    var key = (e.playerKey || '?') + '::' + (e.oppKey || '?');
+    if (!buckets[key]) buckets[key] = [];
+    buckets[key].push(i);
+  }
+  var drop = {};
+  Object.keys(buckets).forEach(function(k){
+    var idxs = buckets[k];
+    if (idxs.length > CS_SIMLOG_MAX_PER_PAIR) {
+      // entries are append-ordered so lowest indices = oldest. Drop oldest.
+      var overflow = idxs.length - CS_SIMLOG_MAX_PER_PAIR;
+      for (var j = 0; j < overflow; j++) drop[idxs[j]] = true;
+    }
+  });
+  return entries.filter(function(_, i){ return !drop[i]; });
+}
+
+// Append a series entry.
+//   playerKey, oppKey: TEAMS keys
+//   format: 'doubles' | 'singles'
+//   bo: 1/3/5/10
+//   battleResults: array of simulateBattle return objects from the series
+//   seriesResult: 'win' | 'loss' | 'draw' (series-level outcome)
+function csSimLogAppendSeries(opts) {
+  try {
+    if (!opts || !opts.playerKey || !opts.oppKey) return false;
+    var battles = Array.isArray(opts.battleResults) ? opts.battleResults : [];
+    var entry = {
+      id: 'sim_' + Date.now() + '_' + Math.floor(Math.random() * 1e6).toString(36),
+      ts: Date.now(),
+      playerKey: opts.playerKey,
+      oppKey:    opts.oppKey,
+      format:    opts.format || 'doubles',
+      bo:        opts.bo || 1,
+      games:     battles.map(_csGameFromBattle).filter(Boolean),
+      seriesResult: opts.seriesResult || null
+    };
+    var store = _csSimLogRead();
+    store.entries.push(entry);
+    // Apply per-pair cap first (usually the tighter of the two).
+    store.entries = _csSimLogCapPerPair(store.entries);
+    // Then the total cap.
+    if (store.entries.length > CS_SIMLOG_MAX_TOTAL) {
+      store.entries = store.entries.slice(store.entries.length - CS_SIMLOG_MAX_TOTAL);
+    }
+    return _csSimLogWrite(store);
+  } catch (e) {
+    console.warn('[Phase4a] simlog append failed:', e && e.message);
+    return false;
+  }
+}
+
+// Read helpers for Phase 4b/c/d.
+function csSimLogGetAll() { return _csSimLogRead().entries.slice(); }
+function csSimLogForTeam(teamKey) {
+  return _csSimLogRead().entries.filter(function(e){ return e.playerKey === teamKey; });
+}
+function csSimLogForMatchup(playerKey, oppKey) {
+  return _csSimLogRead().entries.filter(function(e){
+    return e.playerKey === playerKey && e.oppKey === oppKey;
+  });
+}
+function csSimLogClearTeam(teamKey) {
+  var store = _csSimLogRead();
+  store.entries = store.entries.filter(function(e){ return e.playerKey !== teamKey; });
+  return _csSimLogWrite(store);
+}
+function csSimLogClearAll() {
+  return _csSimLogWrite({ schema_version: CS_SIMLOG_SCHEMA, entries: [] });
+}
+
+// Expose to window so console/debug and Phase 4b/c/d code can reach them.
+try {
+  window.csSimLogAppendSeries = csSimLogAppendSeries;
+  window.csSimLogGetAll       = csSimLogGetAll;
+  window.csSimLogForTeam      = csSimLogForTeam;
+  window.csSimLogForMatchup   = csSimLogForMatchup;
+  window.csSimLogClearTeam    = csSimLogClearTeam;
+  window.csSimLogClearAll     = csSimLogClearAll;
+} catch (_e) { /* non-browser env (node --check) */ }
 
 // Paint cached report immediately if available. Used as the fast-path on
 // team-select change so the user never sees a blank tab between switches.


### PR DESCRIPTION
## Phase 4a of 4 (see PHASE4_DYNAMIC_ADVICE_SPEC.md)

Infrastructure only. No user-visible change. Sets up the data layer for dynamic coaching:
- Phase 4b: confidence badges on static tips
- Phase 4c: loss-pattern detectors ("Whimsicott dies T<=2 in 71% of losses")
- Phase 4d: team grade + per-matchup debriefs

## Engine
- `koEvents[]` on `simulateBattle()` return, populated at all 7 faint sites
- Structured shape: `{ turn, victim, side, byMove, byAttacker, reason }`
- `reason` values: `attack`, `recoil`, `sandstorm`, `burn`, `frostbite`, `poison`, `toxic`
- UI never needs to parse log strings again

## UI
- New `champions_sim_log_v1` localStorage key (separate from Phase 3 strategy key)
- Caps: 500 total entries, 100 per (playerKey,oppKey) pair; LRU evict oldest
- QuotaExceededError -> purge oldest 25% and retry (mirrors Phase 3 pattern)
- One entry per series, N games as sub-records (per approved design Q1)
- Only logs when team is playerKey (approved design Q2)
- Read helpers exposed on window: `csSimLogGetAll`, `csSimLogForTeam`, `csSimLogForMatchup`, `csSimLogClearTeam`, `csSimLogClearAll`

## Versioning
- Chip: v2.1.2-fakeout.1 -> v2.1.3-simlog.1
- CACHE_NAME: v5-fakeout1 -> v5-simlog1

## Validation
- `node --check` all 3 JS files OK
- Headless Playwright smoke:
  - Bo3 aurora_veil_froslass vs rin_sand: 0 pageerrors, 0 console.errors
  - koEvents populated correctly (7 events in a 6-turn game with byMove+byAttacker)
  - Sim log persisted with correct seriesResult
- Multi-series accumulation test:
  - 3 series vs rin_sand + 2 vs mega_altaria = 5 total entries, filters work
  - ~1.8 KB per entry -> 500-entry cap ~= 900 KB (well under 5 MB budget)

Refs #52 #53