### PR TITLE
docs: capture top-1%-sim validation + Phase 5/6 north star

### DIFF
--- a/poke-sim/COACHING_NORTH_STAR.md
+++ b/poke-sim/COACHING_NORTH_STAR.md
@@ -1,0 +1,258 @@
+# Coaching North Star
+
+> **Standing brief.** Every coaching-layer PR (Phase 4+) is checked against this document. If a PR moves the engine measurably closer to the criteria in Section "Acceptance Criteria" below, ship it. If not, push back. This file is updated when the bar moves, never to lower it.
+
+**Owner:** Alfredo Cox (`@alfredocox`)
+**Established:** 2026-04-25 (this conversation)
+**Related specs:**
+- `PHASE4_DYNAMIC_ADVICE_SPEC.md` (state machine + threat response + policy audit)
+- `PHASE5_TURN_LOG_SPEC_DRAFT.md` (structured turn log + position score + win-prob delta)
+- `MASTER_PROMPT.md` (rollout table)
+
+---
+
+## 1. The bar (verbatim, user direction)
+
+> You are building an elite Pokemon Champions ranked competitive battle simulation and coaching engine.
+>
+> Your purpose is not just to simulate battles or calculate damage. Your purpose is to discover truth:
+> - Why games are won
+> - Why games are lost
+> - What decisions actually matter
+> - What habits make players lose
+> - What changes will make them win consistently
+>
+> This system must function as a world-class competitive Pokemon coach, analyst, and simulator combined.
+
+The full original spec is preserved in `Section 9 - Original Spec` at the end of this file. The sections below summarize each demand, classify the gap against current implementation, and tie each to a concrete rollout phase.
+
+---
+
+## 2. Honest classification of demand vs. reality (validated 2026-04-25)
+
+Grounded against `engine.js` (`simulateBattle()` line 1087, `selectMove()` line 1230, return shape line 2196) and `ui.js` (`runBoSeries` line 1858, sim-log writer line 1907). Not a wishlist - this is an inventory.
+
+| # | Spec demand | Today's reality | Gap kind | Lands in |
+|---|---|---|---|---|
+| 1 | Core objective: discover truth, not raw data | Aspiration, not testable until 2-7 ship | Direction | All phases |
+| 2 | Play-by-play turn log: HP%, status, field, speed order, position score, win prob delta, "why position changed" | `log: string[]` unstructured. Has `koEvents`, `movesUsed`, `protectStreakMax` only | **Engine refactor** | Phase 5 |
+| 3 | Simulate all viable lines: safe, aggressive, counter, pivot, protect, double-target, speed-denial, setup-denial | One greedy line per `simulateBattle`. No branching, no lookahead, no line enumeration | **Engine work** (bounded version) | Phase 4d (4 branches x 200 sims), Phase 5 (full tree) |
+| 4 | Line classification: strong / stable / playable / volatile / fake-good / losing / catastrophic | No lines exist to classify | Blocked by 3 | Phase 4d (4 buckets), Phase 5 (7 buckets) |
+| 5 | Bad / fake-good plays + failed trades + missed win conditions | Detectable only with structured turn log + line tree | Blocked by 2, 3 | Phase 4e (rule-mining over sim log), Phase 5 (fake-good detector) |
+| 6 | Pattern detection across games (frequency, severity, correction) | `team_history.dead_moves` and `common_loss_conditions` are stubbed, not populated | **Plumbing** | Phase 4c |
+| 7 | Win condition engine: predicted primary/secondary win + loss conditions per matchup | Only end-of-game `winCondition` string. No predictive layer | **New analysis layer** | Phase 4d (post-hoc), Phase 5 (predictive) |
+| 8 | Matchup intel: best lead (3 max), worst lead, opp likely leads, T1-T3 plan, midgame, endgame | Theory-only today; lead recommendations are static heuristics | **New analysis layer** | Phase 4c (lead perf table), Phase 4d (T1-T3 plan from line tree) |
+| 9 | Team structure: archetype, speed control, damage profile, role per mon, dead moves, missing coverage, structural weaknesses | TEAM_META covers archetype + roles. Dead-move detector pending | Mostly **plumbing** | Phase 4c |
+| 10 | Post-match analysis: turning point turn, root cause, visible mistake, hidden mistake, best alt, exec vs build | None today. Inline pilot card is end-of-series verdict only | Blocked by 2 | Phase 4e (rough), Phase 5 (full turning-point) |
+| 11 | Coaching philosophy: brutally honest, evidence-backed, no RNG excuse, decision-focused | Tone is neutral / generic. No style guide | **Editorial + guardrails** | Phase 6 |
+| 12 | Output structure per match: PRE / IN / POST with specific fields | Pilot Guide + Strategy tab cover ~30% of layout | **Plumbing** | Phase 6 (templates) |
+| 13 | Final objective: expose habits, teach decisions, improve consistency | Aspiration | Direction | All phases |
+
+**Summary:**
+- ~15% already done (1, 6 partial, 9 partial)
+- ~25% is plumbing on existing data (rest of 6, 8 light, 9, 10 light, 12)
+- ~60% requires `engine.js` changes (2, 3, 4, 5, 7 predictive, 10 full, 11 voice layer)
+
+---
+
+## 3. Acceptance criteria (the bar a PR must clear to claim "top 1% sim")
+
+A PR or phase claims it advanced the system toward the north star **only if** it makes at least one of these demonstrably true via headless test or fixture:
+
+1. The system records *what changed* in board state turn-over-turn, not just *what was logged*.
+2. The system can articulate **why** a game was won or lost in terms of one specific turn or sequence.
+3. The system can identify a play as fake-good (short-term win, long-term loss probability drop) with a numeric delta.
+4. The system can detect a **repeated** failure pattern across N games and tie it to a behavior, not a Pokemon.
+5. The system surfaces coaching that cites the data behind it (sample size + observed frequency + counterfactual).
+6. After 100 sims with distinct loss patterns, the advice surface is measurably different from the advice after 10 sims. (Hard invariant from `MASTER_PROMPT.md`.)
+
+A PR that only adds detectors or only renames things without moving any of the six bars above is plumbing - fine to merge, but does not count as advancing the north star.
+
+---
+
+## 4. Validated rollout (decisions locked 2026-04-25)
+
+| Phase | Spec coverage | Effort | Status |
+|-------|---------------|--------|--------|
+| 4c | 6, 8 light, 9 (dead moves + lead perf + loss conditions + confidence) | Days, no engine changes | Next |
+| 4d | 3 bounded (4 branches), 4 (4-bucket), 7 post-hoc, 8 T1-T3 plan | 200 sims/branch x 4 branches/matchup. ~1-2 min Run All. | Scoped |
+| 4e | 5, 6, 10 rough, hard invariant 6 | Rule-mining over sim log + regression test | Scoped |
+| **5** | **2, 4 full, 5 fake-good, 7 predictive, 10 full** | **Engine refactor: `log: string[]` -> `turnLog: Turn[]`. positionScore() heuristic. winProbabilityDelta micro-rollouts.** | **Drafted in PHASE5_TURN_LOG_SPEC_DRAFT.md** |
+| **6** | **11, 12** | **Style guide + output templates + RNG-blame guardrail. Optional fine-tuned prompt for inline pilot card.** | **Spec doc TBD after Phase 5 lands** |
+
+---
+
+## 5. Decisions locked
+
+These are not up for re-debate without a written ADR overriding them.
+
+1. **Staged, not parallel.** Phase 4c -> 4d -> 4e -> 5 -> 6. No long-lived parallel branches that fight at merge time. (User direction 2026-04-25.)
+2. **Phase 4d sim budget:** 200 sims/branch x 4 branches/matchup. Run All bumps to ~1-2 min on average hardware. The full ~5000 sim/matchup tree is opt-in "Deep Coach" only, deferred to Phase 5+.
+3. **Coaching voice:** direct + grounded + evidence-backed. RNG blame is gated on `consistency_score.rng_dependency > 0.6`. We cite the data when criticizing. We do not soften when the signal is strong; we do not sharpen when sample size is below the State 3 threshold (15).
+4. **No data fabrication across storage keys.** Phase 3 aggregate snapshots will never be synthesized into Phase 4 sim-log entries. Empty-state guidance only. (`MASTER_PROMPT.md` invariant.)
+5. **No draws surfaced.** Pokemon has no draws (per user). Draws may be stored in raw log but never render as W-L-D triple.
+6. **"Same advice after 100 battles = failing."** Phase 4e MUST ship a regression test that proves advice diverges between a 10-series and 100-series log with distinct loss patterns. Blocks Phase 4 closeout.
+
+---
+
+## 6. What this is NOT
+
+- Not a promise to ship every spec section. Some (full §3 line enumeration at full depth) require compute we are explicitly deferring.
+- Not a tone permission slip. Brutal != hostile. Brutal here means specific, evidence-backed, and unwilling to blame variance unless variance is in fact the issue.
+- Not a static document. When the bar moves, edit this file in the same PR that moves it. Never lower the bar without a written ADR.
+
+---
+
+## 7. Cross-references
+
+- Engine entry: `engine.js` `simulateBattle()` line ~1087, return shape line ~2196
+- AI selector: `engine.js` `selectMove()` line ~1230 (single-shot greedy, the source of "no line enumeration" today)
+- Sim log writer: `ui.js` `runBoSeries()` line ~1858, sim-log append line ~1907
+- Adaptive state machine: `ui.js` `computeTeamHistory()` line ~5704
+- Sim log shape: `MASTER_PROMPT.md` section "PHASE 4 - ADAPTIVE COACHING"
+- Storage keys: `MASTER_PROMPT.md` section "Storage keys in use"
+
+---
+
+## 8. How to use this doc in PRs
+
+Every coaching-layer PR description must answer:
+
+1. Which numbered demand from Section 2 does this advance?
+2. Which acceptance criterion in Section 3 does it move? (One of the six.)
+3. If none of the above - is this plumbing or refactor? Say so explicitly.
+4. What is the headless test that proves it?
+
+If a PR cannot answer 1, 2, and 4, it does not get the "north-star" label. It can still merge as plumbing.
+
+---
+
+## 9. Original spec (preserved verbatim)
+
+The full text of the standard the user set on 2026-04-25:
+
+> You are building an elite Pokemon Champions ranked competitive battle simulation and coaching engine.
+>
+> Your purpose is not just to simulate battles or calculate damage. Your purpose is to discover truth:
+> - Why games are won
+> - Why games are lost
+> - What decisions actually matter
+> - What habits make players lose
+> - What changes will make them win consistently
+>
+> This system must function as a world-class competitive Pokemon coach, analyst, and simulator combined.
+>
+> SECTION 1 - CORE OBJECTIVE
+> The engine must:
+> 1. Simulate battles across all viable decision paths
+> 2. Record detailed play-by-play data
+> 3. Identify winning lines and losing lines
+> 4. Detect fake-good plays (short-term success, long-term failure)
+> 5. Detect bad plays that consistently lead to losses
+> 6. Identify player mistake patterns across games
+> 7. Evaluate team structure and matchup viability
+> 8. Provide brutally honest coaching feedback
+> 9. Improve player decision-making, not just knowledge
+> The system must prioritize decision clarity, not raw data.
+>
+> SECTION 2 - PLAY-BY-PLAY DATA COLLECTION
+> For every simulated battle, record each turn with full state tracking:
+> - Turn number
+> - Active Pokemon (both sides)
+> - Remaining Pokemon (both sides)
+> - HP percentages
+> - Status conditions
+> - Field effects (weather, terrain)
+> - Speed control states (Tailwind, Trick Room, etc.)
+> - Remaining turns of field effects
+> - Protect usage history
+> - Revealed moves
+> - Revealed items
+> - Speed order
+> - Legal move options
+> - Player action chosen
+> - Opponent action chosen
+> - Damage dealt (including spread modifiers)
+> - KO events
+> - Switch events
+> - Status changes
+> - Board state before action
+> - Board state after action
+> - Position score (before and after)
+> - Win probability (before and after)
+> - Explanation of why the position improved or worsened
+> The system must identify:
+> - The exact turn where the match became winning or losing
+> - The cause of that shift
+>
+> SECTION 3 - SIMULATION REQUIREMENTS
+> The engine must simulate:
+> - All legal lead combinations
+> - All likely opponent lead combinations
+> - Safe lines (low risk)
+> - Aggressive lines (high pressure)
+> - Counter lines (anti-meta or anti-lead)
+> - High-risk / high-reward lines
+> - Defensive pivot lines
+> - Protect-based lines
+> - Double-target lines
+> - Speed control denial lines
+> - Setup denial lines
+> - Endgame preservation lines
+> Simulations must cover:
+> - First-turn decisions
+> - Multi-turn sequences (minimum 2-4 turns deep)
+> - Endgame scenarios
+> - Weather control interactions
+> - Trick Room interactions
+> - Speed control dynamics
+> Each simulated path must be classified.
+>
+> SECTION 4 - LINE CLASSIFICATION
+> Every simulated line must be labeled as one of:
+> - Strong winning line
+> - Stable winning line
+> - Playable line
+> - Volatile line
+> - Fake-good line
+> - Losing line
+> - Catastrophic line
+> Definitions:
+> Fake-good line: A line that appears successful short-term but reduces long-term win probability. Examples: getting a KO while allowing Tailwind or Trick Room; dealing damage but losing position or win condition; protecting safely while allowing opponent setup; removing the wrong Pokemon target.
+> Catastrophic line: A line that immediately leads to a losing position unless opponent misplays heavily.
+>
+> SECTION 5 - BAD PLAY AND MISTAKE DATASETS
+> The system must explicitly collect and store:
+> A. Bad plays - Actions that consistently lead to losses (with explanation + better alternative)
+> B. Fake-good plays - Plays that feel correct but lead to losing game states
+> C. Failed trades - Favorable short-term exchanges that lose long-term structure
+> D. Missed win conditions - Failure to preserve or enable the correct win path
+> E. Lead failures - Leads that consistently result in losing Turn 1 or early disadvantage
+>
+> SECTION 6 - PATTERN DETECTION
+> Across simulations and matches, identify repeated player failure patterns:
+> Examples: overcommitting Turn 1, ignoring speed control threats, allowing Trick Room without contest, chasing damage instead of position, misusing Protect (too early, too often, or wasted), targeting incorrect threats, failing to preserve win-condition Pokemon, switching too late or not at all, overvaluing super-effective damage, undervaluing positioning tools.
+> Each pattern must include: frequency, impact severity, description, coaching correction rule.
+>
+> SECTION 7 - WIN CONDITION ENGINE
+> For every matchup determine: primary win condition, secondary win condition, required setup conditions, required Pokemon preservation, required board state conditions. Also: primary loss condition, critical failure triggers (e.g., Trick Room, Tailwind, status landing). Engine must clearly state "What must happen for you to win" and "What must not happen for you to lose".
+>
+> SECTION 8 - MATCHUP INTELLIGENCE
+> For each matchup: estimate win probability; identify best lead (max 3 - safe / aggressive / counter); worst lead; opponent's most likely lead patterns; early-game plan (Turns 1-3); midgame transition; endgame win path.
+>
+> SECTION 9 - TEAM STRUCTURE ANALYSIS
+> For each team: archetype, speed control tools, damage profile, defensive core + resist coverage, pivot tools, role per Pokemon (lead / sweeper / support / pivot / disruptor / win condition / sacrifice piece). Flag dead moves, low-value items, redundant roles, missing coverage, structural weaknesses vs common archetypes.
+>
+> SECTION 10 - POST-MATCH ANALYSIS
+> For every match: result, key turning point (specific turn), root cause of outcome, visible mistake, hidden strategic mistake, best alternative decision, whether issue was execution or team-building. Plus: most common losing line in that matchup, one team-building recommendation, one behavior change recommendation.
+>
+> SECTION 11 - COACHING PHILOSOPHY
+> Brutally honest. Avoid generic advice. Avoid unnecessary praise. Avoid blaming RNG unless it is the dominant factor. Focus on decision-making errors and strategic misunderstandings. Explain what the player failed to understand. Tone: a top competitive player reviewing your game and telling you exactly why you lost and how to fix it.
+>
+> SECTION 12 - OUTPUT STRUCTURE PER MATCH
+> PRE-MATCH: matchup win probability, best lead options (3 max), worst lead, primary win condition, primary loss condition, Turn 1 plan.
+> IN-MATCH (per turn): threat assessment (what KOs what), speed order clarity, position score, decision categories (Safe / Pressure / Greedy).
+> POST-MATCH: root cause of loss/win, 3-5 key mistakes, 1 structural team flaw, 1 behavioral improvement.
+>
+> SECTION 13 - FINAL OBJECTIVE
+> The system must expose bad habits, reveal hidden mistakes, teach decision-making under pressure, improve consistency across matchups, turn players into high-level competitive thinkers. If the system only reports data, it has failed. If the system teaches players what they did wrong, why it was wrong, and how to fix it, it has succeeded. The system should ultimately feel like a world-class competitive Pokemon coach analyzing every possible outcome and telling the player the hard truth about what actually wins games.

