### PR TITLE
fix(coach): deduplicate move-line leads

### DIFF
--- a/poke-sim/index.html
+++ b/poke-sim/index.html
@@ -43,7 +43,7 @@
         <path d="M 21 6 L 16.5 16 L 19.5 16 L 15.5 28 L 21.5 15.5 L 18.5 15.5 L 22 6 Z" fill="url(#hBolt)" stroke="#ecfeff" stroke-width="0.5" stroke-linejoin="round"/>
       </svg>
       <div>
-        <h1 class="site-title">Poke-e-Sim Champion 2026 <span class="build-version" id="build-version" title="Build version - bumps on every commit so you can confirm which build you are testing">v2.1.4-adaptive.2</span></h1>
+        <h1 class="site-title">Poke-e-Sim Champion 2026 <span class="build-version" id="build-version" title="Build version - bumps on every commit so you can confirm which build you are testing">v2.1.4-adaptive.3</span></h1>
         <p class="site-sub">April 2026 Meta · VGC Doubles Simulator</p>
       </div>
     </div>

--- a/poke-sim/pokemon-champion-2026.html
+++ b/poke-sim/pokemon-champion-2026.html
@@ -1221,7 +1221,7 @@ table{border-collapse:collapse;width:100%}
         <path d="M 21 6 L 16.5 16 L 19.5 16 L 15.5 28 L 21.5 15.5 L 18.5 15.5 L 22 6 Z" fill="url(#hBolt)" stroke="#ecfeff" stroke-width="0.5" stroke-linejoin="round"/>
       </svg>
       <div>
-        <h1 class="site-title">Poke-e-Sim Champion 2026 <span class="build-version" id="build-version" title="Build version - bumps on every commit so you can confirm which build you are testing">v2.1.4-adaptive.2</span></h1>
+        <h1 class="site-title">Poke-e-Sim Champion 2026 <span class="build-version" id="build-version" title="Build version - bumps on every commit so you can confirm which build you are testing">v2.1.4-adaptive.3</span></h1>
         <p class="site-sub">April 2026 Meta · VGC Doubles Simulator</p>
       </div>
     </div>
@@ -13146,8 +13146,15 @@ function csMoveLines(team, identity, leadGuide) {
   var spreadUser = members.find(function(m){ return _pdfHasAny(m, PDF_SPREAD); });
   var intimUser = members.find(function(m){ return (m.ability||'') === 'Intimidate'; });
 
+  // Deduplicate picks: if a and b resolve to the same mon (e.g. Incineroar has
+  // both Fake Out and Intimidate, so foUser and intimUser can be the same),
+  // drop the duplicate and backfill from the remaining team so we never show
+  // a lead pair like "Incineroar + Incineroar". Refs #116.
   function pick2(a, b) {
-    var picks = [a, b].filter(Boolean).map(function(m){ return m.name; });
+    var picks = [];
+    [a, b].forEach(function(m){
+      if (m && m.name && picks.indexOf(m.name) < 0) picks.push(m.name);
+    });
     if (picks.length < 2) {
       members.forEach(function(m){ if (picks.length < 2 && picks.indexOf(m.name) < 0) picks.push(m.name); });
     }

--- a/poke-sim/sw.js
+++ b/poke-sim/sw.js
@@ -4,7 +4,7 @@
 // MUST be bumped on every release that changes engine.js, data.js, ui.js, or style.css
 // Phase 2 automation tracked in #95 (tools/release.sh)
 
-const CACHE_NAME = 'champions-sim-v5-adaptive2';
+const CACHE_NAME = 'champions-sim-v5-adaptive3';
 const SPRITE_CACHE = 'champions-sprites-v1';
 
 const APP_ASSETS = [

--- a/poke-sim/ui.js
+++ b/poke-sim/ui.js
@@ -4542,8 +4542,15 @@ function csMoveLines(team, identity, leadGuide) {
   var spreadUser = members.find(function(m){ return _pdfHasAny(m, PDF_SPREAD); });
   var intimUser = members.find(function(m){ return (m.ability||'') === 'Intimidate'; });
 
+  // Deduplicate picks: if a and b resolve to the same mon (e.g. Incineroar has
+  // both Fake Out and Intimidate, so foUser and intimUser can be the same),
+  // drop the duplicate and backfill from the remaining team so we never show
+  // a lead pair like "Incineroar + Incineroar". Refs #116.
   function pick2(a, b) {
-    var picks = [a, b].filter(Boolean).map(function(m){ return m.name; });
+    var picks = [];
+    [a, b].forEach(function(m){
+      if (m && m.name && picks.indexOf(m.name) < 0) picks.push(m.name);
+    });
     if (picks.length < 2) {
       members.forEach(function(m){ if (picks.length < 2 && picks.indexOf(m.name) < 0) picks.push(m.name); });
     }


### PR DESCRIPTION
## Fix: Move-line scenarios can show same mon as both leads

### Bug
Strategy tab -> Move Lines section was rendering lead pairs like "Incineroar + Incineroar" for scenarios such as "Into Trick Room setters". Root cause: `pick2(a, b)` in `csMoveLines` accepted two role-filtered mons without checking whether they were the same mon. When one Pokemon satisfies multiple roles (Incineroar has both Fake Out and Intimidate, so `foUser === intimUser`), both picks collapsed onto the same mon.

### Fix
Deduplicate `pick2` before finalizing the pair. If `a` and `b` resolve to the same mon, keep one copy and backfill the second slot from the remaining team members. Same-mon-twice is now impossible.

```js
// before
var picks = [a, b].filter(Boolean).map(function(m){ return m.name; });

// after
var picks = [];
[a, b].forEach(function(m){
  if (m && m.name && picks.indexOf(m.name) < 0) picks.push(m.name);
});
if (picks.length < 2) {
  members.forEach(function(m){
    if (picks.length < 2 && picks.indexOf(m.name) < 0) picks.push(m.name);
  });
}
```

### Validation
Headless Playwright smoke across all 22 loaded teams, 6-7 move-line scenarios each:
- Duplicate leads found: 0
- pageerrors: 0
- console.errors: 0

### Version bumps
- Build chip v2.1.4-adaptive.2 -> v2.1.4-adaptive.3
- sw.js CACHE_NAME v5-adaptive2 -> v5-adaptive3

Refs #95
