### PR TITLE
fix(strategy): record bar pulls both-sides sim log so opponent-only teams populate

### DIFF
--- a/poke-sim/index.html
+++ b/poke-sim/index.html
@@ -43,7 +43,7 @@
         <path d="M 21 6 L 16.5 16 L 19.5 16 L 15.5 28 L 21.5 15.5 L 18.5 15.5 L 22 6 Z" fill="url(#hBolt)" stroke="#ecfeff" stroke-width="0.5" stroke-linejoin="round"/>
       </svg>
       <div>
-        <h1 class="site-title">Poke-e-Sim Champion 2026 <span class="build-version" id="build-version" title="Build version - bumps on every commit so you can confirm which build you are testing">v2.1.6-recordbar.1</span></h1>
+        <h1 class="site-title">Poke-e-Sim Champion 2026 <span class="build-version" id="build-version" title="Build version - bumps on every commit so you can confirm which build you are testing">v2.1.7-mirror.1</span></h1>
         <p class="site-sub">April 2026 Meta · VGC Doubles Simulator</p>
       </div>
     </div>

--- a/poke-sim/pokemon-champion-2026.html
+++ b/poke-sim/pokemon-champion-2026.html
@@ -1309,7 +1309,7 @@ table{border-collapse:collapse;width:100%}
         <path d="M 21 6 L 16.5 16 L 19.5 16 L 15.5 28 L 21.5 15.5 L 18.5 15.5 L 22 6 Z" fill="url(#hBolt)" stroke="#ecfeff" stroke-width="0.5" stroke-linejoin="round"/>
       </svg>
       <div>
-        <h1 class="site-title">Poke-e-Sim Champion 2026 <span class="build-version" id="build-version" title="Build version - bumps on every commit so you can confirm which build you are testing">v2.1.6-recordbar.1</span></h1>
+        <h1 class="site-title">Poke-e-Sim Champion 2026 <span class="build-version" id="build-version" title="Build version - bumps on every commit so you can confirm which build you are testing">v2.1.7-mirror.1</span></h1>
         <p class="site-sub">April 2026 Meta · VGC Doubles Simulator</p>
       </div>
     </div>
@@ -14313,6 +14313,45 @@ function csSimLogGetAll() { return _csSimLogRead().entries.slice(); }
 function csSimLogForTeam(teamKey) {
   return _csSimLogRead().entries.filter(function(e){ return e.playerKey === teamKey; });
 }
