### PR TITLE
fix(pilot-guide): populate tab after every single sim, upsert by oppKey

### DIFF
--- a/poke-sim/index.html
+++ b/poke-sim/index.html
@@ -43,7 +43,7 @@
         <path d="M 21 6 L 16.5 16 L 19.5 16 L 15.5 28 L 21.5 15.5 L 18.5 15.5 L 22 6 Z" fill="url(#hBolt)" stroke="#ecfeff" stroke-width="0.5" stroke-linejoin="round"/>
       </svg>
       <div>
-        <h1 class="site-title">Poke-e-Sim Champion 2026 <span class="build-version" id="build-version" title="Build version - bumps on every commit so you can confirm which build you are testing">v2.1.4-adaptive.3</span></h1>
+        <h1 class="site-title">Poke-e-Sim Champion 2026 <span class="build-version" id="build-version" title="Build version - bumps on every commit so you can confirm which build you are testing">v2.1.5-pilotfix.1</span></h1>
         <p class="site-sub">April 2026 Meta · VGC Doubles Simulator</p>
       </div>
     </div>

--- a/poke-sim/pokemon-champion-2026.html
+++ b/poke-sim/pokemon-champion-2026.html
@@ -1221,7 +1221,7 @@ table{border-collapse:collapse;width:100%}
         <path d="M 21 6 L 16.5 16 L 19.5 16 L 15.5 28 L 21.5 15.5 L 18.5 15.5 L 22 6 Z" fill="url(#hBolt)" stroke="#ecfeff" stroke-width="0.5" stroke-linejoin="round"/>
       </svg>
       <div>
-        <h1 class="site-title">Poke-e-Sim Champion 2026 <span class="build-version" id="build-version" title="Build version - bumps on every commit so you can confirm which build you are testing">v2.1.4-adaptive.3</span></h1>
+        <h1 class="site-title">Poke-e-Sim Champion 2026 <span class="build-version" id="build-version" title="Build version - bumps on every commit so you can confirm which build you are testing">v2.1.5-pilotfix.1</span></h1>
         <p class="site-sub">April 2026 Meta · VGC Doubles Simulator</p>
       </div>
     </div>
@@ -10594,6 +10594,12 @@ document.getElementById('run-sim-btn')?.addEventListener('click', async function
 
   document.getElementById('progress-wrap').style.display='none';
   displayResults(res, oppKey);
+  // Refs #95 - also populate the Pilot Guide tab after a single sim so the
+  // tab isn't stuck on its empty-state message. generatePilotGuide is
+  // upsert-by-oppKey, so re-running the same matchup replaces its card.
+  try { generatePilotGuide(oppKey, res); } catch (e) { console.warn('[PilotGuide] single-sim populate failed:', e && e.message); }
+  // Cache for Run All parity - keeps PDF builder and strategy rebuild in sync.
+  try { if (window.lastSimResults) window.lastSimResults[oppKey] = res; } catch(_){}
   simRunning=false; this.disabled=false; document.getElementById('run-all-btn').disabled=false;
 });
 
@@ -10727,6 +10733,9 @@ function generatePilotGuide(oppKey, results) {
 
   const card = document.createElement('div');
   card.className = 'pilot-card';
+  // Refs #95 - tag the card with its opponent key so we can upsert instead of
+  // duplicating when the same matchup is re-simulated from the single-sim path.
+  card.dataset.oppKey = oppKey;
   card.innerHTML = `
     <div class="pilot-card-header">
       <div class="pilot-card-title">${teamName}</div>
@@ -10753,7 +10762,15 @@ function generatePilotGuide(oppKey, results) {
         ${megaTriggerHtml}
       </div>
     </div>`;
-  el.appendChild(card);
+  // Refs #95 - if a card for this opponent already exists (from a prior sim
+  // of the same matchup, or from Run All), replace it in place. Keeps the tab
+  // incremental when the user runs a single sim and prevents duplicate cards.
+  const existing = el.querySelector('.pilot-card[data-opp-key="' + (typeof CSS !== 'undefined' && CSS.escape ? CSS.escape(oppKey) : oppKey) + '"]');
+  if (existing) {
+    el.replaceChild(card, existing);
+  } else {
+    el.appendChild(card);
+  }
 }
 
 // ============================================================

