### PR TITLE
docs: branch protection handoff for @TheYfactora12

### DIFF
--- a/docs/HANDOFF_2026-04-25.md
+++ b/docs/HANDOFF_2026-04-25.md
@@ -1,0 +1,111 @@
+# Handoff: Set Branch Protection on `main`
+
+**Date:** 2026-04-25
+**From:** Alfredo Cox (@alfredocox)
+**To:** Kevin Medeiros (@TheYfactora12)
+**Repo:** [alfredocox/Pokemon-Champions-Sim-Planner](https://github.com/alfredocox/Pokemon-Champions-Sim-Planner)
+**Estimated time:** 2 minutes
+
+---
+
+## Why this is needed
+
+Our automated agent is authenticated as `@TheYfactora12` (write access). Branch protection setup requires `admin` access on the repo, so the API call returns 404 from the agent's side. One admin (Alfredo) needs to apply protection once. After that, the agent can manage everything else under the protected branch via PRs + CI.
+
+This is a one-time setup. Once done, no further admin action is needed for normal development.
+
+---
+
+## What to do (pick ONE path)
+
+### Path A — GitHub UI (recommended, no terminal needed)
+
+1. Open: https://github.com/alfredocox/Pokemon-Champions-Sim-Planner/settings/branches
+2. Click **Add branch protection rule** (classic) OR **Add ruleset** (new style — either works).
+3. **Branch name pattern:** `main`
+4. Check / set the following exactly:
+   - [x] **Require a pull request before merging**
+     - Required approving reviews: **0**
+     - [ ] Dismiss stale pull request approvals when new commits are pushed (off)
+     - [ ] Require review from Code Owners (off)
+   - [x] **Require status checks to pass before merging**
+     - [x] Require branches to be up to date before merging
+     - **Required status checks** (search and add both):
+       - `Verify bundle is fresh`
+       - `Verify sw.js CACHE_NAME bumped`
+   - [ ] Require conversation resolution before merging (off)
+   - [ ] Require signed commits (off)
+   - [ ] Require linear history (off)
+   - [ ] Require deployments to succeed (off)
+   - [ ] Lock branch (off)
+   - [x] **Do not allow bypassing the above settings** (apply rules to admins)
+   - [ ] Allow force pushes (off)
+   - [ ] Allow deletions (off)
+5. Click **Create** (or **Save changes**).
+
+### Path B — One CLI command (if you have `gh` installed and authenticated as @alfredocox)
+
+```bash
+cat > /tmp/protection.json << 'EOF'
+{
+  "required_status_checks": {
+    "strict": true,
+    "contexts": ["Verify bundle is fresh", "Verify sw.js CACHE_NAME bumped"]
+  },
+  "enforce_admins": true,
+  "required_pull_request_reviews": {
+    "dismiss_stale_reviews": false,
+    "require_code_owner_reviews": false,
+    "required_approving_review_count": 0
+  },
+  "restrictions": null,
+  "allow_force_pushes": false,
+  "allow_deletions": false,
+  "required_conversation_resolution": false,
+  "lock_branch": false,
+  "allow_fork_syncing": true
+}
+EOF
+
+gh api -X PUT repos/alfredocox/Pokemon-Champions-Sim-Planner/branches/main/protection \
+  --input /tmp/protection.json
+```
+
+Expected output: a JSON blob describing the new protection rules (no error).
+
+---
+
+## Verification
+
+After applying, you can confirm it took effect by visiting:
+
+https://github.com/alfredocox/Pokemon-Champions-Sim-Planner/settings/branches
+
+You should see one rule listed for `main` with both required status checks visible.
+
+A failed direct push to `main` (without a PR) is the ultimate proof — but no need to test that manually; the agent will verify next session by attempting one and confirming it gets rejected.
+
+---
+
+## What this enforces (plain English)
+
+- No one (not even admins) can push directly to `main`. All changes must go through a PR.
+- PRs cannot be merged until **both** CI checks pass:
+  - Bundle Freshness Check (`pokemon-champion-2026.html` reflects current source)
+  - Cache Bump Check (`sw.js` CACHE_NAME advances when bundle changes)
+- No force pushes, no branch deletion.
+- No approval required (we're a small team, self-merge after CI green is fine).
+
+---
+
+## Once you're done
+
+Just reply / drop a note in the repo. Next agent session will:
+1. Verify protection is live via API.
+2. Resume Phase 4c implementation on `feat/phase-4c-detectors` per the already-approved 3-commit plan.
+
+Thanks Kevin.
+
+---
+
+*This handoff is part of the credibility ladder roadmap. See [`COACHING_NORTH_STAR.md` § 6](../poke-sim/COACHING_NORTH_STAR.md) for context.*


### PR DESCRIPTION
Single-page operational handoff so @TheYfactora12 can apply branch protection to `main`.

## Why
Agent token is authenticated as @TheYfactora12 (write access). Branch protection requires admin, so it's blocked from this side. One admin click from @alfredocox unblocks all future automation.

## What's in the file
- UI path (recommended)
- CLI alternative (gh api PUT)
- Exact rules: PR required, 0 approvals, both CI checks required, enforce on admins, no force-push, no deletion
- Verification + plain-English explanation

Docs only. No code or bundle changes.

Refs N/A