### PR TITLE
infra: add bundle-freshness tools (build-bundle.py, check-bundle.sh, tools/README.md) + MASTER_PROMPT update - Refs #88

### DIFF
--- a/poke-sim/MASTER_PROMPT.md
+++ b/poke-sim/MASTER_PROMPT.md
@@ -76,6 +76,10 @@ Pokemon-Champions-Sim-Planner/
 │   ├── ISSUE_TEMPLATE/
 │   └── pull_request_template.md
 ├── poke-sim/
+│   ├── tools/
+│   │   ├── build-bundle.py             ← #88: extracted rebuild script, shared by CI + humans
+│   │   ├── check-bundle.sh             ← #88: fails if bundle drifts from source files
+│   │   └── README.md                   ← #88: explains all tools + drift fix instructions
 │   ├── poke-sim/                       ← nested dev workspace (source of truth)
 │   │   ├── index.html                  ← App shell + tab structure + PWA meta
 │   │   ├── style.css                   ← Full dark theme, mobile-first
@@ -94,7 +98,7 @@ Pokemon-Champions-Sim-Planner/
 │   │   │                                  bring-picker slot layout + drag/tap (T9j.10)
 │   │   ├── strategy-injectable.js      ← TEAM_META knowledge base
 │   │   ├── manifest.json               ← PWA manifest
-│   │   ├── sw.js                       ← Service worker (cache-first) — CACHE_NAME: see SW CACHE HISTORY table
+│   │   ├── sw.js                       ← Service worker (cache-first) -- CACHE_NAME: see SW CACHE HISTORY table
 │   │   ├── icon-192.png                ← PWA icon
 │   │   ├── icon-512.png                ← PWA icon
 │   │   ├── pokemon-champion-2026.html  ← Self-contained single-file bundle (~685 KB)
@@ -118,7 +122,7 @@ Pokemon-Champions-Sim-Planner/
 │   ├── SPREAD_DAMAGE_SPEC.md           ← Doubles spread damage spec
 │   ├── BATTLE_DAMAGE_DOCUMENT.md       ← Damage formula reference
 │   ├── GITHUB_ISSUES_TO_FILE.md        ← Backlog log
-│   ├── MASTER_PROMPT.md                ← stale root copy (tech debt — see note below)
+│   ├── MASTER_PROMPT.md                ← stale root copy (tech debt -- see note below)
 │   └── README.md                       ← Quickstart guide
 ```
 
@@ -309,10 +313,9 @@ This is a known architectural limitation — do not "fix" it without restructuri
 
 The bundle (`pokemon-champion-2026.html`) is the rebuilt artifact — generated from the source files (`index.html`, `style.css`, `data.js`, `engine.js`, `ui.js`, `strategy-injectable.js`). It is **not** edited directly.
 
-**Rebuild procedure:**
+**Rebuild procedure (from `poke-sim/` directory):**
 ```bash
-cd poke-sim
-python3 build.py   # or: python3 ../t5_apply.py
+cd poke-sim && python3 tools/build-bundle.py
 ```
 The rebuild script inlines all source files into the single-file bundle. After any source file edit, the bundle must be rebuilt and committed together with the source changes.
 
@@ -380,7 +383,7 @@ Any PR that modifies one or more of:
      ```
 5. Rebuild the bundle if any source file changed:
      ```bash
-     cd poke-sim && python3 build.py
+     cd poke-sim && python3 tools/build-bundle.py
      ```
 6. Update MASTER_PROMPT.md to reflect your change
 7. Open PR — the CI check will verify step 2 was done
@@ -553,6 +556,6 @@ Dropdown: **10 / 50 / 100 / 500** (50 default). 500 is the hard ceiling — do n
 - M6 Polish & Launch (v2.0) — pending M1-M5 and M7-M10 close
 - M7 Architecture & Modularity (v2.1) — #77-#80
 - M8 Profile & Sync (v2.2) — #81-#86 (headline ask)
