### PR TITLE
fix: clearer Record bar empty-state guidance for pre-Phase-4 users

### DIFF
--- a/poke-sim/index.html
+++ b/poke-sim/index.html
@@ -43,7 +43,7 @@
         <path d="M 21 6 L 16.5 16 L 19.5 16 L 15.5 28 L 21.5 15.5 L 18.5 15.5 L 22 6 Z" fill="url(#hBolt)" stroke="#ecfeff" stroke-width="0.5" stroke-linejoin="round"/>
       </svg>
       <div>
-        <h1 class="site-title">Poke-e-Sim Champion 2026 <span class="build-version" id="build-version" title="Build version - bumps on every commit so you can confirm which build you are testing">v2.1.7-mirror.1</span></h1>
+        <h1 class="site-title">Poke-e-Sim Champion 2026 <span class="build-version" id="build-version" title="Build version - bumps on every commit so you can confirm which build you are testing">v2.1.8-emptystate.1</span></h1>
         <p class="site-sub">April 2026 Meta · VGC Doubles Simulator</p>
       </div>
     </div>

--- a/poke-sim/pokemon-champion-2026.html
+++ b/poke-sim/pokemon-champion-2026.html
@@ -1277,9 +1277,22 @@ table{border-collapse:collapse;width:100%}
 .cs-record-wr-mid  .cs-record-total-score,
 .cs-record-wr-mid  .cs-record-chip-score { color: #fde68a; }
 
+/* Empty-state hint under the Record pill. Shown only when the Phase 4 sim
+   log has no per-series data yet - tells the user whether they have legacy
+   aggregate data or need to run their first sim. Refs #53, #55. */
+.cs-record-empty-hint {
+  flex-basis: 100%;
+  font-size: 12px;
+  line-height: 1.45;
+  color: #94a3b8;
+  padding: 4px 2px 0;
+  font-style: italic;
+}
+
 @media (max-width: 640px) {
   .cs-record-total-score { font-size: 16px; }
   .cs-record-chip { font-size: 11px; padding: 3px 8px; }
+  .cs-record-empty-hint { font-size: 11px; }
 }
 
 </style>
@@ -1309,7 +1322,7 @@ table{border-collapse:collapse;width:100%}
         <path d="M 21 6 L 16.5 16 L 19.5 16 L 15.5 28 L 21.5 15.5 L 18.5 15.5 L 22 6 Z" fill="url(#hBolt)" stroke="#ecfeff" stroke-width="0.5" stroke-linejoin="round"/>
       </svg>
       <div>
-        <h1 class="site-title">Poke-e-Sim Champion 2026 <span class="build-version" id="build-version" title="Build version - bumps on every commit so you can confirm which build you are testing">v2.1.7-mirror.1</span></h1>
+        <h1 class="site-title">Poke-e-Sim Champion 2026 <span class="build-version" id="build-version" title="Build version - bumps on every commit so you can confirm which build you are testing">v2.1.8-emptystate.1</span></h1>
         <p class="site-sub">April 2026 Meta · VGC Doubles Simulator</p>
       </div>
     </div>
@@ -14672,6 +14685,30 @@ function csRenderAdaptiveBanner(history) {
   return html;
 }
 
+// Detect whether pre-Phase-4 sim data exists in the Phase 3 persistence store
+// but the Phase 4 raw sim log is empty. Used to show a clearer empty-state
+// hint in the Record bar so users who simmed before v2.1.6 know why their
+// prior games don't appear (the per-series log did not exist yet).
+//   Returns 'legacy'  - Phase 3 overlays with sample_size > 0 exist, log empty
+//           'new'     - no data anywhere
+//           'has_log' - Phase 4 sim log has at least one entry
+function _csRecordEmptyStateKind() {
+  try {
+    var logEntries = (typeof csSimLogGetAll === 'function') ? csSimLogGetAll() : [];
+    if (logEntries && logEntries.length > 0) return 'has_log';
+    var store = (typeof _csPersistRead === 'function') ? _csPersistRead() : null;
+    var reports = (store && store.reports) || {};
+    var sigs = Object.keys(reports);
+    for (var i = 0; i < sigs.length; i++) {
+      var overlay = reports[sigs[i]] && reports[sigs[i]].simulation_overlay;
+      if (overlay && overlay.sample_size && overlay.sample_size > 0) return 'legacy';
+    }
+    return 'new';
+  } catch (_e) {
+    return 'new';
+  }
+}
+
 // Render the Record bar: overall W-L pill + per-archetype chips. Shown right
 // under the adaptive banner on the Strategy tab. No draws surfaced (per user:
 // "there no draw in pokemon"). Sorted by sample size so the most-battled
@@ -14708,6 +14745,19 @@ function csRenderRecordBar(history) {
            +  '</span>';
     });
     html += '</div>';
+  }
+  // Empty-state hint: only when there is no per-series data yet. Distinguishes
+  // between "you have legacy aggregate sims from before v2.1.6" and "brand
+  // new install" so the message is actionable. Refs #53, #55.
+  if (total.n === 0) {
+    var kind = _csRecordEmptyStateKind();
+    var hint;
+    if (kind === 'legacy') {
+      hint = 'Previous sim data was recorded before per-series tracking (added in v2.1.6). Run a fresh sim to start your record.';
+    } else {
+      hint = 'Run a sim to start tracking your W-L by matchup.';
+    }
+    html += '<div class="cs-record-empty-hint">' + _csEsc(hint) + '</div>';
   }
   html += '</div>';
   return html;