--- a/poke-sim/MASTER_PROMPT.md
+++ b/poke-sim/MASTER_PROMPT.md
@@ -113,8 +113,12 @@ Pokemon-Champions-Sim-Planner/
 │   │   │    ├── t9j10_tests.js         ← ~16 cases (Team Preview bring-N-of-6)
 │   │   │    └── audit.js               ← 5070-battle regression sweep
 │   │   ├── COACHING_LAYER_SPEC.md      ← Phase 1-3 coaching spec (Sections 1-14)
-│   │   └── PHASE4_DYNAMIC_ADVICE_SPEC.md ← Phase 4 adaptive coaching spec v2
-│   │                                      (state machine + threat response + policy audit)
+│   │   ├── PHASE4_DYNAMIC_ADVICE_SPEC.md ← Phase 4 adaptive coaching spec v2
+│   │   │                                  (state machine + threat response + policy audit)
+│   │   ├── COACHING_NORTH_STAR.md      ← Standing brief: top-1%-sim spec +
+│   │   │                                  validation matrix + acceptance criteria
+│   │   └── PHASE5_TURN_LOG_SPEC_DRAFT.md ← Phase 5 DRAFT: structured turnLog,
+│   │                                      positionScore, winProbabilityDelta
 │   ├── DEVELOPMENT_RUNBOOK.md          ← Full dev history, architecture, QA log
 │   ├── CHAMPIONS_MECHANICS_SPEC.md     ← Authoritative mechanics reference
 │   ├── CHAMPIONS_VALIDATOR_FRAMEWORK.md ← Validator framework doc (T9j.8)
