### PR TITLE
fix(ci): correct source file path pattern in both workflow checks

### DIFF
--- a/.github/workflows/bundle-freshness-check.yml
+++ b/.github/workflows/bundle-freshness-check.yml
@@ -28,7 +28,7 @@ jobs:
           echo "$CHANGED"
 
           APP_CHANGED=$(echo "$CHANGED" | grep -E \
-            'poke-sim/poke-sim/(engine|data|ui|style|strategy-injectable|index)\.(js|css|html)' \
+            'poke-sim/(engine|data|ui|style|strategy-injectable|index)\.(js|css|html)' \
             | grep -v 'pokemon-champion-2026\.html' || true)
 
           if [ -n "$APP_CHANGED" ]; then

--- a/.github/workflows/cache-bump-check.yml
+++ b/.github/workflows/cache-bump-check.yml
@@ -23,7 +23,7 @@ jobs:
           echo "$CHANGED"
 
           APP_CHANGED=$(echo "$CHANGED" | grep -E \
-            'poke-sim/poke-sim/(engine|data|ui|style|strategy-injectable)\.(js|css)' || true)
+            'poke-sim/(engine|data|ui|style|strategy-injectable)\.(js|css)' || true)
 
           if [ -n "$APP_CHANGED" ]; then
             echo "app_changed=true" >> $GITHUB_OUTPUT
@@ -38,11 +38,11 @@ jobs:
         if: steps.app_changed.outputs.app_changed == 'true'
         run: |
           CHANGED=$(git diff --name-only origin/main...HEAD)
-          SW_CHANGED=$(echo "$CHANGED" | grep 'poke-sim/poke-sim/sw.js' || true)
+          SW_CHANGED=$(echo "$CHANGED" | grep 'poke-sim/sw.js' || true)
 
           if [ -z "$SW_CHANGED" ]; then
             echo ""
-            echo "\u274c  App source files changed in this PR:"
+            echo "❌  App source files changed in this PR:"
             echo "${{ steps.app_changed.outputs.app_files }}"
             echo ""
             echo "    But poke-sim/sw.js was NOT updated."
@@ -56,9 +56,9 @@ jobs:
             exit 1
           fi
 
-          echo "\u2705  sw.js CACHE_NAME bumped \u2014 PWA cache is fresh. Good to merge."
+          echo "✅  sw.js CACHE_NAME bumped — PWA cache is fresh. Good to merge."
 
       - name: No app changes detected
         if: steps.app_changed.outputs.app_changed == 'false'
         run: |
-          echo "\u2705  No app source files changed \u2014 sw.js bump not required."
+          echo "✅  No app source files changed — sw.js bump not required."


### PR DESCRIPTION
## Summary

Both `bundle-freshness-check.yml` and `cache-bump-check.yml` were matching against `poke-sim/poke-sim/` but the actual source files live at `poke-sim/` (one level up). This caused both CI checks to **always skip enforcement** — passing trivially with "No app changes detected" instead of actually verifying the bundle and CACHE_NAME were updated.

Discovered when auditing PR #135 (`feat/wire-storage-adapter-ui`) — both checks showed green even though `poke-sim/ui.js` was modified and no bundle rebuild or CACHE_NAME bump had been committed.

## Root Cause

| Workflow | Was matching | Should match |
|---|---|---|
| `bundle-freshness-check.yml` | `poke-sim/poke-sim/(engine\|data\|ui\|...)` | `poke-sim/(engine\|data\|ui\|...)` |
| `cache-bump-check.yml` | `poke-sim/poke-sim/(engine\|data\|ui\|...)` | `poke-sim/(engine\|data\|ui\|...)` |
| `cache-bump-check.yml` (sw.js check) | `poke-sim/poke-sim/sw.js` | `poke-sim/sw.js` |

## Files Changed

- `.github/workflows/bundle-freshness-check.yml` — path pattern corrected
- `.github/workflows/cache-bump-check.yml` — path pattern + sw.js path corrected

## Type of Change

- [ ] Bug fix (engine, data, or UI)
- [ ] Mechanic correction
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [x] Test / tooling

## Impact

After this merges, PRs that touch `poke-sim/ui.js`, `poke-sim/engine.js`, `poke-sim/data.js`, `poke-sim/style.css`, or `poke-sim/strategy-injectable.js` will **correctly fail** if the bundle or `sw.js` CACHE_NAME were not updated.

## Checklist

- [x] No app source files changed — bundle rebuild not required
- [x] No sw.js change required (workflow-only fix)
- [x] `MASTER_PROMPT.md` does not need updating (infra fix only)
- [x] This must merge **before** PR #135 merges