+// Refs #95 - return every entry that involves teamKey on EITHER side, normalized
+// to teamKey's point-of-view. Entries where teamKey was the opponent are returned
+// with seriesResult + per-game result fields flipped (win<->loss, draw unchanged)
+// and playerKey/oppKey swapped so downstream code can treat them uniformly. This
+// is what the Record bar and team_history consume so a team that was only simmed
+// as an opponent still populates its Strategy view (user request: "data should
+// pull in showing win loss against each category of teams").
+function _flipResult(r) {
+  return r === 'win' ? 'loss' : r === 'loss' ? 'win' : r;
+}
+function csSimLogForTeamBothSides(teamKey) {
+  var all = _csSimLogRead().entries;
+  var out = [];
+  for (var i = 0; i < all.length; i++) {
+    var e = all[i];
+    if (e.playerKey === teamKey) {
+      // Shallow copy - downstream iterates games, so keep games refs.
+      out.push(e);
+    } else if (e.oppKey === teamKey) {
+      var flippedGames = (e.games || []).map(function(g){
+        var ng = {};
+        for (var k in g) if (Object.prototype.hasOwnProperty.call(g, k)) ng[k] = g[k];
+        ng.result = _flipResult(g.result);
+        return ng;
+      });
+      out.push({
+        ts: e.ts,
+        playerKey: teamKey,       // normalize to viewer POV
+        oppKey:    e.playerKey,   // the ORIGINAL player is the opponent we faced
+        format:    e.format,
+        bo:        e.bo,
+        games:     flippedGames,
+        seriesResult: _flipResult(e.seriesResult),
+        _mirrored: true
+      });
+    }
+  }
+  return out;
+}
 function csSimLogForMatchup(playerKey, oppKey) {
   return _csSimLogRead().entries.filter(function(e){
     return e.playerKey === playerKey && e.oppKey === oppKey;
@@ -14332,6 +14371,7 @@ try {
   window.csSimLogAppendSeries = csSimLogAppendSeries;
   window.csSimLogGetAll       = csSimLogGetAll;
   window.csSimLogForTeam      = csSimLogForTeam;
+  window.csSimLogForTeamBothSides = csSimLogForTeamBothSides;
   window.csSimLogForMatchup   = csSimLogForMatchup;
   window.csSimLogClearTeam    = csSimLogClearTeam;
   window.csSimLogClearAll     = csSimLogClearAll;
@@ -14362,7 +14402,14 @@ function computeTeamHistory(teamKey) {
   if (cached && (Date.now() - cached.ts) < CS_HISTORY_TTL_MS) {
     return cached.history;
   }
-  var entries = (typeof csSimLogForTeam === 'function') ? csSimLogForTeam(teamKey) : [];
+  // Refs #95 - Use both-sides view so teams that were only simmed as the
+  // opponent still get a populated Record bar and state machine (results are
+  // mirrored to teamKey's POV). Previously this used csSimLogForTeam which
+  // only returned entries where teamKey was the pilot, which is why a team
+  // you'd simmed against but never piloted showed "no games yet".
+  var entries = (typeof csSimLogForTeamBothSides === 'function')
+    ? csSimLogForTeamBothSides(teamKey)
+    : ((typeof csSimLogForTeam === 'function') ? csSimLogForTeam(teamKey) : []);
   var games = [];
   entries.forEach(function(e){ if (e.games) games = games.concat(e.games); });
 

--- a/poke-sim/sw.js
+++ b/poke-sim/sw.js
@@ -4,7 +4,7 @@
 // MUST be bumped on every release that changes engine.js, data.js, ui.js, or style.css
 // Phase 2 automation tracked in #95 (tools/release.sh)
 
-const CACHE_NAME = 'champions-sim-v5-recordbar1';
+const CACHE_NAME = 'champions-sim-v5-mirror1';
 const SPRITE_CACHE = 'champions-sprites-v1';
 
 const APP_ASSETS = [

--- a/poke-sim/ui.js
+++ b/poke-sim/ui.js
@@ -5621,6 +5621,45 @@ function csSimLogGetAll() { return _csSimLogRead().entries.slice(); }
 function csSimLogForTeam(teamKey) {
   return _csSimLogRead().entries.filter(function(e){ return e.playerKey === teamKey; });
 }
+// Refs #95 - return every entry that involves teamKey on EITHER side, normalized
+// to teamKey's point-of-view. Entries where teamKey was the opponent are returned
+// with seriesResult + per-game result fields flipped (win<->loss, draw unchanged)
+// and playerKey/oppKey swapped so downstream code can treat them uniformly. This
+// is what the Record bar and team_history consume so a team that was only simmed
+// as an opponent still populates its Strategy view (user request: "data should
+// pull in showing win loss against each category of teams").
+function _flipResult(r) {
+  return r === 'win' ? 'loss' : r === 'loss' ? 'win' : r;
+}
+function csSimLogForTeamBothSides(teamKey) {
+  var all = _csSimLogRead().entries;
+  var out = [];
+  for (var i = 0; i < all.length; i++) {
+    var e = all[i];
+    if (e.playerKey === teamKey) {
+      // Shallow copy - downstream iterates games, so keep games refs.
+      out.push(e);
+    } else if (e.oppKey === teamKey) {
+      var flippedGames = (e.games || []).map(function(g){
+        var ng = {};
+        for (var k in g) if (Object.prototype.hasOwnProperty.call(g, k)) ng[k] = g[k];
+        ng.result = _flipResult(g.result);
+        return ng;
+      });
+      out.push({
+        ts: e.ts,
+        playerKey: teamKey,       // normalize to viewer POV
+        oppKey:    e.playerKey,   // the ORIGINAL player is the opponent we faced
+        format:    e.format,
+        bo:        e.bo,
+        games:     flippedGames,
+        seriesResult: _flipResult(e.seriesResult),
+        _mirrored: true
+      });
+    }
+  }
+  return out;
+}
 function csSimLogForMatchup(playerKey, oppKey) {
   return _csSimLogRead().entries.filter(function(e){
     return e.playerKey === playerKey && e.oppKey === oppKey;
@@ -5640,6 +5679,7 @@ try {
   window.csSimLogAppendSeries = csSimLogAppendSeries;
   window.csSimLogGetAll       = csSimLogGetAll;
   window.csSimLogForTeam      = csSimLogForTeam;
+  window.csSimLogForTeamBothSides = csSimLogForTeamBothSides;
   window.csSimLogForMatchup   = csSimLogForMatchup;
   window.csSimLogClearTeam    = csSimLogClearTeam;
   window.csSimLogClearAll     = csSimLogClearAll;
@@ -5670,7 +5710,14 @@ function computeTeamHistory(teamKey) {
   if (cached && (Date.now() - cached.ts) < CS_HISTORY_TTL_MS) {
     return cached.history;
   }
-  var entries = (typeof csSimLogForTeam === 'function') ? csSimLogForTeam(teamKey) : [];
+  // Refs #95 - Use both-sides view so teams that were only simmed as the
+  // opponent still get a populated Record bar and state machine (results are
+  // mirrored to teamKey's POV). Previously this used csSimLogForTeam which
+  // only returned entries where teamKey was the pilot, which is why a team
+  // you'd simmed against but never piloted showed "no games yet".
+  var entries = (typeof csSimLogForTeamBothSides === 'function')
+    ? csSimLogForTeamBothSides(teamKey)
+    : ((typeof csSimLogForTeam === 'function') ? csSimLogForTeam(teamKey) : []);
   var games = [];
   entries.forEach(function(e){ if (e.games) games = games.concat(e.games); });
 


### PR DESCRIPTION
## Problem
Strategy tab showed "no games yet" for any team that was only simmed AGAINST. Seeing the screenshot: user simmed with `player` selected, then switched player-select to a different team to view its Strategy - and the Record bar was empty even though that team had fought 10+ series as the opponent.

## Root cause
`csSimLogForTeam(teamKey)` only matched entries where `playerKey === teamKey`. Sims only attribute to the pilot side.

## Fix (read-side mirroring, no migration)
- New `csSimLogForTeamBothSides(teamKey)` returns entries where team appears on either side, with results mirrored (win <-> loss, playerKey/oppKey swapped) for the opp-side hits. Draws left unchanged.
- `computeTeamHistory` now consumes the both-sides view.
- Mirrored entries carry `_mirrored: true` for debugging.
- Version chip `v2.1.6-recordbar.1` -> `v2.1.7-mirror.1`, CACHE_NAME `v5-recordbar1` -> `v5-mirror1`.

## Validation (headless)
| Case | Result |
|---|---|
| Sim player vs mega_altaria, view player | 20-1 (95%) vs Hyper Offense |
| Same session, view mega_altaria | 1-20 (5%) vs Balanced Offense (mirrored) |
| Symmetry (draw-free) | WRs sum to 1.000 |
| Untouched team (mega_dragonite) | 0 battles, state 1 (no leakage) |
| `node --check ui.js` | PASS |
| Page errors | 0 |

Refs #95