--- a/poke-sim/sw.js
+++ b/poke-sim/sw.js
@@ -4,7 +4,7 @@
 // MUST be bumped on every release that changes engine.js, data.js, ui.js, or style.css
 // Phase 2 automation tracked in #95 (tools/release.sh)
 
-const CACHE_NAME = 'champions-sim-v5-adaptive3';
+const CACHE_NAME = 'champions-sim-v5-pilotfix1';
 const SPRITE_CACHE = 'champions-sprites-v1';
 
 const APP_ASSETS = [

--- a/poke-sim/ui.js
+++ b/poke-sim/ui.js
@@ -1990,6 +1990,12 @@ document.getElementById('run-sim-btn')?.addEventListener('click', async function
 
   document.getElementById('progress-wrap').style.display='none';
   displayResults(res, oppKey);
+  // Refs #95 - also populate the Pilot Guide tab after a single sim so the
+  // tab isn't stuck on its empty-state message. generatePilotGuide is
+  // upsert-by-oppKey, so re-running the same matchup replaces its card.
+  try { generatePilotGuide(oppKey, res); } catch (e) { console.warn('[PilotGuide] single-sim populate failed:', e && e.message); }
+  // Cache for Run All parity - keeps PDF builder and strategy rebuild in sync.
+  try { if (window.lastSimResults) window.lastSimResults[oppKey] = res; } catch(_){}
   simRunning=false; this.disabled=false; document.getElementById('run-all-btn').disabled=false;
 });
 
@@ -2123,6 +2129,9 @@ function generatePilotGuide(oppKey, results) {
 
   const card = document.createElement('div');
   card.className = 'pilot-card';
+  // Refs #95 - tag the card with its opponent key so we can upsert instead of
+  // duplicating when the same matchup is re-simulated from the single-sim path.
+  card.dataset.oppKey = oppKey;
   card.innerHTML = `
     <div class="pilot-card-header">
       <div class="pilot-card-title">${teamName}</div>
@@ -2149,7 +2158,15 @@ function generatePilotGuide(oppKey, results) {
         ${megaTriggerHtml}
       </div>
     </div>`;
-  el.appendChild(card);
+  // Refs #95 - if a card for this opponent already exists (from a prior sim
+  // of the same matchup, or from Run All), replace it in place. Keeps the tab
+  // incremental when the user runs a single sim and prevents duplicate cards.
+  const existing = el.querySelector('.pilot-card[data-opp-key="' + (typeof CSS !== 'undefined' && CSS.escape ? CSS.escape(oppKey) : oppKey) + '"]');
+  if (existing) {
+    el.replaceChild(card, existing);
+  } else {
+    el.appendChild(card);
+  }
 }
 
 // ============================================================


### PR DESCRIPTION
## Problem
Pilot Guide tab stays stuck on its empty-state message ("Run Run All Matchups to generate pilot guides...") after a single sim. Only Run All Matchups would populate it.

## Root cause
Single-sim handler called `displayResults` + `showInlinePilotCard` but never `generatePilotGuide(oppKey, res)`. That's only wired into the Run All loop.

## Fix
- `generatePilotGuide` now tags each card with `data-opp-key` and upserts instead of appending - prevents duplicate cards when re-simming the same matchup.
- Single-sim handler calls `generatePilotGuide(oppKey, res)` after `displayResults`, and caches the result into `window.lastSimResults[oppKey]` for parity with Run All (so strategy rebuild + PDF builder see it).
- Version chip `v2.1.4-adaptive.3` -> `v2.1.5-pilotfix.1`
- CACHE_NAME `champions-sim-v5-adaptive3` -> `v5-pilotfix1`

## Validation (headless Playwright)
| Case | Result |
|---|---|
| Single sim | 1 pilot card, empty state removed |
| 2nd single sim, same opp | Still 1 card (upsert) |
| Single sim, different opp | 2 cards |
| Run All (prior smoke) | 21 cards, 0 page errors |

Refs #95