### PR TITLE
feat(strategy): record bar showing W-L total + per-archetype splits

### DIFF
--- a/poke-sim/index.html
+++ b/poke-sim/index.html
@@ -43,7 +43,7 @@
         <path d="M 21 6 L 16.5 16 L 19.5 16 L 15.5 28 L 21.5 15.5 L 18.5 15.5 L 22 6 Z" fill="url(#hBolt)" stroke="#ecfeff" stroke-width="0.5" stroke-linejoin="round"/>
       </svg>
       <div>
-        <h1 class="site-title">Poke-e-Sim Champion 2026 <span class="build-version" id="build-version" title="Build version - bumps on every commit so you can confirm which build you are testing">v2.1.5-pilotfix.1</span></h1>
+        <h1 class="site-title">Poke-e-Sim Champion 2026 <span class="build-version" id="build-version" title="Build version - bumps on every commit so you can confirm which build you are testing">v2.1.6-recordbar.1</span></h1>
         <p class="site-sub">April 2026 Meta · VGC Doubles Simulator</p>
       </div>
     </div>
@@ -175,10 +175,10 @@
       <div class="control-block">
         <label class="control-label">Simulated Series</label>
         <select class="select-input" id="sim-count">
-          <option value="50">50 series (fast)</option>
-          <option value="200">200 series</option>
-          <option value="500" selected>500 series</option>
-          <option value="1000">1000 series</option>
+          <option value="10">10 series (fast)</option>
+          <option value="50" selected>50 series</option>
+          <option value="100">100 series</option>
+          <option value="500">500 series (max)</option>
         </select>
       </div>
 