--- a/poke-sim/style.css
+++ b/poke-sim/style.css
@@ -1257,7 +1257,20 @@ table{border-collapse:collapse;width:100%}
 .cs-record-wr-mid  .cs-record-total-score,
 .cs-record-wr-mid  .cs-record-chip-score { color: #fde68a; }
 
+/* Empty-state hint under the Record pill. Shown only when the Phase 4 sim
+   log has no per-series data yet - tells the user whether they have legacy
+   aggregate data or need to run their first sim. Refs #53, #55. */
+.cs-record-empty-hint {
+  flex-basis: 100%;
+  font-size: 12px;
+  line-height: 1.45;
+  color: #94a3b8;
+  padding: 4px 2px 0;
+  font-style: italic;
+}
+
 @media (max-width: 640px) {
   .cs-record-total-score { font-size: 16px; }
   .cs-record-chip { font-size: 11px; padding: 3px 8px; }
+  .cs-record-empty-hint { font-size: 11px; }
 }

--- a/poke-sim/sw.js
+++ b/poke-sim/sw.js
@@ -4,7 +4,7 @@
 // MUST be bumped on every release that changes engine.js, data.js, ui.js, or style.css
 // Phase 2 automation tracked in #95 (tools/release.sh)
 
-const CACHE_NAME = 'champions-sim-v5-mirror1';
+const CACHE_NAME = 'champions-sim-v5-emptystate1';
 const SPRITE_CACHE = 'champions-sprites-v1';
 
 const APP_ASSETS = [

--- a/poke-sim/ui.js
+++ b/poke-sim/ui.js
@@ -5980,6 +5980,30 @@ function csRenderAdaptiveBanner(history) {
   return html;
 }
 
+// Detect whether pre-Phase-4 sim data exists in the Phase 3 persistence store
+// but the Phase 4 raw sim log is empty. Used to show a clearer empty-state
+// hint in the Record bar so users who simmed before v2.1.6 know why their
+// prior games don't appear (the per-series log did not exist yet).
+//   Returns 'legacy'  - Phase 3 overlays with sample_size > 0 exist, log empty
+//           'new'     - no data anywhere
+//           'has_log' - Phase 4 sim log has at least one entry
+function _csRecordEmptyStateKind() {
+  try {
+    var logEntries = (typeof csSimLogGetAll === 'function') ? csSimLogGetAll() : [];
+    if (logEntries && logEntries.length > 0) return 'has_log';
+    var store = (typeof _csPersistRead === 'function') ? _csPersistRead() : null;
+    var reports = (store && store.reports) || {};
+    var sigs = Object.keys(reports);
+    for (var i = 0; i < sigs.length; i++) {
+      var overlay = reports[sigs[i]] && reports[sigs[i]].simulation_overlay;
+      if (overlay && overlay.sample_size && overlay.sample_size > 0) return 'legacy';
+    }
+    return 'new';
+  } catch (_e) {
+    return 'new';
+  }
+}
+
 // Render the Record bar: overall W-L pill + per-archetype chips. Shown right
 // under the adaptive banner on the Strategy tab. No draws surfaced (per user:
 // "there no draw in pokemon"). Sorted by sample size so the most-battled
@@ -6016,6 +6040,19 @@ function csRenderRecordBar(history) {
            +  '</span>';
     });
     html += '</div>';
+  }
+  // Empty-state hint: only when there is no per-series data yet. Distinguishes
+  // between "you have legacy aggregate sims from before v2.1.6" and "brand
+  // new install" so the message is actionable. Refs #53, #55.
+  if (total.n === 0) {
+    var kind = _csRecordEmptyStateKind();
+    var hint;
+    if (kind === 'legacy') {
+      hint = 'Previous sim data was recorded before per-series tracking (added in v2.1.6). Run a fresh sim to start your record.';
+    } else {
+      hint = 'Run a sim to start tracking your W-L by matchup.';
+    }
+    html += '<div class="cs-record-empty-hint">' + _csEsc(hint) + '</div>';
   }
   html += '</div>';
   return html;


### PR DESCRIPTION
## What

Clearer empty-state guidance for the Record bar when users have pre-Phase-4 sim data but no per-series log.

## Root cause

Two separate localStorage keys back two different summaries:

- `champions_strategy_report_v1` → Phase 3 aggregate snapshots (header "Sample: N")
- `champions_sim_log_v1` → Phase 4 per-series raw log (Record bar W-L / splits, added in v2.1.6)

Users who simmed before v2.1.6 accumulated Phase 3 data but no per-series log entries. The old aggregates can't be decomposed back into series-level W-L, so the Record bar correctly shows zero. The empty state previously just said "no games yet", which was confusing when the header simultaneously claimed "Sample: 700 games".

## Fix

- New helper `_csRecordEmptyStateKind()` returns `'legacy' | 'new' | 'has_log'`.
- When `total.n === 0`, Record bar appends a single hint line below the pill:
  - **legacy:** "Previous sim data was recorded before per-series tracking (added in v2.1.6). Run a fresh sim to start your record."
  - **new:** "Run a sim to start tracking your W-L by matchup."
- Matching `.cs-record-empty-hint` styles (muted italic, 12px, 11px on mobile).
- Version chip → `v2.1.8-emptystate.1`, CACHE_NAME → `champions-sim-v5-emptystate1`.

No data migration. No synthesized entries. Hint only renders when the Record bar would otherwise be empty, so zero visual impact on users with real per-series data.

## Validation

Headless Playwright across three scenarios (all zero page errors):

| Scenario | emptyKind | Total | Legacy hint | New hint | Record score |
|---|---|---|---|---|---|
| Truly new install | `new` | 0-0 | ❌ | ✅ | ❌ |
| Legacy aggregate only | `legacy` | 0-0 | ✅ | ❌ | ❌ |
| Phase 4 sim log seeded | `has_log` | 1-0 | ❌ | ❌ | ✅ |

Plus `node --check` on `ui.js`, `engine.js`, `data.js`.

Refs #53, #55