@@ -430,9 +434,15 @@ Multi-phase rollout for the Strategy tab + coaching engine. Tracked in `poke-sim
 | 4b+ | Both-sides sim log mirroring (opponent-only teams populate Strategy view) | #120 / #95 | ✅ Merged |
 | 4b+ | Record bar legacy vs new empty-state guidance | #121 / #53 #55 | ✅ Merged |
 | 4c | Detectors — dead moves, lead performance, common loss conditions, confidence badges | pending / #53 #54 | Open |
-| 4d | Threat Response System with Monte Carlo solver (200 sims/branch) | pending / #54 | Open |
+| 4d | Threat Response System with Monte Carlo solver (200 sims/branch × 4 branches) | pending / #54 | Open |
 | 4e | Policy audit / player coaching + "same advice after 100 battles = failing" regression test | pending / #54 #55 | Open |
-| 5 | Source labels + Stress Test polish | pending | Open |
+| **5a** | **Structured `turnLog: Turn[]` capture in `simulateBattle` (engine refactor, backwards-compat `log: string[]` derived view)** | spec drafted / N§2 | **Drafted** |
+| **5b** | **`positionScore(state)` heuristic + `position_path` + `turning_point` + cause taxonomy** | spec drafted / N§4 N§10 | **Drafted** |
+| **5c** | **Opt-in `winProbabilityDelta` micro-rollouts + Deep Coach toggle** | spec drafted / N§5 N§7 | **Drafted** |
+| **6** | **Coaching voice + per-match output templates (PRE/IN/POST). RNG blame gated on `consistency_score.rng_dependency > 0.6`** | spec TBD post-Phase-5 / N§11 N§12 | **Open** |
+| 7 | Source labels + Stress Test polish | pending | Open |
+
+> N§X references = north-star spec section in `COACHING_NORTH_STAR.md` Section 2 (validation matrix). Phase 5 sub-phases drafted in `PHASE5_TURN_LOG_SPEC_DRAFT.md`. Phase 6 spec deferred until Phase 5 lands.
 
 **Storage keys in use:**
 - `champions_strategy_v1::<sig>` — legacy T9j.16 history (untouched, soft-migrated)
@@ -512,6 +522,23 @@ Dropdown: **10 / 50 / 100 / 500** (50 default). 500 is the hard ceiling — do n
 - **4c** — Detectors: dead moves, lead performance win rates, common loss conditions, confidence badges per recommendation (`low` / `med` / `high` based on sample_size).
 - **4d** — Threat Response System: Monte Carlo solver runs 200 sims per candidate response branch against each opposing threat, ranks by win delta.
 - **4e** — Policy audit / player coaching layer + regression test (invariant #2 above).
+
+### Phase 5 + 6 north-star coverage (validated 2026-04-25)
+
+User-supplied "top 1% sim" coaching spec validated against current `engine.js` (single-line greedy `selectMove` AI, unstructured `log: string[]`, no position score) and `ui.js` sim-log writer. Conclusion: ~15% already done, ~25% achievable as plumbing on Phase 4 data, ~60% requires `engine.js` changes — hence Phase 5.
+
+Full validation matrix, acceptance criteria, and original spec preserved verbatim in `COACHING_NORTH_STAR.md`. Every coaching-layer PR description must answer:
+1. Which numbered demand from N§2 does this advance?
+2. Which acceptance criterion (1–6) does it move?
+3. Plumbing or refactor? (Plumbing PRs do not need north-star coverage.)
+4. Headless test that proves it.
+
+**Decisions locked (do not re-debate without ADR):**
+- Stage Phase 4c → 4d → 4e → 5 → 6. No long-lived parallel branches.
+- Phase 4d budget: 200 sims/branch × 4 branches/matchup. Run All ~1–2 min on average HW.
+- Coaching voice: direct + grounded + evidence-backed. RNG blame gated on `consistency_score.rng_dependency > 0.6`.
+- `turnLog` is **memory-only**, never persisted to localStorage. Only summary fields (`turning_point`, `position_path`) get stored.
+- Phase 5 spec is **DRAFT**. Approval gate is *after Phase 4c lands* so we have evidence which detectors actually need turn-level data.
 
 ### Coaching ticket audit (post-PR #121 state)
 

--- a/poke-sim/PHASE5_TURN_LOG_SPEC_DRAFT.md
+++ b/poke-sim/PHASE5_TURN_LOG_SPEC_DRAFT.md
@@ -1,0 +1,321 @@
+# Phase 5 - Structured Turn Log + Position Score (DRAFT)
+
+> **Status: DRAFT.** Not approved for implementation. Draft created 2026-04-25 alongside `COACHING_NORTH_STAR.md`. Review and approval gate is **after Phase 4c lands** so we have evidence of which detectors actually need turn-level data versus those that can run on aggregates.
+
+**Phase parent:** Coaching layer rollout (`COACHING_LAYER_SPEC.md`, `PHASE4_DYNAMIC_ADVICE_SPEC.md`)
+**Coverage of `COACHING_NORTH_STAR.md`:** Sections 2 (full), 4 (full 7-bucket), 5 (fake-good), 7 (predictive), 10 (turning-point)
+**Owner:** TBD (to be assigned at approval)
+
+---
+
+## 1. Why Phase 5 exists
+
+Phase 4a-4e all read from `champions_sim_log_v1`, which stores **per-game aggregates** plus a few structured event arrays (`koEvents`, `movesUsed`, `protectStreakMax`). That is enough for:
+
+- Win/loss splits by archetype (PR #119)
+- Lead win-rate tables (Phase 4c)
+- Dead-move detection (Phase 4c)
+- Threat-response Monte Carlo on bounded branches (Phase 4d, 4 branches x 200 sims)
+
+It is **not** enough for:
+
+- "The match flipped on Turn 4 when X" - requires per-turn position score
+- "You got the KO but lost the game by allowing Tailwind" - requires fake-good detection across paired turns
+- "Predicted primary win condition: Trick Room up by Turn 3" - requires forward-looking position evaluator
+- Section 12 IN-MATCH per-turn output (threat assessment, position score, decision category) - has no data source today
+
+Phase 5 builds the foundation those features need. Without it, sections 2, 4 (full), 5 (fake-good), 7 (predictive), 10 (turning-point) of the north-star spec are not implementable - we would be inventing data.
+
+---
+
+## 2. Scope
+
+**In scope:**
+- Replace `simulateBattle()` `log: string[]` with `turnLog: Turn[]`, plus a `log: string[]` derived view for backward compatibility
+- New `Turn` shape capturing pre-state, action, post-state, deltas (Section 3 below)
+- `positionScore(state)` heuristic evaluator (Section 4)
+- `winProbabilityDelta` per turn via opt-in micro-rollouts (Section 5)
+- Test migration plan - no existing test should break (Section 7)
+- Storage: `turnLog` is **NOT** persisted to localStorage. Only summary fields (turning-point turn, position-score path) are persisted to keep within the existing 500-entry / oldest-first cap
+
+**Out of scope (deferred to Phase 5b/5c or Phase 6):**
+- Full 7-bucket line classification (depends on line tree, Phase 5b)
+- Coaching voice + output templates (Phase 6)
+- Replacing the greedy `selectMove` AI with a search-based one (separate engine RFC)
+- IndexedDB migration (deferred per `COACHING_LAYER_SPEC.md` Section 11)
+
+---
+
+## 3. Turn shape
+
+```js
+// One entry per game turn. Stored only in memory during simulateBattle, not in
+// the persisted sim log. Aggregates derived from turnLog (turning point,
+// position-score path) DO get persisted.
+//
+// Sides are 'player' and 'opponent' to match the existing log conventions.
+
+const Turn = {
+  turn: 1,                          // 1-indexed turn number
+
+  // ----- BEFORE actions resolve -----
+  pre: {
+    active:    { player: ['Incineroar','Arcanine'], opponent: ['Altaria','Kingdra'] },
+    bench:     { player: [...names], opponent: [...names] },
+    hp_pct:    { 'Incineroar': 1.0, 'Arcanine': 0.83, ... },     // 0..1 per mon by name
+    status:    { 'Arcanine': 'brn', ... },                        // missing key = no status
+    field: {
+      weather:        'sun' | 'rain' | 'sand' | 'snow' | null,
+      weather_turns:  3,                                           // 0 if absent
+      terrain:        'electric' | 'grassy' | 'misty' | 'psychic' | null,
+      terrain_turns:  0,
+      trick_room:     2,                                           // turns remaining, 0 if off
+    },
+    speed_control: {
+      player:   { tailwind_turns: 0, screens: { reflect: 2, light: 0, aurora: 0 } },
+      opponent: { tailwind_turns: 4, screens: { reflect: 0, light: 0, aurora: 0 } },
+    },
+    speed_order: ['Kingdra','Arcanine','Altaria','Incineroar'],   // computed final order
+    revealed: {
+      moves: { 'Altaria': ['Hyper Voice'], ... },                  // cumulative through this turn
+      items: { 'Kingdra': 'Choice Specs', ... },                   // null when unrevealed
+    },
+    legal_options: {
+      // For the PLAYER side only - what the engine considered legal this turn
+      // (used for fake-good detection: "you had X available, you chose Y")
+      'Incineroar': ['Fake Out -> Altaria', 'Knock Off -> Altaria', 'Flare Blitz -> Altaria', 'Protect'],
+      'Arcanine':   ['Extreme Speed -> Altaria', 'Flare Blitz -> Kingdra', 'Snarl', 'Protect'],
+    },
+    position_score: 0.62,                                          // 0..1, see Section 4
+    win_probability: 0.58,                                         // 0..1, see Section 5 (may be null if rollouts disabled)
+  },
+
+  // ----- ACTIONS chosen -----
+  actions: {
+    player:   [{ actor: 'Incineroar', kind: 'move', move: 'Fake Out', target: 'Altaria' },
+               { actor: 'Arcanine',   kind: 'move', move: 'Flare Blitz', target: 'Altaria' }],
+    opponent: [{ actor: 'Altaria',    kind: 'move', move: 'Hyper Voice', target: 'spread' },
+               { actor: 'Kingdra',    kind: 'move', move: 'Draco Meteor', target: 'Arcanine' }],
+    // Switches and Mega/Tera triggers also go here:
+    //   { actor, kind: 'switch', incoming: 'Whimsicott' }
+    //   { actor, kind: 'mega' } / { actor, kind: 'tera', tera_type: 'Fairy' }
+  },
+
+  // ----- DAMAGE + EVENTS resolved -----
+  events: [
+    { type: 'damage', source: 'Arcanine',   target: 'Altaria',  move: 'Flare Blitz',  dmg_pct: 0.91, crit: false, spread: false },
+    { type: 'damage', source: 'Altaria',    target: 'Arcanine', move: 'Hyper Voice',  dmg_pct: 0.18, crit: false, spread: true  },
+    { type: 'damage', source: 'Altaria',    target: 'Incineroar', move: 'Hyper Voice', dmg_pct: 0.16, crit: false, spread: true },
+    { type: 'damage', source: 'Kingdra',    target: 'Arcanine', move: 'Draco Meteor', dmg_pct: 0.74, crit: false, spread: false },
+    { type: 'flinch', source: 'Incineroar', target: 'Altaria',  move: 'Fake Out' },
+    { type: 'ko',     source: 'Arcanine',   target: 'Altaria' },                         // mirrors Phase 4a koEvents
+    { type: 'status', source: 'Altaria',    target: 'Arcanine', status: 'brn' },
+    { type: 'switch', side: 'opponent',     out: 'Altaria',     in: 'Salamence' },
+    { type: 'field',  effect: 'tailwind',   side: 'opponent',   action: 'expired' },
+  ],
+
+  // ----- AFTER actions resolve -----
+  post: {
+    // Same shape as `pre`, sampled after end-of-turn effects (poison, weather, screens decrement).
+    active:        { player: [...], opponent: [...] },
+    bench:         { player: [...], opponent: [...] },
+    hp_pct:        { ... },
+    status:        { ... },
+    field:         { ... },
+    speed_control: { ... },
+    speed_order:   [...],
+    revealed:      { ... },
+    position_score: 0.41,
+    win_probability: 0.34,                                         // null if rollouts disabled this turn
+  },
+
+  // ----- DERIVED (filled after the turn resolves) -----
+  delta: {
+    position_score: -0.21,
+    win_probability: -0.24,
+    primary_cause: 'tailwind_expired_unanswered',                  // see Section 4.4 cause taxonomy
+    explanation: 'Got the KO on Altaria but allowed Kingdra Specs Draco Meteor to remove Arcanine. Position swung opponent because remaining offense favors them.'
+  },
+};
+```
+
+A `simulateBattle()` result then exposes:
+
+```js
+{
+  // ... existing fields unchanged ...
+  log: string[],                  // backward compat: derived from turnLog formatters
+  turnLog: Turn[],                // NEW
+  turning_point: {                // NEW - cached summary from turnLog scan
+    turn: 4,                      // turn with largest |position_score delta|
+    direction: 'opponent',        // who it favored
+    cause: 'tailwind_expired_unanswered',
+  },
+  position_path: [0.55, 0.62, 0.58, 0.61, 0.41, 0.39, 0.20],  // length = turns + 1, includes pre-T1 baseline
+}
+```
+
+---
+
+## 4. Position score heuristic
+
+`positionScore(state) -> 0..1` where 1 = certain win, 0 = certain loss, 0.5 = even.
+
+Designed to be **fast** (called every turn pre + post = ~10 calls per game). Pure function of board state. No simulation inside.
+
+### 4.1 Formula (v1 draft)
+
+Weighted sum of normalized components, clamped to [0,1].
+
+| Component | Weight | Computation |
+|---|---|---|
+| `hp_diff_norm` | 0.30 | `(player_total_hp_pct - opp_total_hp_pct) / 2 + 0.5`. Considers only mons still in bring set. |
+| `survivors_diff_norm` | 0.20 | `(player_alive_count - opp_alive_count) / max_bring + 0.5` |
+| `speed_control_edge` | 0.15 | +0.5 if our Tailwind/TR favors us this turn relative to baseline speed gap, -0.5 if opponent's, scaled by turns remaining |
+| `screens_edge` | 0.05 | +0.05 per active screen on our side, -0.05 on theirs |
+| `status_edge` | 0.10 | -0.1 per debilitating status on our side (slp, par, brn-on-physical, frz, tox), +0.1 on theirs |
+| `field_threat_edge` | 0.10 | +0.1 if our field favors our archetype (sun for Fire team, TR for slow team), -0.1 if opp's. Reads team archetype from TEAM_META |
+| `win_condition_alive` | 0.10 | +0.05 if our win-condition mon (TEAM_META.win_condition) is alive and >50% HP, -0.05 mirror for opp |
+
+```
+score = 0.5
+      + 0.30 * (hp_diff_norm - 0.5)
+      + 0.20 * (survivors_diff_norm - 0.5)
+      + 0.15 * speed_control_edge
+      + 0.05 * screens_edge
+      + 0.10 * status_edge
+      + 0.10 * field_threat_edge
+      + 0.10 * win_condition_alive
+score = clamp(score, 0, 1)
+```
+
+### 4.2 Why this formula
+
+- It's directional and explainable. We can attribute a delta to its dominant component (Section 4.4 cause taxonomy).
+- It is not trying to predict win probability. That is the **rollout** job (Section 5). This is a fast proxy that lets us scan every turn.
+- It composes with PR #120's both-sides mirroring: `positionScore` is symmetric - call it from the opposite side and it returns `1 - x` within rounding.
+
+### 4.3 Calibration plan
+
+Before Phase 5 ships, run a 5,000-game calibration pass:
+1. Compute `positionScore` at every turn of every game.
+2. Bucket terminal outcomes by score bucket at turn 3 (10 buckets).
+3. Plot empirical win-rate per bucket.
+4. Score is **acceptable** if: monotonically increasing with score bucket, AND turn-3 score >= 0.7 has empirical WR >= 0.7, AND <= 0.3 has WR <= 0.3.
+5. If not, tune weights via grid search and re-validate.
+
+Calibration test goes in `tests/phase5_position_score_calibration.js` and is gated on a feature flag so it does not run on every CI build.
+
+### 4.4 Cause taxonomy (`delta.primary_cause`)
+
+Tag the dominant component of a turn's score swing:
+- `ko_in_our_favor` / `ko_in_opp_favor`
+- `tailwind_set` / `tailwind_expired_unanswered` / `trick_room_set` / `trick_room_expired`
+- `screen_set` / `screen_broken`
+- `status_landed_on_threat` / `status_landed_on_us`
+- `win_condition_lost` / `win_condition_secured`
+- `speed_tier_flipped`
+- `field_threat_changed`
+- `damage_only` (no qualitative shift, just chip)
+
+Used by the post-match coaching layer (Phase 6) to write the "why" sentence.
+
+---
+
+## 5. Win-probability via micro-rollouts
+
+`winProbabilityDelta(state) -> 0..1` is **opt-in** because it costs sims.
+
+### 5.1 When it runs
+
+- Disabled by default in Run All Matchups (cost-prohibitive).
+- Enabled when:
+  - `bo === 1` and user clicked "Deep Coach" toggle.
+  - OR: post-hoc on a single replay click ("explain this game").
+  - OR: nightly background job for top-3 most-simmed matchups.
+
+### 5.2 Method
+
+For each turn we want a true win probability:
+
+```
+runs = 50                                 # tunable, 50 is the budget per turn
+seed_strategy = derive from base seed     # so calibration is reproducible
+for i in 0..runs:
+  clone state
+  randomize remaining unrevealed information (opponent moves not yet seen,
+    crit flags, accuracy rolls within engine PRNG)
+  simulate forward to game end with current AI from this state
+  count win / loss / draw
+return wins / runs
+```
+
+`positionScore` (Section 4) is the heuristic we use **between** rollout-supported turns.
+
+### 5.3 Storage cost
+
+50 sims/turn x 7 turns avg x 1 game = 350 extra `simulateBattle` calls per game.
+At ~1ms/sim that's ~350ms - acceptable for opt-in single-game replay coaching, prohibitive for Run All.
+
+---
+
+## 6. Backwards compatibility
+
+### 6.1 `log: string[]`
+
+Existing UI grep code (`generatePilotGuide`, `Replay Log`) reads strings from `log`. We keep those readers working by deriving `log` from `turnLog`:
+
+```js
+function deriveLogFromTurnLog(turnLog) {
+  return turnLog.flatMap(t => [
+    `[Turn ${t.turn}] Player: ${t.actions.player.map(a => a.move).join(', ')}`,
+    `[Turn ${t.turn}] Opp:    ${t.actions.opponent.map(a => a.move).join(', ')}`,
+    ...t.events.filter(e => e.type === 'ko').map(e => `${e.target} fainted`),
+  ]);
+}
+```
+
+Old format strings the codebase grep'd for must still appear (search for `\bfainted\b`, `\bUI/PDF\b`, etc). Audit before merge.
+
+### 6.2 Sim log writer
+
+`csSimLogAppendSeries` continues to read the **summary** fields from a battle result. We add `turning_point` and `position_path` to the per-game payload but keep the existing fields. Storage cap stays at 500 entries / oldest-first eviction.
+
+`turnLog` itself is **never** persisted to localStorage. It is regenerated on demand by re-running the seeded sim if a deep replay is requested.
+
+### 6.3 Tests
+
+- `tests/audit.js` (5070-battle regression) must produce identical aggregate win rates +/- noise after refactor. Gate Phase 5 merge on this.
+- `tests/t9j8/9/10/...` test cases that grep `log` strings must still pass.
+- New `tests/phase5_*` files for turn-shape contract, position-score formula, calibration, micro-rollout determinism.
+
+---
+
+## 7. Rollout sub-phases
+
+| Sub-phase | Scope | Headless test | Flag |
+|---|---|---|---|
+| **5a** | Add `turnLog` capture in `simulateBattle` (no behavior change). Derive `log` from it. | All existing tests pass. Turn-shape contract test passes. | `CS_PHASE5_TURNLOG = true` |
+| **5b** | Add `positionScore()` + `position_path` + `turning_point` + cause taxonomy | Calibration pass at 5,000 games hits acceptance criteria in 4.3 | `CS_PHASE5_POSITION_SCORE = true` |
+| **5c** | Opt-in `winProbabilityDelta` micro-rollouts + Deep Coach button | 50-sim determinism test (same seed -> same WR within +/- 0.02) | `CS_PHASE5_DEEP_COACH = true` |
+
+Each sub-phase ships independently. Flag-gated so we can disable any sub-phase if calibration fails post-merge.
+
+---
+
+## 8. Open questions (locked before implementation)
+
+1. **`turnLog` size:** average game is ~10 turns, each Turn ~4KB. ~40KB per game in memory. 500-game sim log eviction means peak ~20MB transient. **Decision needed:** acceptable, or stream-and-discard?
+2. **Hidden information:** `pre.legal_options` is from the player's perspective. Do we record opponent's legal options too (for line tree analysis later)? **Default: no.** Add later if Phase 6 needs it.
+3. **Switch action accounting:** when both sides switch on the same turn, ordering matters for `pre`/`post` but not for events. Keep events list ordered by resolution time.
+4. **Mega/Tera turn:** the Mega trigger turn is already tracked in `engine.js`. Surface it as `actions[side].kind === 'mega'` so the coaching layer can ask "did you Mega the right turn?"
+
+---
+
+## 9. Cross-references
+
+- North star: `COACHING_NORTH_STAR.md` (Sections 2, 4 full, 5 fake-good, 7 predictive, 10 full)
+- Engine entry: `engine.js` `simulateBattle()` line ~1087, return shape line ~2196
+- AI selector (will not change in Phase 5): `engine.js` `selectMove()` line ~1230
+- Sim log: `MASTER_PROMPT.md` "PHASE 4 - ADAPTIVE COACHING" section
+- Existing per-game arrays we keep: `koEvents`, `movesUsed`, `protectStreakMax`


### PR DESCRIPTION
## What

Captures validation of the user's "top 1% sim" coaching spec and locks the next two phases (5, 6) onto the rollout table.

Docs only. No source files touched.

## Why

The user supplied a comprehensive spec ("elite Pokemon Champions ranked competitive battle simulation and coaching engine") describing per-turn position score, line enumeration with classification, fake-good play detection, turning-point analysis, and brutally honest coaching voice.

Honest validation against the codebase shows:
- ~15% already implemented (`koEvents`, `movesUsed`, `protectStreakMax`, archetype + role metadata)
- ~25% achievable as plumbing on existing Phase 4 sim-log data (Phase 4c/d/e)
- ~60% requires `engine.js` changes (structured turn log replacing `log: string[]`, position score heuristic, win-probability micro-rollouts, line enumeration)

The spec is the right north star but it is not a single PR. This docs PR formalizes that as a multi-phase initiative with a standing brief that future PRs are checked against.

## Changes

### `poke-sim/COACHING_NORTH_STAR.md` (new)

Standing brief. Preserves the user's spec verbatim, then maps each section to:
- Honest classification (already done / plumbing / engine work / aspirational)
- Phase that owns it
- Acceptance criteria a PR must clear to claim "advances the north star" (six concrete criteria)
- Decisions locked from this conversation

Used as a checklist for every future coaching-layer PR description.

### `poke-sim/PHASE5_TURN_LOG_SPEC_DRAFT.md` (new, DRAFT)

Engineering spec for Phase 5. Covers:
- `Turn` shape replacing `log: string[]` with full pre/action/event/post state per turn
- `positionScore(state)` heuristic formula with named components and a 5,000-game calibration plan with concrete acceptance bands
- Cause taxonomy for explaining position-score swings (TR set, TW expired, KO in our favor, etc.)
- Opt-in `winProbabilityDelta` via 50-sim micro-rollouts (Deep Coach toggle, single-game replay only)
- Backwards-compat plan: derive `log: string[]` from `turnLog` so existing UI and tests do not break
- Sub-phases 5a, 5b, 5c with feature flags so any sub-phase can be disabled if calibration fails post-merge
- Test migration plan (5,070-battle audit must produce identical aggregate WR after refactor)

DRAFT status. Approval gate is *after Phase 4c lands* so the actual data needs are validated first.

### `poke-sim/MASTER_PROMPT.md` (updated)

- Adds Phase 5a/5b/5c and Phase 6 rows to the rollout table
- Cross-links the two new docs in the repo layout tree
- Documents the validated decisions (stage approach, 200 sims/branch x 4 budget, voice gating)
- Adds the four-question requirement for every coaching-layer PR description
- Renumbers the old "source labels + Stress Test polish" to Phase 7

## Decisions locked (from validation Q&A)

1. **Staged, not parallel.** 4c -> 4d -> 4e -> 5 -> 6.
2. **Phase 4d sim budget:** 200 sims/branch x 4 branches per matchup. Run All ~1-2 min on average HW. Full ~5,000 sim/matchup tree deferred to opt-in "Deep Coach" only.
3. **Coaching voice:** direct + grounded + evidence-backed. RNG blame gated on `consistency_score.rng_dependency > 0.6`.
4. **`turnLog` is memory-only.** Never persisted to localStorage. Only summary fields (`turning_point`, `position_path`) get stored.

## What this PR does NOT do

- No engine changes. `simulateBattle` shape is unchanged.
- No new tests. Phase 5 implementation PRs will add `tests/phase5_*` files per the draft spec.
- Does not delete the stale outer `MASTER_PROMPT.md` at the repo root. That is a separate cleanup PR.

## Validation

- `node --check` not applicable (docs only)
- Markdown structure verified by reading the rendered preview locally
- All cross-references (`COACHING_NORTH_STAR.md` <-> `PHASE5_TURN_LOG_SPEC_DRAFT.md` <-> `MASTER_PROMPT.md`) resolve

Refs #52 #53 #54 #55