--- a/poke-sim/pokemon-champion-2026.html
+++ b/poke-sim/pokemon-champion-2026.html
@@ -1194,6 +1194,94 @@ table{border-collapse:collapse;width:100%}
 .cs-consistency-inconsistent     { background: rgba(245,158,11,0.22);  color: #fde68a; }
 .cs-consistency-volatile         { background: rgba(239,68,68,0.22);   color: #fecaca; }
 
+/* ==================================================================
+   Phase 4b (Refs #95) - Record bar: total W-L + per-archetype splits
+   User rule: no draws surfaced in Pokemon
+   ================================================================== */
+.cs-record-bar {
+  margin: 0 0 14px;
+  padding: 10px 12px;
+  border-radius: 10px;
+  background: #0f172a;
+  border: 1px solid #1e293b;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 10px 12px;
+}
+.cs-record-total {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 8px;
+  padding: 6px 12px;
+  border-radius: 8px;
+  background: rgba(148,163,184,0.10);
+  border: 1px solid rgba(148,163,184,0.25);
+}
+.cs-record-total-label {
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.5px;
+  text-transform: uppercase;
+  color: #94a3b8;
+}
+.cs-record-total-score {
+  font-size: 18px;
+  font-weight: 700;
+  color: #f8fafc;
+  font-variant-numeric: tabular-nums;
+}
+.cs-record-total-wr {
+  font-size: 13px;
+  font-weight: 600;
+  color: #cbd5e1;
+  font-variant-numeric: tabular-nums;
+}
+.cs-record-splits {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  flex: 1 1 auto;
+}
+.cs-record-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 10px;
+  border-radius: 999px;
+  font-size: 12px;
+  line-height: 1.2;
+  background: rgba(148,163,184,0.10);
+  border: 1px solid rgba(148,163,184,0.22);
+  color: #e2e8f0;
+  white-space: nowrap;
+}
+.cs-record-chip-arch {
+  font-weight: 500;
+  color: #cbd5e1;
+}
+.cs-record-chip-score {
+  font-weight: 700;
+  font-variant-numeric: tabular-nums;
+  color: #f8fafc;
+}
+/* Win-rate color variants - apply to both total pill and chips */
+.cs-record-wr-good { background: rgba(34,197,94,0.16);  border-color: rgba(34,197,94,0.45); }
+.cs-record-wr-mid  { background: rgba(245,158,11,0.14); border-color: rgba(245,158,11,0.45); }
+.cs-record-wr-bad  { background: rgba(239,68,68,0.14);  border-color: rgba(239,68,68,0.45); }
+.cs-record-wr-na   { background: rgba(148,163,184,0.10); border-color: rgba(148,163,184,0.25); }
+.cs-record-wr-good .cs-record-total-score,
+.cs-record-wr-good .cs-record-chip-score { color: #bbf7d0; }
+.cs-record-wr-bad  .cs-record-total-score,
+.cs-record-wr-bad  .cs-record-chip-score { color: #fecaca; }
+.cs-record-wr-mid  .cs-record-total-score,
+.cs-record-wr-mid  .cs-record-chip-score { color: #fde68a; }
+
+@media (max-width: 640px) {
+  .cs-record-total-score { font-size: 16px; }
+  .cs-record-chip { font-size: 11px; padding: 3px 8px; }
+}
+
 </style>
 </head>
 <body>
@@ -1221,7 +1309,7 @@ table{border-collapse:collapse;width:100%}
         <path d="M 21 6 L 16.5 16 L 19.5 16 L 15.5 28 L 21.5 15.5 L 18.5 15.5 L 22 6 Z" fill="url(#hBolt)" stroke="#ecfeff" stroke-width="0.5" stroke-linejoin="round"/>
       </svg>
       <div>
-        <h1 class="site-title">Poke-e-Sim Champion 2026 <span class="build-version" id="build-version" title="Build version - bumps on every commit so you can confirm which build you are testing">v2.1.5-pilotfix.1</span></h1>
+        <h1 class="site-title">Poke-e-Sim Champion 2026 <span class="build-version" id="build-version" title="Build version - bumps on every commit so you can confirm which build you are testing">v2.1.6-recordbar.1</span></h1>
         <p class="site-sub">April 2026 Meta · VGC Doubles Simulator</p>
       </div>
     </div>
@@ -1353,10 +1441,10 @@ table{border-collapse:collapse;width:100%}
       <div class="control-block">
         <label class="control-label">Simulated Series</label>
         <select class="select-input" id="sim-count">
-          <option value="50">50 series (fast)</option>
-          <option value="200">200 series</option>
-          <option value="500" selected>500 series</option>
-          <option value="1000">1000 series</option>
+          <option value="10">10 series (fast)</option>
+          <option value="50" selected>50 series</option>
+          <option value="100">100 series</option>
+          <option value="500">500 series (max)</option>
         </select>
       </div>
 
@@ -13703,6 +13791,7 @@ function renderStrategyTab(teamKey) {
   try {
     var _history = (typeof computeTeamHistory === 'function') ? computeTeamHistory(teamKey) : null;
     if (_history) html += csRenderAdaptiveBanner(_history);
+    if (_history) html += csRenderRecordBar(_history);
   } catch (e) { console.warn('[Phase4b] banner render failed:', e && e.message); }
 
   // Section 1: Team report card
@@ -14427,6 +14516,43 @@ function computeTeamHistory(teamKey) {
     });
   });
 
+  // Record by opponent archetype. Classifies each opponent team via the same
+  // inferPlaystyle() heuristic used on the player side, then tallies W/L at
+  // the game level. Pokemon has no real "draw" in the user's view, so draws
+  // are omitted from the record bar entirely (they still live in total_battles
+  // elsewhere for sample-size math). Gives the user a bar like
+  // "vs Trick Room: 12-4" at a glance.
+  var record_total = { n: wins + losses, w: wins, l: losses,
+                       win_rate: (wins + losses) > 0 ? wins / (wins + losses) : 0 };
+  var record_by_archetype = {};
+  var _archetypeCache = {};
+  function _classifyOpp(oppKey) {
+    if (_archetypeCache[oppKey]) return _archetypeCache[oppKey];
+    var label = 'Unknown';
+    try {
+      if (typeof TEAMS !== 'undefined' && TEAMS[oppKey] && typeof inferPlaystyle === 'function') {
+        label = inferPlaystyle(TEAMS[oppKey].members || []) || 'Balanced';
+      }
+    } catch (e) { /* leave as Unknown */ }
+    _archetypeCache[oppKey] = label;
+    return label;
+  }
+  entries.forEach(function(e){
+    var arch = _classifyOpp(e.oppKey);
+    if (!record_by_archetype[arch]) record_by_archetype[arch] = { n: 0, w: 0, l: 0 };
+    (e.games || []).forEach(function(g){
+      if (g.result === 'win')       { record_by_archetype[arch].n++; record_by_archetype[arch].w++; }
+      else if (g.result === 'loss') { record_by_archetype[arch].n++; record_by_archetype[arch].l++; }
+      // draws intentionally skipped in the surfaced record
+    });
+  });
+  var record_by_archetype_arr = Object.keys(record_by_archetype).map(function(k){
+    var r = record_by_archetype[k];
+    return { archetype: k, n: r.n, w: r.w, l: r.l,
+             win_rate: r.n > 0 ? r.w / r.n : 0 };
+  }).filter(function(r){ return r.n > 0; })
+    .sort(function(a,b){ return b.n - a.n; });
+
   var history = {
     total_battles: total_battles,
     total_series: total_series,
@@ -14444,6 +14570,8 @@ function computeTeamHistory(teamKey) {
     common_loss_conditions: common_loss_conditions,
     dead_moves: dead_moves,
     protect_peaks: protectPeaks,
+    record_total: record_total,
+    record_by_archetype: record_by_archetype_arr,
     player_behavior_patterns: []  // Phase 4e fills this
   };
 
@@ -14497,10 +14625,52 @@ function csRenderAdaptiveBanner(history) {
   return html;
 }
 
+// Render the Record bar: overall W-L pill + per-archetype chips. Shown right
+// under the adaptive banner on the Strategy tab. No draws surfaced (per user:
+// "there no draw in pokemon"). Sorted by sample size so the most-battled
+// archetypes lead the bar.
+function csRenderRecordBar(history) {
+  if (!history) return '';
+  var total = history.record_total || { n: 0, w: 0, l: 0, win_rate: 0 };
+  var splits = history.record_by_archetype || [];
+  function _wrClass(wr, n) {
+    if (!n) return 'cs-record-wr-na';
+    if (wr >= 0.60) return 'cs-record-wr-good';
+    if (wr >= 0.45) return 'cs-record-wr-mid';
+    return 'cs-record-wr-bad';
+  }
+  function _pct(wr) { return Math.round((wr || 0) * 100) + '%'; }
+  var html = '';
+  html += '<div class="cs-record-bar">';
+  html +=   '<div class="cs-record-total ' + _wrClass(total.win_rate, total.n) + '">';
+  html +=     '<span class="cs-record-total-label">Record</span>';
+  if (total.n > 0) {
+    html +=   '<span class="cs-record-total-score">' + total.w + '-' + total.l + '</span>';
+    html +=   '<span class="cs-record-total-wr">' + _pct(total.win_rate) + '</span>';
+  } else {
+    html +=   '<span class="cs-record-total-score">no games yet</span>';
+  }
+  html +=   '</div>';
+  if (splits.length > 0) {
+    html += '<div class="cs-record-splits">';
+    splits.forEach(function(r){
+      html += '<span class="cs-record-chip ' + _wrClass(r.win_rate, r.n) + '" '
+           +  'title="' + _csEsc(r.archetype) + ': ' + r.w + '-' + r.l + ' (' + _pct(r.win_rate) + ')">'
+           +    '<span class="cs-record-chip-arch">vs ' + _csEsc(r.archetype) + '</span>'
+           +    '<span class="cs-record-chip-score">' + r.w + '-' + r.l + '</span>'
+           +  '</span>';
+    });
+    html += '</div>';
+  }
+  html += '</div>';
+  return html;
+}
+
 try {
   window.computeTeamHistory       = computeTeamHistory;
   window.csInvalidateTeamHistory  = csInvalidateTeamHistory;
   window.csRenderAdaptiveBanner   = csRenderAdaptiveBanner;
+  window.csRenderRecordBar        = csRenderRecordBar;
 } catch (_e) { /* non-browser */ }
 
 // Paint cached report immediately if available. Used as the fast-path on

--- a/poke-sim/style.css
+++ b/poke-sim/style.css
@@ -1173,3 +1173,91 @@ table{border-collapse:collapse;width:100%}
 .cs-consistency-consistent       { background: rgba(34,197,94,0.22);   color: #bbf7d0; }
 .cs-consistency-inconsistent     { background: rgba(245,158,11,0.22);  color: #fde68a; }
 .cs-consistency-volatile         { background: rgba(239,68,68,0.22);   color: #fecaca; }
+
+/* ==================================================================
+   Phase 4b (Refs #95) - Record bar: total W-L + per-archetype splits
+   User rule: no draws surfaced in Pokemon
+   ================================================================== */
+.cs-record-bar {
+  margin: 0 0 14px;
+  padding: 10px 12px;
+  border-radius: 10px;
+  background: #0f172a;
+  border: 1px solid #1e293b;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 10px 12px;
+}
+.cs-record-total {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 8px;
+  padding: 6px 12px;
+  border-radius: 8px;
+  background: rgba(148,163,184,0.10);
+  border: 1px solid rgba(148,163,184,0.25);
+}
+.cs-record-total-label {
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.5px;
+  text-transform: uppercase;
+  color: #94a3b8;
+}
+.cs-record-total-score {
+  font-size: 18px;
+  font-weight: 700;
+  color: #f8fafc;
+  font-variant-numeric: tabular-nums;
+}
+.cs-record-total-wr {
+  font-size: 13px;
+  font-weight: 600;
+  color: #cbd5e1;
+  font-variant-numeric: tabular-nums;
+}
+.cs-record-splits {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  flex: 1 1 auto;
+}
+.cs-record-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 10px;
+  border-radius: 999px;
+  font-size: 12px;
+  line-height: 1.2;
+  background: rgba(148,163,184,0.10);
+  border: 1px solid rgba(148,163,184,0.22);
+  color: #e2e8f0;
+  white-space: nowrap;
+}
+.cs-record-chip-arch {
+  font-weight: 500;
+  color: #cbd5e1;
+}
+.cs-record-chip-score {
+  font-weight: 700;
+  font-variant-numeric: tabular-nums;
+  color: #f8fafc;
+}
+/* Win-rate color variants - apply to both total pill and chips */
+.cs-record-wr-good { background: rgba(34,197,94,0.16);  border-color: rgba(34,197,94,0.45); }
+.cs-record-wr-mid  { background: rgba(245,158,11,0.14); border-color: rgba(245,158,11,0.45); }
+.cs-record-wr-bad  { background: rgba(239,68,68,0.14);  border-color: rgba(239,68,68,0.45); }
+.cs-record-wr-na   { background: rgba(148,163,184,0.10); border-color: rgba(148,163,184,0.25); }
+.cs-record-wr-good .cs-record-total-score,
+.cs-record-wr-good .cs-record-chip-score { color: #bbf7d0; }
+.cs-record-wr-bad  .cs-record-total-score,
+.cs-record-wr-bad  .cs-record-chip-score { color: #fecaca; }
+.cs-record-wr-mid  .cs-record-total-score,
+.cs-record-wr-mid  .cs-record-chip-score { color: #fde68a; }
+
+@media (max-width: 640px) {
+  .cs-record-total-score { font-size: 16px; }
+  .cs-record-chip { font-size: 11px; padding: 3px 8px; }
+}

--- a/poke-sim/sw.js
+++ b/poke-sim/sw.js
@@ -4,7 +4,7 @@
 // MUST be bumped on every release that changes engine.js, data.js, ui.js, or style.css
 // Phase 2 automation tracked in #95 (tools/release.sh)
 
-const CACHE_NAME = 'champions-sim-v5-pilotfix1';
+const CACHE_NAME = 'champions-sim-v5-recordbar1';
 const SPRITE_CACHE = 'champions-sprites-v1';
 
 const APP_ASSETS = [

--- a/poke-sim/ui.js
+++ b/poke-sim/ui.js
@@ -5099,6 +5099,7 @@ function renderStrategyTab(teamKey) {
   try {
     var _history = (typeof computeTeamHistory === 'function') ? computeTeamHistory(teamKey) : null;
     if (_history) html += csRenderAdaptiveBanner(_history);
+    if (_history) html += csRenderRecordBar(_history);
   } catch (e) { console.warn('[Phase4b] banner render failed:', e && e.message); }
 
   // Section 1: Team report card
@@ -5823,6 +5824,43 @@ function computeTeamHistory(teamKey) {
     });
   });
 
+  // Record by opponent archetype. Classifies each opponent team via the same
+  // inferPlaystyle() heuristic used on the player side, then tallies W/L at
+  // the game level. Pokemon has no real "draw" in the user's view, so draws
+  // are omitted from the record bar entirely (they still live in total_battles
+  // elsewhere for sample-size math). Gives the user a bar like
+  // "vs Trick Room: 12-4" at a glance.
+  var record_total = { n: wins + losses, w: wins, l: losses,
+                       win_rate: (wins + losses) > 0 ? wins / (wins + losses) : 0 };
+  var record_by_archetype = {};
+  var _archetypeCache = {};
+  function _classifyOpp(oppKey) {
+    if (_archetypeCache[oppKey]) return _archetypeCache[oppKey];
+    var label = 'Unknown';
+    try {
+      if (typeof TEAMS !== 'undefined' && TEAMS[oppKey] && typeof inferPlaystyle === 'function') {
+        label = inferPlaystyle(TEAMS[oppKey].members || []) || 'Balanced';
+      }
+    } catch (e) { /* leave as Unknown */ }
+    _archetypeCache[oppKey] = label;
+    return label;
+  }
+  entries.forEach(function(e){
+    var arch = _classifyOpp(e.oppKey);
+    if (!record_by_archetype[arch]) record_by_archetype[arch] = { n: 0, w: 0, l: 0 };
+    (e.games || []).forEach(function(g){
+      if (g.result === 'win')       { record_by_archetype[arch].n++; record_by_archetype[arch].w++; }
+      else if (g.result === 'loss') { record_by_archetype[arch].n++; record_by_archetype[arch].l++; }
+      // draws intentionally skipped in the surfaced record
+    });
+  });
+  var record_by_archetype_arr = Object.keys(record_by_archetype).map(function(k){
+    var r = record_by_archetype[k];
+    return { archetype: k, n: r.n, w: r.w, l: r.l,
+             win_rate: r.n > 0 ? r.w / r.n : 0 };
+  }).filter(function(r){ return r.n > 0; })
+    .sort(function(a,b){ return b.n - a.n; });
+
   var history = {
     total_battles: total_battles,
     total_series: total_series,
@@ -5840,6 +5878,8 @@ function computeTeamHistory(teamKey) {
     common_loss_conditions: common_loss_conditions,
     dead_moves: dead_moves,
     protect_peaks: protectPeaks,
+    record_total: record_total,
+    record_by_archetype: record_by_archetype_arr,
     player_behavior_patterns: []  // Phase 4e fills this
   };
 
@@ -5893,10 +5933,52 @@ function csRenderAdaptiveBanner(history) {
   return html;
 }
 
+// Render the Record bar: overall W-L pill + per-archetype chips. Shown right
+// under the adaptive banner on the Strategy tab. No draws surfaced (per user:
+// "there no draw in pokemon"). Sorted by sample size so the most-battled
+// archetypes lead the bar.
+function csRenderRecordBar(history) {
+  if (!history) return '';
+  var total = history.record_total || { n: 0, w: 0, l: 0, win_rate: 0 };
+  var splits = history.record_by_archetype || [];
+  function _wrClass(wr, n) {
+    if (!n) return 'cs-record-wr-na';
+    if (wr >= 0.60) return 'cs-record-wr-good';
+    if (wr >= 0.45) return 'cs-record-wr-mid';
+    return 'cs-record-wr-bad';
+  }
+  function _pct(wr) { return Math.round((wr || 0) * 100) + '%'; }
+  var html = '';
+  html += '<div class="cs-record-bar">';
+  html +=   '<div class="cs-record-total ' + _wrClass(total.win_rate, total.n) + '">';
+  html +=     '<span class="cs-record-total-label">Record</span>';
+  if (total.n > 0) {
+    html +=   '<span class="cs-record-total-score">' + total.w + '-' + total.l + '</span>';
+    html +=   '<span class="cs-record-total-wr">' + _pct(total.win_rate) + '</span>';
+  } else {
+    html +=   '<span class="cs-record-total-score">no games yet</span>';
+  }
+  html +=   '</div>';
+  if (splits.length > 0) {
+    html += '<div class="cs-record-splits">';
+    splits.forEach(function(r){
+      html += '<span class="cs-record-chip ' + _wrClass(r.win_rate, r.n) + '" '
+           +  'title="' + _csEsc(r.archetype) + ': ' + r.w + '-' + r.l + ' (' + _pct(r.win_rate) + ')">'
+           +    '<span class="cs-record-chip-arch">vs ' + _csEsc(r.archetype) + '</span>'
+           +    '<span class="cs-record-chip-score">' + r.w + '-' + r.l + '</span>'
+           +  '</span>';
+    });
+    html += '</div>';
+  }
+  html += '</div>';
+  return html;
+}
+
 try {
   window.computeTeamHistory       = computeTeamHistory;
   window.csInvalidateTeamHistory  = csInvalidateTeamHistory;
   window.csRenderAdaptiveBanner   = csRenderAdaptiveBanner;
+  window.csRenderRecordBar        = csRenderRecordBar;
 } catch (_e) { /* non-browser */ }
 
 // Paint cached report immediately if available. Used as the fast-path on


### PR DESCRIPTION
## What
Adds a Record bar to the top of the Strategy tab (under the adaptive banner) showing overall W-L and per-archetype splits.

Closes the last gap from user feedback: *"should have win loss and what type your record was total and then vs different types of team like trick room, aggressive, balance control"* + *"there no draw in pokemon"*.

## Changes
- `computeTeamHistory` produces `record_total` (n/w/l/win_rate) and `record_by_archetype` (sorted by sample size desc, n>0 only). **Draws excluded entirely.**
- `csRenderRecordBar()` renders: overall W-L pill + per-archetype "vs {archetype} W-L" chips. WR color coding: green >=60, amber 45-60, red <45.
- Wired into `renderStrategyTab` right after the adaptive banner.
- Exposed via `window.csRenderRecordBar`.
- `style.css`: `.cs-record-bar` / `.cs-record-total` / `.cs-record-chip` + WR variants + mobile override.
- `index.html`: sim-count dropdown now `10 / 50 / 100 / 500` (50 default, 500 labeled max) per user request.
- Version chip `v2.1.5-pilotfix.1` -> `v2.1.6-recordbar.1`
- CACHE_NAME `v5-pilotfix1` -> `v5-recordbar1`

## Validation (headless Playwright + screenshot)
| Check | Result |
|---|---|
| Bar renders with correct structure | PASS |
| Total pill shows W-L + % (no D) | 35-14 71% |
| Archetype chips show W-L only | vs Balanced Offense 17-10, vs Hyper Offense 18-4 |
| Bar textContent does NOT match /draw/i | PASS |
| Page errors on load + 2 sims + Strategy render | 0 errors |
| `node --check ui.js` | PASS |

Refs #95