-- M9 Observability & QA (v2.3) — #87-#91 | **#95 ALL 3 PHASES DONE**
+- M9 Observability & QA (v2.3) — #87-#91 | **#95 ALL 3 PHASES DONE** | **#88 DONE**
 - M10 Performance & Quality (v2.4) — #92-#96
 - M11 Advanced Features (v2.5) — #97-#99 plus deferred #7 Tera

--- a/poke-sim/tools/README.md
+++ b/poke-sim/tools/README.md
@@ -1,0 +1,59 @@
+# poke-sim/tools
+
+Build and validation scripts for the Champions Sim project.
+
+---
+
+## Scripts
+
+### `build-bundle.py`
+Assembles the single-file bundle `poke-sim/pokemon-champion-2026.html` from the five source files:
+- `poke-sim/index.html`
+- `poke-sim/style.css`
+- `poke-sim/data.js`
+- `poke-sim/engine.js`
+- `poke-sim/ui.js`
+
+**Run from the `poke-sim/` directory:**
+```bash
+cd poke-sim && python3 tools/build-bundle.py
+```
+
+**Options:**
+- `--to-stdout` -- prints bundle to stdout instead of writing to disk (used internally by `check-bundle.sh`)
+
+---
+
+### `check-bundle.sh`
+Verifies that the committed bundle matches what the build script would produce.
+Returns exit code `0` if fresh, `1` if drift is detected.
+
+**Run from repo root:**
+```bash
+bash poke-sim/tools/check-bundle.sh
+```
+
+Called automatically by CI on every PR (wired in `.github/workflows/ci.yml`, issue #87).
+
+---
+
+## Fixing a Bundle Drift Failure
+
+If CI fails with `Bundle drift detected`, it means source files were changed but the bundle was not rebuilt. Fix:
+
+```bash
+# 1. Rebuild the bundle
+cd poke-sim && python3 tools/build-bundle.py
+
+# 2. Commit the updated bundle
+git add poke-sim/pokemon-champion-2026.html
+git commit -m "chore: rebuild bundle after source changes"
+
+# 3. Push
+git push
+```
+
+---
+
+### `release.sh`
+Auto-bumps `sw.js` CACHE_NAME on release. See [MASTER_PROMPT.md > RELEASE PROCEDURE](../MASTER_PROMPT.md) for full steps.

--- a/poke-sim/tools/build-bundle.py
+++ b/poke-sim/tools/build-bundle.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+"""
+build-bundle.py  --  Champions Sim bundle builder
+Extracted from MASTER_PROMPT rebuild command so CI and humans use the same code path.
+
+Usage:
+  python3 tools/build-bundle.py               # writes pokemon-champion-2026.html
+  python3 tools/build-bundle.py --to-stdout   # prints bundle to stdout (used by check-bundle.sh)
+"""
+import re, os, sys
+
+# Resolve BASE to the poke-sim/ directory (parent of tools/)
+BASE = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+
+def read(path):
+    with open(os.path.join(BASE, path), 'r') as f:
+        return f.read()
+
+html   = read('index.html')
+css    = read('style.css')
+data   = read('data.js')
+engine = read('engine.js')
+ui     = read('ui.js')
+
+html = html.replace('<script src="data.js"></script>', '')
+html = html.replace('<script src="engine.js"></script>', '')
+html = html.replace('<script src="ui.js"></script>', '')
+html = html.replace('<link rel="stylesheet" href="style.css"/>', '')
+html = re.sub(r'<script>\nif \(.serviceWorker.\).*?</script>', '', html, flags=re.DOTALL)
+html = html.replace('<link rel="manifest" href="manifest.json"/>', '')
+html = html.replace('<link rel="apple-touch-icon" href="icon-192.png"/>', '')
+html = html.replace('</head>', '<style>\n' + css + '\n</style>\n</head>')
+html = html.replace('</body>', '<script>\n' + data + '\n\n' + engine + '\n\n' + ui + '\n</script>\n</body>')
+
+if '--to-stdout' in sys.argv:
+    sys.stdout.write(html)
+else:
+    out = os.path.join(BASE, 'pokemon-champion-2026.html')
+    with open(out, 'w') as f:
+        f.write(html)
+    print(f'Bundle: {os.path.getsize(out):,} bytes -> {out}')

--- a/poke-sim/tools/check-bundle.sh
+++ b/poke-sim/tools/check-bundle.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+# check-bundle.sh -- Fail if the committed bundle is out of sync with source files.
+# Called by CI (.github/workflows/ci.yml, issue #87).
+# Run manually: bash poke-sim/tools/check-bundle.sh (from repo root)
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+BUNDLE="$REPO_ROOT/poke-sim/pokemon-champion-2026.html"
+
+if [ ! -f "$BUNDLE" ]; then
+  echo "::error::Bundle not found at poke-sim/pokemon-champion-2026.html"
+  exit 1
+fi
+
+EXPECTED=$(python3 "$REPO_ROOT/poke-sim/tools/build-bundle.py" --to-stdout | sha256sum | cut -d' ' -f1)
+ACTUAL=$(sha256sum "$BUNDLE" | cut -d' ' -f1)
+
+if [ "$EXPECTED" != "$ACTUAL" ]; then
+  echo ""
+  echo "Bundle drift detected."
+  echo "    poke-sim/pokemon-champion-2026.html does not match what the build script produces."
+  echo ""
+  echo "    Fix: run the following from the repo root, then commit pokemon-champion-2026.html:"
+  echo "      cd poke-sim && python3 tools/build-bundle.py"
+  echo ""
+  echo "    See poke-sim/tools/README.md for full rebuild instructions."
+  echo "    See MASTER_PROMPT.md > RELEASE PROCEDURE for context."
+  exit 1
+fi
+
+echo "Bundle is fresh -- pokemon-champion-2026.html matches source files."


### PR DESCRIPTION
## Summary

Extracts the rebuild command from `MASTER_PROMPT` into proper tooling and adds a CI-callable bundle drift checker.

## Linked Issues

Refs #88

## Type of Change

- [x] Test / tooling
- [x] Documentation

## Files Touched

- [x] New: `poke-sim/tools/build-bundle.py` — extracted rebuild script, shared by CI + humans
- [x] New: `poke-sim/tools/check-bundle.sh` — exits 1 if bundle drifts from source files
- [x] New: `poke-sim/tools/README.md` — explains all tools + drift fix instructions
- [x] `poke-sim/MASTER_PROMPT.md` — add `tools/` to repo layout, mark #88 DONE in MILESTONES

## Risk Assessment

| Check | Status | Notes |
|-------|--------|-------|
| Touches `engine.js` / `data.js` / `ui.js`? | NO | No bundle rebuild needed |
| Touches `sw.js`? | NO | Cache bump not required |
| Breaks `var COVERAGE_CHECKS`? | NO | No JS files touched |
| Will 404 or break live URL? | NO | New `tools/` directory only |
| ASCII-hyphen commit messages? | YES | No em-dashes |
| Refs #N in commit message? | YES | Refs #88 |
| MASTER_PROMPT.md updated? | YES | Canonical inner copy updated |

## Test Evidence

To verify locally after merge:
```bash
# From repo root
cd poke-sim && python3 tools/build-bundle.py
# Expected: Bundle: <N> bytes -> .../pokemon-champion-2026.html

bash poke-sim/tools/check-bundle.sh
# Expected: Bundle is fresh -- pokemon-champion-2026.html matches source files.
```

## Breaking / Behavior Changes

None — no app source files changed.

## Checklist

- [x] No em-dashes in commit messages
- [x] New globals referenced during init use `var` (TDZ-safe) — N/A (no JS changes)
- [x] Updated `MASTER_PROMPT.md` to reflect this change
- [x] No `engine.js`, `data.js`, `ui.js`, `style.css` changes — no bundle rebuild or `sw.js` bump needed
