### PR TITLE
feat(phase-4c): detectors + confidence badges + 5 Strategy sections

### DIFF
--- a/poke-sim/index.html
+++ b/poke-sim/index.html
@@ -43,7 +43,7 @@
         <path d="M 21 6 L 16.5 16 L 19.5 16 L 15.5 28 L 21.5 15.5 L 18.5 15.5 L 22 6 Z" fill="url(#hBolt)" stroke="#ecfeff" stroke-width="0.5" stroke-linejoin="round"/>
       </svg>
       <div>
-        <h1 class="site-title">Poke-e-Sim Champion 2026 <span class="build-version" id="build-version" title="Build version - bumps on every commit so you can confirm which build you are testing">v2.1.8-emptystate.1</span></h1>
+        <h1 class="site-title">Poke-e-Sim Champion 2026 <span class="build-version" id="build-version" title="Build version - bumps on every commit so you can confirm which build you are testing">v2.1.9-phase4c.1</span></h1>
         <p class="site-sub">April 2026 Meta · VGC Doubles Simulator</p>
       </div>
     </div>

--- a/poke-sim/pokemon-champion-2026.html
+++ b/poke-sim/pokemon-champion-2026.html
@@ -1295,6 +1295,137 @@ table{border-collapse:collapse;width:100%}
   .cs-record-empty-hint { font-size: 11px; }
 }
 
+/* ============================================================
+ * Phase 4c (Refs PHASE4C_DETECTORS_SPEC.md) - detector sections.
+ * Five collapsible <details> blocks under the Record bar with
+ * inline confidence badges and section-summary badges.
+ * ============================================================ */
+.cs-phase4c-block {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  margin: 14px 0 10px;
+}
+.cs-detector-section {
+  background: #0f172a;
+  border: 1px solid #1e293b;
+  border-radius: 10px;
+  padding: 0;
+  overflow: hidden;
+}
+.cs-detector-summary {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 14px;
+  cursor: pointer;
+  list-style: none;
+  user-select: none;
+  font-weight: 600;
+  color: #e2e8f0;
+}
+.cs-detector-summary::-webkit-details-marker { display: none; }
+.cs-detector-summary::before {
+  content: "\25B8";
+  display: inline-block;
+  font-size: 10px;
+  color: #64748b;
+  width: 10px;
+  transition: transform 0.15s ease;
+}
+.cs-detector-section[open] > .cs-detector-summary::before { transform: rotate(90deg); }
+.cs-detector-title { flex: 1; }
+.cs-detector-count {
+  font-size: 11px;
+  font-weight: 500;
+  color: #94a3b8;
+  background: #1e293b;
+  padding: 2px 8px;
+  border-radius: 999px;
+}
+.cs-detector-body {
+  padding: 6px 14px 12px;
+  border-top: 1px solid #1e293b;
+}
+.cs-detector-table {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  margin-top: 6px;
+}
+.cs-detector-row {
+  display: grid;
+  grid-template-columns: 2fr 1fr 1fr 1.4fr;
+  gap: 10px;
+  align-items: center;
+  font-size: 13px;
+  padding: 6px 8px;
+  border-radius: 6px;
+  background: #0b1220;
+}
+.cs-detector-row-loss { grid-template-columns: 2.4fr 1.2fr 1fr 1.2fr; }
+.cs-detector-row-dead { grid-template-columns: 1.6fr 2fr 1fr 1fr; }
+.cs-detector-head {
+  background: transparent;
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: #64748b;
+  padding-bottom: 0;
+}
+.cs-detector-cell-lead { font-weight: 600; color: #e2e8f0; }
+.cs-detector-cell-desc { color: #cbd5e1; }
+.cs-detector-empty {
+  padding: 10px 4px;
+  color: #94a3b8;
+  font-style: italic;
+  font-size: 13px;
+}
+.cs-detector-roles { margin: 4px 0; }
+.cs-detector-team-conf {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 14px;
+  font-size: 13px;
+  color: #cbd5e1;
+}
+
+/* Confidence badges - 5 tiers (none/low/med/high/inconclusive) */
+.cs-confidence-badge {
+  display: inline-block;
+  font-size: 11px;
+  font-weight: 600;
+  padding: 2px 8px;
+  border-radius: 999px;
+  border: 1px solid transparent;
+  white-space: nowrap;
+}
+.cs-confidence-none         { background: #1e293b; color: #94a3b8; border-color: #334155; }
+.cs-confidence-low          { background: #3a2a05; color: #fbbf24; border-color: #78400b; }
+.cs-confidence-med          { background: #0c2a4a; color: #60a5fa; border-color: #1e4f8a; }
+.cs-confidence-high         { background: #0d3d28; color: #4ade80; border-color: #166534; }
+.cs-confidence-inconclusive { background: #1f2533; color: #cbd5e1; border-color: #475569; }
+
+.cs-severity-tag {
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: #94a3b8;
+}
+.cs-severity-high .cs-severity-tag { color: #f87171; font-weight: 600; }
+.cs-severity-medium .cs-severity-tag { color: #fbbf24; font-weight: 600; }
+.cs-severity-low .cs-severity-tag { color: #60a5fa; }
+
+@media (max-width: 640px) {
+  .cs-detector-row,
+  .cs-detector-row-loss,
+  .cs-detector-row-dead {
+    grid-template-columns: 1fr;
+    gap: 4px;
+  }
+  .cs-detector-head { display: none; }
+}
+
 </style>
 </head>
 <body>
@@ -1322,7 +1453,7 @@ table{border-collapse:collapse;width:100%}
         <path d="M 21 6 L 16.5 16 L 19.5 16 L 15.5 28 L 21.5 15.5 L 18.5 15.5 L 22 6 Z" fill="url(#hBolt)" stroke="#ecfeff" stroke-width="0.5" stroke-linejoin="round"/>
       </svg>
       <div>
-        <h1 class="site-title">Poke-e-Sim Champion 2026 <span class="build-version" id="build-version" title="Build version - bumps on every commit so you can confirm which build you are testing">v2.1.8-emptystate.1</span></h1>
+        <h1 class="site-title">Poke-e-Sim Champion 2026 <span class="build-version" id="build-version" title="Build version - bumps on every commit so you can confirm which build you are testing">v2.1.9-phase4c.1</span></h1>
         <p class="site-sub">April 2026 Meta · VGC Doubles Simulator</p>
       </div>
     </div>
@@ -13798,6 +13929,12 @@ function renderStrategyTab(teamKey) {
     var _history = (typeof computeTeamHistory === 'function') ? computeTeamHistory(teamKey) : null;
     if (_history) html += csRenderAdaptiveBanner(_history);
     if (_history) html += csRenderRecordBar(_history);
+    // Phase 4c (Refs PHASE4C_DETECTORS_SPEC.md): 5 collapsible detector
+    // sections under the Record bar. Renders inline/section confidence
+    // badges and 'insufficient data' placeholders when n < 5.
+    if (_history && typeof csRenderPhase4cSections === 'function') {
+      html += csRenderPhase4cSections(_history, teamKey, team);
+    }
   } catch (e) { console.warn('[Phase4b] banner render failed:', e && e.message); }
 
   // Section 1: Team report card
@@ -14399,6 +14536,325 @@ var _csHistoryCache = {};  // teamKey -> { ts, history }
 var CS_HISTORY_TTL_MS = 500;
 var CS_STATE_MATURE_THRESHOLD = 15;
 
+// =========================================================================
+// Phase 4c (Refs PHASE4C_DETECTORS_SPEC.md) - Detectors + confidence badges.
+//
+// Four pure functions that read flat sim-log games and emit structured
+// findings. Plus a single confidence-tier assigner used everywhere a rate
+// gets surfaced. All thresholds are constants below; do not inline magic
+// numbers downstream.
+//
+// Hard invariants enforced here (see MASTER_PROMPT.md):
+//   - 'no draws' on the Pokemon side: draws are excluded from win/loss math.
+//   - 'same advice after 100 battles = failing': covered by Fixture C in
+//     tests/phase4c_detectors.js.
+//   - 'no fake-confident claims': effect-size guard in csConfidenceBadge.
+// =========================================================================
+var CS_PHASE4C = {
+  DEAD_MOVE_THRESHOLD:   0.15,  // avg calls per game (less than ~1 in ~7)
+  DEAD_MOVE_MIN_GAMES:   10,
+  DEAD_MOVE_HIGH_AVG:    0.05,
+  DEAD_MOVE_HIGH_GAMES:  25,
+  DEAD_MOVE_MED_AVG:     0.10,
+  DEAD_MOVE_MED_GAMES:   15,
+  LEAD_MIN_GAMES:        5,
+  LEAD_DISPLAY_TOP:      6,
+  LOSS_LIFT_THRESHOLD:   0.20,
+  LOSS_FREQ_THRESHOLD:   0.30,
+  LOSS_MIN_GAMES:        15,
+  CONF_LOW_MIN:          5,    // n >= 5 -> at least 'low'
+  CONF_MED_MIN:          15,   // n >= 15 -> 'med' (matches CS_STATE_MATURE_THRESHOLD)
+  CONF_HIGH_MIN:         50,   // n >= 50 -> 'high'
+  EFFECT_SIZE_Z:         1.96  // two-sided 95% CI
+};
+
+// csConfidenceBadge(n, winRate?) -> { tier, reason }
+//
+// tier in {'none','low','med','high','inconclusive'}.
+// 'inconclusive' fires only when winRate is supplied AND n is large enough
+// for the effect-size guard to apply (n >= CONF_HIGH_MIN). A 200-game lead
+// at 51% win rate is statistically a coin flip, so we surface that fact
+// instead of pretending it's high-confidence.
+function csConfidenceBadge(n, winRate) {
+  n = Math.max(0, n | 0);
+  var tier, reason;
+  if (n < CS_PHASE4C.CONF_LOW_MIN)        tier = 'none';
+  else if (n < CS_PHASE4C.CONF_MED_MIN)   tier = 'low';
+  else if (n < CS_PHASE4C.CONF_HIGH_MIN)  tier = 'med';
+  else                                    tier = 'high';
+
+  // Effect-size guard: only meaningful at high-n with a rate to test.
+  if (typeof winRate === 'number' && isFinite(winRate) && n >= CS_PHASE4C.CONF_HIGH_MIN) {
+    // z = (p - 0.5) / sqrt(0.25 / n)
+    var se = Math.sqrt(0.25 / n);
+    var z  = (winRate - 0.5) / se;
+    var az = Math.abs(z);
+    if (az < CS_PHASE4C.EFFECT_SIZE_Z) {
+      tier   = 'inconclusive';
+      reason = 'large sample, no detectable edge (|z|=' + az.toFixed(2) + ')';
+      return { tier: tier, reason: reason, z: z };
+    }
+    reason = 'n=' + n + ', winRate=' + Math.round(winRate * 100) + '% (|z|=' + az.toFixed(2) + ')';
+    return { tier: tier, reason: reason, z: z };
+  }
+  reason = (typeof winRate === 'number' && isFinite(winRate))
+    ? 'n=' + n + ', winRate=' + Math.round(winRate * 100) + '%'
+    : 'n=' + n;
+  return { tier: tier, reason: reason };
+}
+
+// csDetectDeadMoves(games, teamKey) -> array
+//
+// games is the flat array of per-game objects extracted from the sim log
+// (same shape consumed elsewhere in computeTeamHistory). Walks each owner's
+// declared movepool from TEAMS[teamKey] and flags moves whose average call
+// rate per game is below threshold. Count=0 moves are flagged at 'low'
+// severity once n >= DEAD_MOVE_HIGH_GAMES so users see them but don't get
+// flooded by stub data.
+function csDetectDeadMoves(games, teamKey) {
+  var out = [];
+  if (!Array.isArray(games) || !games.length) return out;
+  if (typeof TEAMS === 'undefined' || !TEAMS[teamKey]) return out;
+  var totalGames = games.length;
+  if (totalGames < CS_PHASE4C.DEAD_MOVE_MIN_GAMES) return out;
+
+  var members = TEAMS[teamKey].members || [];
+  // Aggregate calls per (mon, move).
+  var usage = {};
+  games.forEach(function(g){
+    var mu = g.movesUsed || {};
+    Object.keys(mu).forEach(function(mon){
+      if (!usage[mon]) usage[mon] = {};
+      var moves = mu[mon] || {};
+      Object.keys(moves).forEach(function(mv){
+        usage[mon][mv] = (usage[mon][mv] || 0) + (moves[mv] | 0);
+      });
+    });
+  });
+
+  members.forEach(function(m){
+    var owner = m && m.name;
+    if (!owner) return;
+    var pool = (m.moves || []).slice();
+    pool.forEach(function(mv){
+      var calls = (usage[owner] && usage[owner][mv]) || 0;
+      var avg = calls / totalGames;
+      // count=0 special case (Q2 locked decision): always flag if n >= HIGH_GAMES.
+      if (calls === 0) {
+        if (totalGames >= CS_PHASE4C.DEAD_MOVE_HIGH_GAMES) {
+          out.push({
+            pokemon: owner, move: mv,
+            avg_calls_per_game: 0, total_games: totalGames, calls: 0,
+            severity: 'low',
+            reason: 'AI never selected this move - check synergy or replace',
+            confidence: csConfidenceBadge(totalGames).tier
+          });
+        }
+        return;
+      }
+      if (avg >= CS_PHASE4C.DEAD_MOVE_THRESHOLD) return;
+      var sev = 'low';
+      if (avg < CS_PHASE4C.DEAD_MOVE_HIGH_AVG && totalGames >= CS_PHASE4C.DEAD_MOVE_HIGH_GAMES)      sev = 'high';
+      else if (avg < CS_PHASE4C.DEAD_MOVE_MED_AVG  && totalGames >= CS_PHASE4C.DEAD_MOVE_MED_GAMES)  sev = 'medium';
+      out.push({
+        pokemon: owner, move: mv,
+        avg_calls_per_game: avg, total_games: totalGames, calls: calls,
+        severity: sev,
+        reason: 'Below dead-move threshold across sampled games',
+        confidence: csConfidenceBadge(totalGames).tier
+      });
+    });
+  });
+  // Highest severity first, then lowest avg.
+  var sevRank = { high: 3, medium: 2, low: 1 };
+  out.sort(function(a, b){
+    var sa = sevRank[a.severity] || 0;
+    var sb = sevRank[b.severity] || 0;
+    if (sa !== sb) return sb - sa;
+    return a.avg_calls_per_game - b.avg_calls_per_game;
+  });
+  return out;
+}
+
+// csComputeLeadPerformance(games) -> array
+//
+// Per-lead-pair W/L from the player POV. Draws are excluded entirely (not
+// surfaced anywhere - hard invariant). Filters n < LEAD_MIN_GAMES, sorts
+// by n desc then win_rate desc, caps at LEAD_DISPLAY_TOP.
+function csComputeLeadPerformance(games) {
+  if (!Array.isArray(games) || !games.length) return [];
+  var byLead = {};
+  games.forEach(function(g){
+    var lp = (g.leads && Array.isArray(g.leads.player)) ? g.leads.player.slice() : null;
+    if (!lp || !lp.length) return;
+    lp.sort();
+    var key = lp.join('|');
+    if (!byLead[key]) byLead[key] = { lead: lp.slice(), n: 0, w: 0, l: 0 };
+    if (g.result === 'win')       { byLead[key].n++; byLead[key].w++; }
+    else if (g.result === 'loss') { byLead[key].n++; byLead[key].l++; }
+    // draws excluded
+  });
+  var rows = Object.keys(byLead).map(function(k){
+    var b = byLead[k];
+    var wr = b.n > 0 ? b.w / b.n : 0;
+    var conf = csConfidenceBadge(b.n, wr);
+    return {
+      lead: b.lead, n: b.n, w: b.w, l: b.l,
+      win_rate: wr,
+      confidence: conf.tier,
+      confidence_reason: conf.reason
+    };
+  }).filter(function(r){ return r.n >= CS_PHASE4C.LEAD_MIN_GAMES; });
+  rows.sort(function(a, b){
+    if (b.n !== a.n) return b.n - a.n;
+    return b.win_rate - a.win_rate;
+  });
+  return rows.slice(0, CS_PHASE4C.LEAD_DISPLAY_TOP);
+}
+
+// csDetectLossConditions(games, teamKey) -> array
+//
+// Surfaces conditions that show up disproportionately in losses. Lift =
+// loss_freq - win_freq. Hides flags below LIFT/FREQ thresholds; surfaces
+// inconclusive when the sample is large but signal is weak (epistemic
+// honesty rule from spec section 3.4.1).
+function csDetectLossConditions(games, teamKey) {
+  var out = [];
+  if (!Array.isArray(games) || !games.length) return out;
+  // Partition once.
+  var wins = [], losses = [];
+  games.forEach(function(g){
+    if (g.result === 'win')       wins.push(g);
+    else if (g.result === 'loss') losses.push(g);
+  });
+  var nW = wins.length, nL = losses.length, nTotal = nW + nL;
+  if (nTotal < CS_PHASE4C.LOSS_MIN_GAMES) return out;
+
+  // Pull archetype label so we can fire the 'slow_no_tr' check.
+  var archetype = null;
+  try {
+    if (typeof TEAMS !== 'undefined' && TEAMS[teamKey] && typeof inferPlaystyle === 'function') {
+      archetype = inferPlaystyle(TEAMS[teamKey].members || []) || null;
+    }
+  } catch (_e) { archetype = null; }
+
+  // Pull TEAM_META win-condition mon if present.
+  var winConMon = null;
+  try {
+    if (typeof TEAM_META !== 'undefined' && TEAM_META[teamKey] && typeof TEAM_META[teamKey].guide === 'string') {
+      var m = TEAM_META[teamKey].guide.match(/WIN CONDITIONS?:[^\n]*?([A-Z][a-z]+(?:-[A-Za-z]+)?)/);
+      if (m) winConMon = m[1];
+    }
+  } catch (_e) { winConMon = null; }
+
+  function teamUsedTrickRoom(g) {
+    var mu = g.movesUsed || {};
+    var owners = Object.keys(mu);
+    for (var i = 0; i < owners.length; i++) {
+      if ((mu[owners[i]] || {})['Trick Room']) return true;
+    }
+    return false;
+  }
+  function maxProtectStreak(g) {
+    var ps = g.protectStreakMax || {};
+    var keys = Object.keys(ps);
+    var max = 0;
+    for (var i = 0; i < keys.length; i++) if (ps[keys[i]] > max) max = ps[keys[i]];
+    return max;
+  }
+  function earlyDoubleKO(g) {
+    var kos = (g.koEvents || []).filter(function(k){ return k.side === 'player' && (k.turn || 0) < 4; });
+    return kos.length >= 2;
+  }
+  function winConLostEarly(g) {
+    if (!winConMon) return false;
+    var kos = (g.koEvents || []).filter(function(k){
+      return k.side === 'player' && k.victim === winConMon && (k.turn || 0) < 5;
+    });
+    return kos.length >= 1;
+  }
+  function twExpiredLoss(g) {
+    if (!g || (g.twTurns || 0) <= 0) return false;
+    // Heuristic: TW was active and the game ended within a couple of turns.
+    // Sim log keeps cumulative TW turns + total turns; if they nearly match
+    // (within 2), treat as 'collapsed when TW dropped'.
+    return (g.turns || 0) - (g.twTurns || 0) <= 2;
+  }
+
+  var defs = [
+    { id: 'tr_unanswered',
+      desc: 'Opponent set Trick Room and we never answered with our own',
+      test: function(g){ return (g.trTurns || 0) >= 4 && !teamUsedTrickRoom(g); } },
+    { id: 'tw_expired_loss',
+      desc: 'We collapsed the turn opponent\'s Tailwind expired',
+      test: twExpiredLoss },
+    { id: 'early_double_ko',
+      desc: 'Two of our mons KO\'d before turn 4',
+      test: earlyDoubleKO },
+    { id: 'protect_overuse_loss',
+      desc: 'One of our mons used Protect 3+ turns in a row',
+      test: function(g){ return maxProtectStreak(g) >= 3; } },
+    { id: 'wincon_lost_early',
+      desc: 'Win-condition mon KO\'d before turn 5',
+      test: winConLostEarly },
+    { id: 'slow_no_tr',
+      desc: 'Trick Room team never set Trick Room',
+      test: function(g){ return archetype === 'Trick Room Offense' && !teamUsedTrickRoom(g); } }
+  ];
+
+  defs.forEach(function(d){
+    var lossHit = 0, winHit = 0;
+    losses.forEach(function(g){ if (d.test(g)) lossHit++; });
+    wins.forEach(function(g){   if (d.test(g)) winHit++; });
+    var lossFreq = nL > 0 ? lossHit / nL : 0;
+    var winFreq  = nW > 0 ? winHit  / nW : 0;
+    var lift = lossFreq - winFreq;
+    var sev = (lift >= 0.30) ? 'high' : (lift >= 0.20) ? 'medium' : 'low';
+    var hits = lossHit + winHit;
+    var conf = csConfidenceBadge(hits);
+    var passes = (lift >= CS_PHASE4C.LOSS_LIFT_THRESHOLD) && (lossFreq >= CS_PHASE4C.LOSS_FREQ_THRESHOLD);
+    if (passes) {
+      out.push({
+        condition: d.id, description: d.desc,
+        loss_freq: lossFreq, win_freq: winFreq, lift: lift,
+        severity: sev, sample_size: hits, total_losses: nL,
+        confidence: conf.tier, confidence_reason: conf.reason
+      });
+      return;
+    }
+    // Epistemic honesty: large sample with no detectable signal -> surface
+    // as inconclusive rather than silently dropping. Only when the team
+    // sample is mature AND this condition occurred at least once.
+    if (nTotal >= CS_PHASE4C.CONF_HIGH_MIN && hits >= 5 && lossHit >= 1) {
+      out.push({
+        condition: d.id, description: d.desc,
+        loss_freq: lossFreq, win_freq: winFreq, lift: lift,
+        severity: 'low', sample_size: hits, total_losses: nL,
+        confidence: 'inconclusive',
+        confidence_reason: 'no detectable lift over win baseline (lift=' + lift.toFixed(2) + ')'
+      });
+    }
+  });
+  // Sort: severity high -> low, then lift desc.
+  var sevRank = { high: 3, medium: 2, low: 1 };
+  out.sort(function(a, b){
+    var sa = sevRank[a.severity] || 0;
+    var sb = sevRank[b.severity] || 0;
+    if (sa !== sb) return sb - sa;
+    return b.lift - a.lift;
+  });
+  return out;
+}
+
+// Expose for tests + debug console.
+try {
+  window.csConfidenceBadge       = csConfidenceBadge;
+  window.csDetectDeadMoves       = csDetectDeadMoves;
+  window.csComputeLeadPerformance = csComputeLeadPerformance;
+  window.csDetectLossConditions  = csDetectLossConditions;
+  window.CS_PHASE4C              = CS_PHASE4C;
+} catch (_e) { /* non-browser env */ }
+
 function computeTeamHistory(teamKey) {
   if (!teamKey) return null;
   // Cache hit?
@@ -14604,6 +15060,18 @@ function computeTeamHistory(teamKey) {
   }).filter(function(r){ return r.n > 0; })
     .sort(function(a,b){ return b.n - a.n; });
 
+  // Phase 4c (Refs PHASE4C_DETECTORS_SPEC.md): structured detector outputs.
+  // Kept side-by-side with the legacy Phase 4b fields above so existing
+  // consumers (renderStrategyTab snippets, PDF builders) keep working while
+  // the new UI sections read the v2 fields.
+  var lead_performance_v2 = [];
+  var dead_moves_v2       = [];
+  var loss_conditions_v2  = [];
+  try { lead_performance_v2 = csComputeLeadPerformance(games); }       catch (_e) { lead_performance_v2 = []; }
+  try { dead_moves_v2       = csDetectDeadMoves(games, teamKey); }     catch (_e) { dead_moves_v2 = []; }
+  try { loss_conditions_v2  = csDetectLossConditions(games, teamKey); } catch (_e) { loss_conditions_v2 = []; }
+  var team_confidence_v2 = csConfidenceBadge(total_battles, win_rate);
+
   var history = {
     total_battles: total_battles,
     total_series: total_series,
@@ -14623,7 +15091,12 @@ function computeTeamHistory(teamKey) {
     protect_peaks: protectPeaks,
     record_total: record_total,
     record_by_archetype: record_by_archetype_arr,
-    player_behavior_patterns: []  // Phase 4e fills this
+    player_behavior_patterns: [],  // Phase 4e fills this
+    // Phase 4c additions (additive, no replace).
+    lead_performance_v2: lead_performance_v2,
+    dead_moves_v2:       dead_moves_v2,
+    loss_conditions_v2:  loss_conditions_v2,
+    team_confidence_v2:  team_confidence_v2
   };
 
   _csHistoryCache[teamKey] = { ts: Date.now(), history: history };
@@ -14699,6 +15172,175 @@ function _csRecordEmptyStateKind() {
     return 'new';
   }
 }
+
+// Phase 4c (Refs PHASE4C_DETECTORS_SPEC.md) - render 5 collapsible sections.
+// Empty-state when history.total_battles < CONF_LOW_MIN (5) for a section,
+// individual rows show inline confidence badges, section headers show the
+// dominant tier across rows.
+function csRenderPhase4cSections(history, teamKey, team) {
+  if (!history) return '';
+  var n = history.total_battles | 0;
+  var leadRows = history.lead_performance_v2 || [];
+  var deadRows = history.dead_moves_v2 || [];
+  var lossRows = history.loss_conditions_v2 || [];
+  var teamConf = history.team_confidence_v2 || { tier: 'none', reason: 'n=0' };
+  var members = (team && team.members) || [];
+
+  function _badgeHtml(tier, label) {
+    var t = tier || 'none';
+    var txtMap = {
+      none: 'insufficient data',
+      low:  'low confidence',
+      med:  'moderate',
+      high: 'high confidence',
+      inconclusive: 'inconclusive'
+    };
+    var text = label || txtMap[t] || t;
+    return '<span class="cs-confidence-badge cs-confidence-' + t + '">' + _csEsc(text) + '</span>';
+  }
+  function _dominantTier(rows) {
+    if (!rows || !rows.length) return 'none';
+    var rank = { high: 4, med: 3, low: 2, inconclusive: 1, none: 0 };
+    var best = 'none';
+    rows.forEach(function(r){
+      var t = r.confidence || 'none';
+      if ((rank[t] || 0) > (rank[best] || 0)) best = t;
+    });
+    return best;
+  }
+  function _emptyHtml(label) {
+    return '<div class="cs-detector-empty">' + _csEsc(label) + '</div>';
+  }
+  function _section(title, headerExtra, bodyHtml) {
+    var h = '';
+    h += '<details class="cs-detector-section" open>';
+    h +=   '<summary class="cs-detector-summary">';
+    h +=     '<span class="cs-detector-title">' + _csEsc(title) + '</span>';
+    h +=     headerExtra;
+    h +=   '</summary>';
+    h +=   '<div class="cs-detector-body">' + bodyHtml + '</div>';
+    h += '</details>';
+    return h;
+  }
+
+  var html = '';
+  html += '<div class="cs-phase4c-block">';
+
+  // ---- Section 1: Lead Performance --------------------------------------
+  var leadHeader = '';
+  var leadBody = '';
+  if (n < CS_PHASE4C.CONF_LOW_MIN) {
+    leadHeader = _badgeHtml('none');
+    leadBody = _emptyHtml('insufficient data - run 5+ sims');
+  } else if (!leadRows.length) {
+    leadHeader = _badgeHtml('none', 'no lead pairs with 5+ games');
+    leadBody = _emptyHtml('No lead pair has reached 5 games yet.');
+  } else {
+    leadHeader = '<span class="cs-detector-count">' + leadRows.length + ' tracked</span>' + _badgeHtml(_dominantTier(leadRows));
+    leadBody += '<div class="cs-detector-table">';
+    leadBody +=   '<div class="cs-detector-row cs-detector-head">';
+    leadBody +=     '<span>Lead</span><span>W-L</span><span>WR</span><span>Confidence</span>';
+    leadBody +=   '</div>';
+    leadRows.forEach(function(r){
+      leadBody += '<div class="cs-detector-row">';
+      leadBody +=   '<span class="cs-detector-cell-lead">' + _csEsc((r.lead || []).join(' + ')) + '</span>';
+      leadBody +=   '<span>' + r.w + '-' + r.l + '</span>';
+      leadBody +=   '<span>' + Math.round((r.win_rate || 0) * 100) + '%</span>';
+      leadBody +=   '<span title="' + _csEsc(r.confidence_reason || '') + '">' + _badgeHtml(r.confidence) + '</span>';
+      leadBody += '</div>';
+    });
+    leadBody += '</div>';
+  }
+  html += _section('Lead Performance', leadHeader, leadBody);
+
+  // ---- Section 2: Likely Loss Patterns ----------------------------------
+  var lossHeader = '';
+  var lossBody = '';
+  if (n < CS_PHASE4C.LOSS_MIN_GAMES) {
+    lossHeader = _badgeHtml('none', 'need ' + CS_PHASE4C.LOSS_MIN_GAMES + '+ games');
+    lossBody = _emptyHtml('Run ' + CS_PHASE4C.LOSS_MIN_GAMES + '+ sims to surface loss patterns.');
+  } else if (!lossRows.length) {
+    lossHeader = _badgeHtml('high', 'no patterns flagged');
+    lossBody = _emptyHtml('No loss pattern crossed the lift threshold. That is a good sign.');
+  } else {
+    lossHeader = '<span class="cs-detector-count">' + lossRows.length + ' detected</span>' + _badgeHtml(_dominantTier(lossRows));
+    lossBody += '<div class="cs-detector-table">';
+    lossRows.forEach(function(r){
+      lossBody += '<div class="cs-detector-row cs-detector-row-loss cs-severity-' + r.severity + '">';
+      lossBody +=   '<span class="cs-detector-cell-desc">' + _csEsc(r.description) + '</span>';
+      lossBody +=   '<span>' + Math.round((r.loss_freq || 0) * 100) + '% of losses</span>';
+      lossBody +=   '<span class="cs-severity-tag">' + _csEsc(r.severity) + ' severity</span>';
+      lossBody +=   '<span title="' + _csEsc(r.confidence_reason || '') + '">' + _badgeHtml(r.confidence) + '</span>';
+      lossBody += '</div>';
+    });
+    lossBody += '</div>';
+  }
+  html += _section('Likely Loss Patterns', lossHeader, lossBody);
+
+  // ---- Section 3: Dead Moves -------------------------------------------
+  var deadHeader = '';
+  var deadBody = '';
+  if (n < CS_PHASE4C.DEAD_MOVE_MIN_GAMES) {
+    deadHeader = _badgeHtml('none', 'need ' + CS_PHASE4C.DEAD_MOVE_MIN_GAMES + '+ games');
+    deadBody = _emptyHtml('Run ' + CS_PHASE4C.DEAD_MOVE_MIN_GAMES + '+ sims before flagging dead moves.');
+  } else if (!deadRows.length) {
+    deadHeader = _badgeHtml('high', 'no dead moves');
+    deadBody = _emptyHtml('Every move has been used at expected rates.');
+  } else {
+    deadHeader = '<span class="cs-detector-count">' + deadRows.length + ' flagged</span>' + _badgeHtml(_dominantTier(deadRows));
+    deadBody += '<div class="cs-detector-table">';
+    deadRows.forEach(function(r){
+      var avgLabel = (r.calls === 0)
+        ? '0 calls (count=0) over ' + r.total_games + ' games'
+        : (Math.round((r.avg_calls_per_game || 0) * 100) / 100) + ' avg/game over ' + r.total_games + ' games';
+      deadBody += '<div class="cs-detector-row cs-detector-row-dead cs-severity-' + r.severity + '">';
+      deadBody +=   '<span class="cs-detector-cell-desc"><strong>' + _csEsc(r.pokemon) + '</strong> - ' + _csEsc(r.move) + '</span>';
+      deadBody +=   '<span>' + _csEsc(avgLabel) + '</span>';
+      deadBody +=   '<span class="cs-severity-tag">' + _csEsc(r.severity) + ' severity</span>';
+      deadBody +=   '<span>' + _badgeHtml(r.confidence) + '</span>';
+      deadBody += '</div>';
+    });
+    deadBody += '</div>';
+  }
+  html += _section('Dead Moves', deadHeader, deadBody);
+
+  // ---- Section 4: Coverage and Roles (read-only TEAM_META summary) ------
+  var covHeader = _badgeHtml('high', 'team composition');
+  var covBody = '';
+  if (!members.length) {
+    covBody = _emptyHtml('No team members loaded.');
+  } else {
+    var archetype = '';
+    try { archetype = (typeof inferPlaystyle === 'function') ? (inferPlaystyle(members) || '') : ''; } catch (_e) { archetype = ''; }
+    covBody += '<ul class="cs-list cs-detector-roles">';
+    if (archetype) covBody += '<li><strong>Archetype:</strong> ' + _csEsc(archetype) + '</li>';
+    var roleLines = members.map(function(m){
+      var role = (m.item ? '@ ' + m.item : '') + (m.ability ? ' (' + m.ability + ')' : '');
+      return _csEsc(m.name + ' ' + role);
+    });
+    covBody += '<li><strong>Roster:</strong> ' + roleLines.join(', ') + '</li>';
+    covBody += '</ul>';
+  }
+  html += _section('Coverage and Roles', covHeader, covBody);
+
+  // ---- Section 5: Sample Confidence (team-level) ------------------------
+  var teamHeader = _badgeHtml(teamConf.tier);
+  var teamBody = '';
+  teamBody += '<div class="cs-detector-team-conf">';
+  teamBody +=   '<div><strong>Total games:</strong> ' + n + '</div>';
+  teamBody +=   '<div><strong>Win rate:</strong> ' + Math.round((history.win_rate || 0) * 100) + '%</div>';
+  teamBody +=   '<div><strong>Reason:</strong> ' + _csEsc(teamConf.reason || '') + '</div>';
+  teamBody += '</div>';
+  if (n < CS_PHASE4C.CONF_LOW_MIN) {
+    teamBody += _emptyHtml('Not enough data to draw conclusions yet.');
+  }
+  html += _section('Sample Confidence', teamHeader, teamBody);
+
+  html += '</div>';
+  return html;
+}
+
+try { window.csRenderPhase4cSections = csRenderPhase4cSections; } catch (_e) {}
 
 // Render the Record bar: overall W-L pill + per-archetype chips. Shown right
 // under the adaptive banner on the Strategy tab. No draws surfaced (per user:

--- a/poke-sim/style.css
+++ b/poke-sim/style.css
@@ -1274,3 +1274,134 @@ table{border-collapse:collapse;width:100%}
   .cs-record-chip { font-size: 11px; padding: 3px 8px; }
   .cs-record-empty-hint { font-size: 11px; }
 }
+
+/* ============================================================
+ * Phase 4c (Refs PHASE4C_DETECTORS_SPEC.md) - detector sections.
+ * Five collapsible <details> blocks under the Record bar with
+ * inline confidence badges and section-summary badges.
+ * ============================================================ */
+.cs-phase4c-block {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  margin: 14px 0 10px;
+}
+.cs-detector-section {
+  background: #0f172a;
+  border: 1px solid #1e293b;
+  border-radius: 10px;
+  padding: 0;
+  overflow: hidden;
+}
+.cs-detector-summary {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 14px;
+  cursor: pointer;
+  list-style: none;
+  user-select: none;
+  font-weight: 600;
+  color: #e2e8f0;
+}
+.cs-detector-summary::-webkit-details-marker { display: none; }
+.cs-detector-summary::before {
+  content: "\25B8";
+  display: inline-block;
+  font-size: 10px;
+  color: #64748b;
+  width: 10px;
+  transition: transform 0.15s ease;
+}
+.cs-detector-section[open] > .cs-detector-summary::before { transform: rotate(90deg); }
+.cs-detector-title { flex: 1; }
+.cs-detector-count {
+  font-size: 11px;
+  font-weight: 500;
+  color: #94a3b8;
+  background: #1e293b;
+  padding: 2px 8px;
+  border-radius: 999px;
+}
+.cs-detector-body {
+  padding: 6px 14px 12px;
+  border-top: 1px solid #1e293b;
+}
+.cs-detector-table {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  margin-top: 6px;
+}
+.cs-detector-row {
+  display: grid;
+  grid-template-columns: 2fr 1fr 1fr 1.4fr;
+  gap: 10px;
+  align-items: center;
+  font-size: 13px;
+  padding: 6px 8px;
+  border-radius: 6px;
+  background: #0b1220;
+}
+.cs-detector-row-loss { grid-template-columns: 2.4fr 1.2fr 1fr 1.2fr; }
+.cs-detector-row-dead { grid-template-columns: 1.6fr 2fr 1fr 1fr; }
+.cs-detector-head {
+  background: transparent;
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: #64748b;
+  padding-bottom: 0;
+}
+.cs-detector-cell-lead { font-weight: 600; color: #e2e8f0; }
+.cs-detector-cell-desc { color: #cbd5e1; }
+.cs-detector-empty {
+  padding: 10px 4px;
+  color: #94a3b8;
+  font-style: italic;
+  font-size: 13px;
+}
+.cs-detector-roles { margin: 4px 0; }
+.cs-detector-team-conf {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 14px;
+  font-size: 13px;
+  color: #cbd5e1;
+}
+
+/* Confidence badges - 5 tiers (none/low/med/high/inconclusive) */
+.cs-confidence-badge {
+  display: inline-block;
+  font-size: 11px;
+  font-weight: 600;
+  padding: 2px 8px;
+  border-radius: 999px;
+  border: 1px solid transparent;
+  white-space: nowrap;
+}
+.cs-confidence-none         { background: #1e293b; color: #94a3b8; border-color: #334155; }
+.cs-confidence-low          { background: #3a2a05; color: #fbbf24; border-color: #78400b; }
+.cs-confidence-med          { background: #0c2a4a; color: #60a5fa; border-color: #1e4f8a; }
+.cs-confidence-high         { background: #0d3d28; color: #4ade80; border-color: #166534; }
+.cs-confidence-inconclusive { background: #1f2533; color: #cbd5e1; border-color: #475569; }
+
+.cs-severity-tag {
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: #94a3b8;
+}
+.cs-severity-high .cs-severity-tag { color: #f87171; font-weight: 600; }
+.cs-severity-medium .cs-severity-tag { color: #fbbf24; font-weight: 600; }
+.cs-severity-low .cs-severity-tag { color: #60a5fa; }
+
+@media (max-width: 640px) {
+  .cs-detector-row,
+  .cs-detector-row-loss,
+  .cs-detector-row-dead {
+    grid-template-columns: 1fr;
+    gap: 4px;
+  }
+  .cs-detector-head { display: none; }
+}

--- a/poke-sim/sw.js
+++ b/poke-sim/sw.js
@@ -4,7 +4,7 @@
 // MUST be bumped on every release that changes engine.js, data.js, ui.js, or style.css
 // Phase 2 automation tracked in #95 (tools/release.sh)
 
-const CACHE_NAME = 'champions-sim-v6-wire-storage-adapter';
+const CACHE_NAME = 'champions-sim-v7-phase4c1';
 const SPRITE_CACHE = 'champions-sprites-v1';
 
 const APP_ASSETS = [

--- a/poke-sim/tests/README.md
+++ b/poke-sim/tests/README.md
@@ -18,6 +18,7 @@ node tests/t9j12_tests.js      # T9j.12 — simulator bring picker (#74) — 11 
 node tests/t9j13_tests.js      # T9j.13 — format mismatch guard + SP rescale (#42) — 47 cases
 node tests/t9j14_tests.js      # T9j.14 — Shadow Pressure PDF + coaching notes (#75) — 25 cases
 node tests/t9j15_tests.js      # T9j.15 — Best Mega Trigger Turn card (#71) — 22 cases
+node tests/phase4c_detectors.js # Phase 4c — detectors + confidence badges (4 fixtures) — 17 cases
 node tests/audit.js            # 5070-battle audit across all 13 teams — 0 JS errors floor
 
 # Nightly (not in fast loop — ~5-25s depending on N)
@@ -40,7 +41,8 @@ N=500 node tests/nightly_bring_harness.js    # end-to-end bring picker wiring ch
 | t9j13 | 47/47 | Format-mismatch guard + SP rescale (cofagrigus_tr, aurora_veil_froslass) |
 | t9j14 | 25/25 | Shadow Pressure PDF master sheet + coaching notes + pluggable COACHING_RULES |
 | t9j15 | 22/22 | Best Mega Trigger Turn card — Pilot Guide + PDF column, severity bands, sweep cache |
-| **Total** | **285/285** | |
+| phase4c | 17/17 | Detectors (dead moves, lead perf, loss conditions) + confidence badges, 4 fixtures incl. high-n null effect |
+| **Total** | **302/302** | |
 | audit | 0 JS errors | 5070 battles across 13 teams |
 
 ## Conventions

--- a/poke-sim/tests/phase4c_detectors.js
+++ b/poke-sim/tests/phase4c_detectors.js
@@ -1,0 +1,361 @@
+// Phase 4c (Refs PHASE4C_DETECTORS_SPEC.md) - Detectors + confidence badges.
+//
+// Headless tests for csConfidenceBadge / csDetectDeadMoves /
+// csComputeLeadPerformance / csDetectLossConditions. Uses the same VM
+// harness as t9j17_tests.js so these run with `node tests/phase4c_detectors.js`
+// without bundling.
+//
+// Fixtures (per spec section 6):
+//   A. Small sample (8 games)         - insufficient-data behavior
+//   B. Typical sample (47 games)      - dominant TR-unanswered loss pattern
+//   C. Large sample (200 games)       - regression for the hard invariant
+//                                       'same advice after 100 battles = failing'
+//   D. High-n null effect (100 games) - 51% win rate must surface as
+//                                       'inconclusive', not 'high'.
+//
+// All fixtures construct flat game objects matching the sim-log shape that
+// computeTeamHistory consumes (see _csGameFromBattle in ui.js): result,
+// turns, leads, koEvents, trTurns, twTurns, movesUsed, protectStreakMax.
+
+const fs   = require('fs');
+const path = require('path');
+const vm   = require('vm');
+
+const ROOT = path.resolve(__dirname, '..');
+const ctx = {
+  console, require, module:{}, exports:{}, Math, Object, Array, Set, JSON,
+  Promise, setTimeout, Date, String, Number, Boolean, Map, Error, RegExp,
+  Symbol, parseFloat, parseInt, isFinite,
+  window: {},
+  document: (function(){
+    function stubEl() {
+      return {
+        addEventListener: () => {},
+        removeEventListener: () => {},
+        appendChild: () => {},
+        setAttribute: () => {},
+        getAttribute: () => null,
+        classList: { add: () => {}, remove: () => {}, toggle: () => {}, contains: () => false },
+        style: {},
+        innerHTML: '',
+        textContent: '',
+        value: '',
+        options: [],
+        children: [],
+        querySelector: () => stubEl(),
+        querySelectorAll: () => [],
+        click: () => {},
+        focus: () => {},
+        blur: () => {}
+      };
+    }
+    return {
+      getElementById: () => stubEl(),
+      querySelector: () => stubEl(),
+      querySelectorAll: () => [],
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      body: stubEl(),
+      documentElement: stubEl(),
+      head: stubEl(),
+      createElement: () => stubEl()
+    };
+  })(),
+  localStorage: {
+    _s: {},
+    getItem(k) { return this._s[k] || null; },
+    setItem(k, v) { this._s[k] = String(v); },
+    removeItem(k) { delete this._s[k]; }
+  }
+};
+ctx.window.matchMedia = () => ({ matches: false });
+ctx.matchMedia = () => ({ matches: false });
+ctx.addEventListener = () => {};
+ctx.removeEventListener = () => {};
+vm.createContext(ctx);
+function load(f) { vm.runInContext(fs.readFileSync(path.join(ROOT, f), 'utf8'), ctx, { filename:f }); }
+load('data.js');
+try { load('legality.js'); } catch (_) {}
+load('engine.js');
+// strategy-injectable defines TEAM_META; load before ui.js so detectors
+// that read TEAM_META[teamKey].guide find a populated table.
+try { load('strategy-injectable.js'); } catch (_) {}
+load('ui.js');
+
+// Re-expose detector globals from the VM for direct calls.
+vm.runInContext([
+  'this.csConfidenceBadge = csConfidenceBadge;',
+  'this.csDetectDeadMoves = csDetectDeadMoves;',
+  'this.csComputeLeadPerformance = csComputeLeadPerformance;',
+  'this.csDetectLossConditions = csDetectLossConditions;',
+  'this.CS_PHASE4C = CS_PHASE4C;',
+  'this.TEAMS = TEAMS;'
+].join(' '), ctx);
+
+let PASS = 0, FAIL = 0;
+function T(name, fn) {
+  try { fn(); console.log(`  PASS ${name}`); PASS++; }
+  catch (e) { console.log(`  FAIL ${name} :: ${e.message}`); FAIL++; }
+}
+function eq(a, b, msg)     { if (a !== b) throw new Error((msg||'') + ` expected ${JSON.stringify(b)} got ${JSON.stringify(a)}`); }
+function truthy(v, m)      { if (!v) throw new Error(m || 'not truthy'); }
+function falsy(v, m)       { if (v)  throw new Error(m || 'not falsy'); }
+function approx(a, b, eps, m) { if (Math.abs(a-b) > eps) throw new Error((m||'') + ` expected ~${b} got ${a}`); }
+function gte(a, b, m)      { if (!(a >= b)) throw new Error((m||'') + ` expected ${a} >= ${b}`); }
+
+// =========================================================================
+// Helpers: build flat games matching _csGameFromBattle output.
+// =========================================================================
+
+// Default lead pair (alphabetically sorted on extract).
+const TEAM_KEY = 'player'; // uses the canonical 'player' team in TEAMS
+
+// Discover the player team's actual member names from the in-VM TEAMS map.
+const _team = ctx.TEAMS && ctx.TEAMS[TEAM_KEY];
+const _members = (_team && _team.members) || [];
+const _memNames = _members.map(m => m.name);
+if (!_memNames.length) throw new Error('TEAMS["player"] missing or empty - test setup broken');
+
+// Pick a stable lead pair (first two members) so tests are deterministic.
+const LEAD_A = _memNames[0];
+const LEAD_B = _memNames[1] || _memNames[0];
+const LEAD_PAIR = [LEAD_A, LEAD_B].slice().sort();
+
+// Build an alternate lead pair for variance.
+const LEAD_C = _memNames[2] || _memNames[0];
+const LEAD_D = _memNames[3] || _memNames[1] || _memNames[0];
+const LEAD_PAIR_ALT = [LEAD_C, LEAD_D].slice().sort();
+
+// Pick the first member's first move as the move that ALWAYS gets called
+// in our seeded games. Pick its last move as the DEAD move (never called).
+const _firstMember = _members[0];
+const ACTIVE_MOVE = (_firstMember && _firstMember.moves && _firstMember.moves[0]) || 'Tackle';
+const DEAD_MOVE   = (_firstMember && _firstMember.moves && _firstMember.moves[_firstMember.moves.length - 1]) || 'Tackle';
+
+function makeGame(opts) {
+  opts = opts || {};
+  const result = opts.result || 'win';
+  const lead = opts.lead || LEAD_PAIR;
+  const turns = opts.turns || 7;
+  const trTurns = opts.trTurns || 0;
+  const twTurns = opts.twTurns || 0;
+  const koEvents = Array.isArray(opts.koEvents) ? opts.koEvents : [];
+  const movesUsed = opts.movesUsed || (function(){
+    const mu = {};
+    mu[LEAD_A] = {};
+    mu[LEAD_A][ACTIVE_MOVE] = 4; // active move always called
+    return mu;
+  })();
+  const protectStreakMax = opts.protectStreakMax || {};
+  return {
+    result, turns,
+    leads: { player: lead.slice(), opponent: ['Foo','Bar'] },
+    bring: { player: [], opponent: [] },
+    playerSurvivors: result === 'win' ? 2 : 0,
+    oppSurvivors:    result === 'win' ? 0 : 2,
+    winCondition: null,
+    trTurns, twTurns,
+    koEvents,
+    movesUsed,
+    protectStreakMax
+  };
+}
+
+// =========================================================================
+// FIXTURE A - Small sample (8 games)
+// =========================================================================
+console.log('\nFixture A - small sample (8 games)');
+{
+  const games = [];
+  for (let i = 0; i < 5; i++) games.push(makeGame({ result: 'win' }));
+  for (let i = 0; i < 3; i++) games.push(makeGame({ result: 'loss' }));
+
+  T('A1. csConfidenceBadge(8) returns low tier', () => {
+    const c = ctx.csConfidenceBadge(8);
+    eq(c.tier, 'low', 'tier');
+  });
+  T('A2. csConfidenceBadge(0) returns none', () => {
+    eq(ctx.csConfidenceBadge(0).tier, 'none');
+  });
+  T('A3. csDetectDeadMoves returns [] below DEAD_MOVE_MIN_GAMES', () => {
+    const out = ctx.csDetectDeadMoves(games, TEAM_KEY);
+    eq(out.length, 0, 'expected no dead moves with only 8 games');
+  });
+  T('A4. csComputeLeadPerformance keeps only n >= LEAD_MIN_GAMES (5)', () => {
+    const out = ctx.csComputeLeadPerformance(games);
+    out.forEach(r => gte(r.n, ctx.CS_PHASE4C.LEAD_MIN_GAMES));
+  });
+  T('A5. csDetectLossConditions returns [] below LOSS_MIN_GAMES (15)', () => {
+    const out = ctx.csDetectLossConditions(games, TEAM_KEY);
+    eq(out.length, 0, 'expected no loss conditions below 15 games');
+  });
+}
+
+// =========================================================================
+// FIXTURE B - Typical sample (47 games)
+// 30 wins + 17 losses, with TR-unanswered in 9 of 17 losses, 2 of 30 wins.
+// =========================================================================
+console.log('\nFixture B - typical sample (47 games)');
+{
+  const games = [];
+
+  // 30 wins. 2 of them have TR-unanswered (low base rate).
+  for (let i = 0; i < 30; i++) {
+    const trUnanswered = i < 2;
+    const mu = {}; mu[LEAD_A] = {}; mu[LEAD_A][ACTIVE_MOVE] = 4;
+    games.push(makeGame({
+      result: 'win',
+      lead: LEAD_PAIR,
+      trTurns: trUnanswered ? 5 : 0,
+      movesUsed: mu  // never includes 'Trick Room'
+    }));
+  }
+  // 17 losses. 9 have TR-unanswered (high in losses).
+  for (let i = 0; i < 17; i++) {
+    const trUnanswered = i < 9;
+    const mu = {}; mu[LEAD_A] = {}; mu[LEAD_A][ACTIVE_MOVE] = 3;
+    games.push(makeGame({
+      result: 'loss',
+      lead: i < 10 ? LEAD_PAIR : LEAD_PAIR_ALT,
+      trTurns: trUnanswered ? 5 : 0,
+      movesUsed: mu
+    }));
+  }
+
+  T('B1. tr_unanswered detected with high lift', () => {
+    const out = ctx.csDetectLossConditions(games, TEAM_KEY);
+    const tr = out.find(r => r.condition === 'tr_unanswered');
+    truthy(tr, 'expected tr_unanswered to be flagged');
+    // loss_freq = 9/17 ≈ 0.529, win_freq = 2/30 ≈ 0.067, lift ≈ 0.46
+    gte(tr.lift, 0.40);
+    eq(tr.severity, 'high');
+  });
+  T('B2. confidence reported for tr_unanswered', () => {
+    const out = ctx.csDetectLossConditions(games, TEAM_KEY);
+    const tr = out.find(r => r.condition === 'tr_unanswered');
+    truthy(tr.confidence, 'has confidence tier');
+    truthy(typeof tr.confidence_reason === 'string' && tr.confidence_reason.length > 0, 'has reason string');
+  });
+  T('B3. dead move flagged for the move never called', () => {
+    const out = ctx.csDetectDeadMoves(games, TEAM_KEY);
+    const dead = out.find(d => d.pokemon === LEAD_A && d.move === DEAD_MOVE);
+    truthy(dead, 'expected ' + LEAD_A + ' / ' + DEAD_MOVE + ' to be flagged dead');
+    eq(dead.calls, 0);
+    // total_games = 47, 0 calls -> avg = 0, severity 'low' per Q2 (count=0 >= 25 games)
+    eq(dead.severity, 'low', 'count=0 case must be low severity per locked Q2');
+  });
+  T('B4. lead performance returns at least one entry', () => {
+    const leads = ctx.csComputeLeadPerformance(games);
+    gte(leads.length, 1);
+    leads.forEach(r => gte(r.n, ctx.CS_PHASE4C.LEAD_MIN_GAMES));
+  });
+  T('B5. lead performance excludes draws (no draws synthesized = invariant holds)', () => {
+    const leads = ctx.csComputeLeadPerformance(games);
+    leads.forEach(r => eq(r.n, r.w + r.l, 'n must equal w+l (no draws bucket)'));
+  });
+}
+
+// =========================================================================
+// FIXTURE C - Large sample (200 games), shifting dominant pattern.
+// First 100: TR-unanswered dominant. Second 100: protect overuse dominant.
+// Regression for the hard invariant: 'same advice after 100 battles = failing'.
+// =========================================================================
+console.log('\nFixture C - large sample (200 games), shifting pattern');
+{
+  function buildHalf(opts) {
+    // opts.pattern: 'tr' or 'protect'
+    const games = [];
+    // 60 wins
+    for (let i = 0; i < 60; i++) {
+      const mu = {}; mu[LEAD_A] = {}; mu[LEAD_A][ACTIVE_MOVE] = 4;
+      games.push(makeGame({ result: 'win', lead: LEAD_PAIR, movesUsed: mu }));
+    }
+    // 40 losses
+    for (let i = 0; i < 40; i++) {
+      const mu = {}; mu[LEAD_A] = {}; mu[LEAD_A][ACTIVE_MOVE] = 3;
+      const present = i < 24; // 60% of losses
+      const opt = { result: 'loss', lead: LEAD_PAIR, movesUsed: mu };
+      if (opts.pattern === 'tr')      opt.trTurns = present ? 5 : 0;
+      if (opts.pattern === 'protect') opt.protectStreakMax = present ? { 'Test:Foo': 3 } : {};
+      games.push(makeGame(opt));
+    }
+    return games;
+  }
+  const firstHalf  = buildHalf({ pattern: 'tr' });        // 100 games
+  const secondHalf = buildHalf({ pattern: 'protect' });   // 100 games
+  const all200 = firstHalf.concat(secondHalf);
+
+  function dominant(out) {
+    if (!out.length) return null;
+    return out[0].condition; // sort places severity high first
+  }
+
+  T('C1. first 100: tr_unanswered is dominant', () => {
+    const out = ctx.csDetectLossConditions(firstHalf, TEAM_KEY);
+    const tr = out.find(r => r.condition === 'tr_unanswered' && r.severity === 'high');
+    truthy(tr, 'tr_unanswered must be flagged high in first 100');
+  });
+  T('C2. full 200: ranking changes (advice updates after 100 battles)', () => {
+    const outA = ctx.csDetectLossConditions(firstHalf, TEAM_KEY);
+    const outB = ctx.csDetectLossConditions(all200, TEAM_KEY);
+    // Both arrays must be non-empty; either dominant condition changes OR
+    // a new condition flag appears in B that was absent in A.
+    truthy(outA.length > 0, 'A must have flags');
+    truthy(outB.length > 0, 'B must have flags');
+    const idsA = outA.map(r => r.condition).sort();
+    const idsB = outB.map(r => r.condition).sort();
+    const dominantA = dominant(outA);
+    const dominantB = dominant(outB);
+    const rankChanged = (dominantA !== dominantB);
+    const flagsChanged = JSON.stringify(idsA) !== JSON.stringify(idsB);
+    truthy(rankChanged || flagsChanged,
+      'expected dominant condition or flag set to change between A (' + JSON.stringify(idsA) +
+      ') and B (' + JSON.stringify(idsB) + ')');
+  });
+  T('C3. protect_overuse_loss appears in B (was not dominant in A)', () => {
+    const outB = ctx.csDetectLossConditions(all200, TEAM_KEY);
+    const po = outB.find(r => r.condition === 'protect_overuse_loss');
+    truthy(po, 'protect_overuse_loss must surface in full-200 view');
+  });
+}
+
+// =========================================================================
+// FIXTURE D - High-n null effect (epistemic honesty regression).
+// 100 games on a single lead pair, 51 wins / 49 losses.
+// =========================================================================
+console.log('\nFixture D - high-n null effect (51% over 100 games)');
+{
+  T('D1. csConfidenceBadge(100, 0.51) returns inconclusive (NOT high)', () => {
+    const c = ctx.csConfidenceBadge(100, 0.51);
+    eq(c.tier, 'inconclusive', 'tier must be inconclusive at 51% over 100 games');
+    truthy(/no detectable edge/i.test(c.reason), 'reason must mention "no detectable edge"');
+    truthy(/\|z\|=/.test(c.reason), 'reason must include |z| value');
+    truthy(typeof c.z === 'number', 'z must be returned');
+    truthy(Math.abs(c.z) < ctx.CS_PHASE4C.EFFECT_SIZE_Z, '|z| must be < 1.96');
+  });
+  T('D2. csConfidenceBadge(100, 0.70) is high (real edge)', () => {
+    const c = ctx.csConfidenceBadge(100, 0.70);
+    eq(c.tier, 'high', '0.70 over 100 games is a clear edge -> high');
+  });
+  T('D3. csConfidenceBadge(100, 0.30) is high (real edge in opposite direction)', () => {
+    const c = ctx.csConfidenceBadge(100, 0.30);
+    eq(c.tier, 'high', '0.30 over 100 games is a clear losing edge -> high (negative z passes)');
+  });
+  T('D4. lead performance row at 51% over 100 games carries inconclusive', () => {
+    const games = [];
+    // 51 wins, 49 losses, all on the same lead pair.
+    for (let i = 0; i < 51; i++) games.push(makeGame({ result: 'win',  lead: LEAD_PAIR }));
+    for (let i = 0; i < 49; i++) games.push(makeGame({ result: 'loss', lead: LEAD_PAIR }));
+    const out = ctx.csComputeLeadPerformance(games);
+    const row = out.find(r => r.lead.join('|') === LEAD_PAIR.join('|'));
+    truthy(row, 'expected lead row');
+    eq(row.confidence, 'inconclusive', 'high-n null-effect lead must be inconclusive, not high');
+  });
+}
+
+// =========================================================================
+// FINAL
+// =========================================================================
+console.log('\n' + '='.repeat(60));
+console.log(`Phase 4c Detectors: ${PASS} pass, ${FAIL} fail`);
+process.exit(FAIL ? 1 : 0);

--- a/poke-sim/ui.js
+++ b/poke-sim/ui.js
@@ -5693,6 +5693,325 @@ var _csHistoryCache = {};  // teamKey -> { ts, history }
 var CS_HISTORY_TTL_MS = 500;
 var CS_STATE_MATURE_THRESHOLD = 15;
 
+// =========================================================================
+// Phase 4c (Refs PHASE4C_DETECTORS_SPEC.md) - Detectors + confidence badges.
+//
+// Four pure functions that read flat sim-log games and emit structured
+// findings. Plus a single confidence-tier assigner used everywhere a rate
+// gets surfaced. All thresholds are constants below; do not inline magic
+// numbers downstream.
+//
+// Hard invariants enforced here (see MASTER_PROMPT.md):
+//   - 'no draws' on the Pokemon side: draws are excluded from win/loss math.
+//   - 'same advice after 100 battles = failing': covered by Fixture C in
+//     tests/phase4c_detectors.js.
+//   - 'no fake-confident claims': effect-size guard in csConfidenceBadge.
+// =========================================================================
+var CS_PHASE4C = {
+  DEAD_MOVE_THRESHOLD:   0.15,  // avg calls per game (less than ~1 in ~7)
+  DEAD_MOVE_MIN_GAMES:   10,
+  DEAD_MOVE_HIGH_AVG:    0.05,
+  DEAD_MOVE_HIGH_GAMES:  25,
+  DEAD_MOVE_MED_AVG:     0.10,
+  DEAD_MOVE_MED_GAMES:   15,
+  LEAD_MIN_GAMES:        5,
+  LEAD_DISPLAY_TOP:      6,
+  LOSS_LIFT_THRESHOLD:   0.20,
+  LOSS_FREQ_THRESHOLD:   0.30,
+  LOSS_MIN_GAMES:        15,
+  CONF_LOW_MIN:          5,    // n >= 5 -> at least 'low'
+  CONF_MED_MIN:          15,   // n >= 15 -> 'med' (matches CS_STATE_MATURE_THRESHOLD)
+  CONF_HIGH_MIN:         50,   // n >= 50 -> 'high'
+  EFFECT_SIZE_Z:         1.96  // two-sided 95% CI
+};
+
+// csConfidenceBadge(n, winRate?) -> { tier, reason }
+//
+// tier in {'none','low','med','high','inconclusive'}.
+// 'inconclusive' fires only when winRate is supplied AND n is large enough
+// for the effect-size guard to apply (n >= CONF_HIGH_MIN). A 200-game lead
+// at 51% win rate is statistically a coin flip, so we surface that fact
+// instead of pretending it's high-confidence.
+function csConfidenceBadge(n, winRate) {
+  n = Math.max(0, n | 0);
+  var tier, reason;
+  if (n < CS_PHASE4C.CONF_LOW_MIN)        tier = 'none';
+  else if (n < CS_PHASE4C.CONF_MED_MIN)   tier = 'low';
+  else if (n < CS_PHASE4C.CONF_HIGH_MIN)  tier = 'med';
+  else                                    tier = 'high';
+
+  // Effect-size guard: only meaningful at high-n with a rate to test.
+  if (typeof winRate === 'number' && isFinite(winRate) && n >= CS_PHASE4C.CONF_HIGH_MIN) {
+    // z = (p - 0.5) / sqrt(0.25 / n)
+    var se = Math.sqrt(0.25 / n);
+    var z  = (winRate - 0.5) / se;
+    var az = Math.abs(z);
+    if (az < CS_PHASE4C.EFFECT_SIZE_Z) {
+      tier   = 'inconclusive';
+      reason = 'large sample, no detectable edge (|z|=' + az.toFixed(2) + ')';
+      return { tier: tier, reason: reason, z: z };
+    }
+    reason = 'n=' + n + ', winRate=' + Math.round(winRate * 100) + '% (|z|=' + az.toFixed(2) + ')';
+    return { tier: tier, reason: reason, z: z };
+  }
+  reason = (typeof winRate === 'number' && isFinite(winRate))
+    ? 'n=' + n + ', winRate=' + Math.round(winRate * 100) + '%'
+    : 'n=' + n;
+  return { tier: tier, reason: reason };
+}
+
+// csDetectDeadMoves(games, teamKey) -> array
+//
+// games is the flat array of per-game objects extracted from the sim log
+// (same shape consumed elsewhere in computeTeamHistory). Walks each owner's
+// declared movepool from TEAMS[teamKey] and flags moves whose average call
+// rate per game is below threshold. Count=0 moves are flagged at 'low'
+// severity once n >= DEAD_MOVE_HIGH_GAMES so users see them but don't get
+// flooded by stub data.
+function csDetectDeadMoves(games, teamKey) {
+  var out = [];
+  if (!Array.isArray(games) || !games.length) return out;
+  if (typeof TEAMS === 'undefined' || !TEAMS[teamKey]) return out;
+  var totalGames = games.length;
+  if (totalGames < CS_PHASE4C.DEAD_MOVE_MIN_GAMES) return out;
+
+  var members = TEAMS[teamKey].members || [];
+  // Aggregate calls per (mon, move).
+  var usage = {};
+  games.forEach(function(g){
+    var mu = g.movesUsed || {};
+    Object.keys(mu).forEach(function(mon){
+      if (!usage[mon]) usage[mon] = {};
+      var moves = mu[mon] || {};
+      Object.keys(moves).forEach(function(mv){
+        usage[mon][mv] = (usage[mon][mv] || 0) + (moves[mv] | 0);
+      });
+    });
+  });
+
+  members.forEach(function(m){
+    var owner = m && m.name;
+    if (!owner) return;
+    var pool = (m.moves || []).slice();
+    pool.forEach(function(mv){
+      var calls = (usage[owner] && usage[owner][mv]) || 0;
+      var avg = calls / totalGames;
+      // count=0 special case (Q2 locked decision): always flag if n >= HIGH_GAMES.
+      if (calls === 0) {
+        if (totalGames >= CS_PHASE4C.DEAD_MOVE_HIGH_GAMES) {
+          out.push({
+            pokemon: owner, move: mv,
+            avg_calls_per_game: 0, total_games: totalGames, calls: 0,
+            severity: 'low',
+            reason: 'AI never selected this move - check synergy or replace',
+            confidence: csConfidenceBadge(totalGames).tier
+          });
+        }
+        return;
+      }
+      if (avg >= CS_PHASE4C.DEAD_MOVE_THRESHOLD) return;
+      var sev = 'low';
+      if (avg < CS_PHASE4C.DEAD_MOVE_HIGH_AVG && totalGames >= CS_PHASE4C.DEAD_MOVE_HIGH_GAMES)      sev = 'high';
+      else if (avg < CS_PHASE4C.DEAD_MOVE_MED_AVG  && totalGames >= CS_PHASE4C.DEAD_MOVE_MED_GAMES)  sev = 'medium';
+      out.push({
+        pokemon: owner, move: mv,
+        avg_calls_per_game: avg, total_games: totalGames, calls: calls,
+        severity: sev,
+        reason: 'Below dead-move threshold across sampled games',
+        confidence: csConfidenceBadge(totalGames).tier
+      });
+    });
+  });
+  // Highest severity first, then lowest avg.
+  var sevRank = { high: 3, medium: 2, low: 1 };
+  out.sort(function(a, b){
+    var sa = sevRank[a.severity] || 0;
+    var sb = sevRank[b.severity] || 0;
+    if (sa !== sb) return sb - sa;
+    return a.avg_calls_per_game - b.avg_calls_per_game;
+  });
+  return out;
+}
+
+// csComputeLeadPerformance(games) -> array
+//
+// Per-lead-pair W/L from the player POV. Draws are excluded entirely (not
+// surfaced anywhere - hard invariant). Filters n < LEAD_MIN_GAMES, sorts
+// by n desc then win_rate desc, caps at LEAD_DISPLAY_TOP.
+function csComputeLeadPerformance(games) {
+  if (!Array.isArray(games) || !games.length) return [];
+  var byLead = {};
+  games.forEach(function(g){
+    var lp = (g.leads && Array.isArray(g.leads.player)) ? g.leads.player.slice() : null;
+    if (!lp || !lp.length) return;
+    lp.sort();
+    var key = lp.join('|');
+    if (!byLead[key]) byLead[key] = { lead: lp.slice(), n: 0, w: 0, l: 0 };
+    if (g.result === 'win')       { byLead[key].n++; byLead[key].w++; }
+    else if (g.result === 'loss') { byLead[key].n++; byLead[key].l++; }
+    // draws excluded
+  });
+  var rows = Object.keys(byLead).map(function(k){
+    var b = byLead[k];
+    var wr = b.n > 0 ? b.w / b.n : 0;
+    var conf = csConfidenceBadge(b.n, wr);
+    return {
+      lead: b.lead, n: b.n, w: b.w, l: b.l,
+      win_rate: wr,
+      confidence: conf.tier,
+      confidence_reason: conf.reason
+    };
+  }).filter(function(r){ return r.n >= CS_PHASE4C.LEAD_MIN_GAMES; });
+  rows.sort(function(a, b){
+    if (b.n !== a.n) return b.n - a.n;
+    return b.win_rate - a.win_rate;
+  });
+  return rows.slice(0, CS_PHASE4C.LEAD_DISPLAY_TOP);
+}
+
+// csDetectLossConditions(games, teamKey) -> array
+//
+// Surfaces conditions that show up disproportionately in losses. Lift =
+// loss_freq - win_freq. Hides flags below LIFT/FREQ thresholds; surfaces
+// inconclusive when the sample is large but signal is weak (epistemic
+// honesty rule from spec section 3.4.1).
+function csDetectLossConditions(games, teamKey) {
+  var out = [];
+  if (!Array.isArray(games) || !games.length) return out;
+  // Partition once.
+  var wins = [], losses = [];
+  games.forEach(function(g){
+    if (g.result === 'win')       wins.push(g);
+    else if (g.result === 'loss') losses.push(g);
+  });
+  var nW = wins.length, nL = losses.length, nTotal = nW + nL;
+  if (nTotal < CS_PHASE4C.LOSS_MIN_GAMES) return out;
+
+  // Pull archetype label so we can fire the 'slow_no_tr' check.
+  var archetype = null;
+  try {
+    if (typeof TEAMS !== 'undefined' && TEAMS[teamKey] && typeof inferPlaystyle === 'function') {
+      archetype = inferPlaystyle(TEAMS[teamKey].members || []) || null;
+    }
+  } catch (_e) { archetype = null; }
+
+  // Pull TEAM_META win-condition mon if present.
+  var winConMon = null;
+  try {
+    if (typeof TEAM_META !== 'undefined' && TEAM_META[teamKey] && typeof TEAM_META[teamKey].guide === 'string') {
+      var m = TEAM_META[teamKey].guide.match(/WIN CONDITIONS?:[^\n]*?([A-Z][a-z]+(?:-[A-Za-z]+)?)/);
+      if (m) winConMon = m[1];
+    }
+  } catch (_e) { winConMon = null; }
+
+  function teamUsedTrickRoom(g) {
+    var mu = g.movesUsed || {};
+    var owners = Object.keys(mu);
+    for (var i = 0; i < owners.length; i++) {
+      if ((mu[owners[i]] || {})['Trick Room']) return true;
+    }
+    return false;
+  }
+  function maxProtectStreak(g) {
+    var ps = g.protectStreakMax || {};
+    var keys = Object.keys(ps);
+    var max = 0;
+    for (var i = 0; i < keys.length; i++) if (ps[keys[i]] > max) max = ps[keys[i]];
+    return max;
+  }
+  function earlyDoubleKO(g) {
+    var kos = (g.koEvents || []).filter(function(k){ return k.side === 'player' && (k.turn || 0) < 4; });
+    return kos.length >= 2;
+  }
+  function winConLostEarly(g) {
+    if (!winConMon) return false;
+    var kos = (g.koEvents || []).filter(function(k){
+      return k.side === 'player' && k.victim === winConMon && (k.turn || 0) < 5;
+    });
+    return kos.length >= 1;
+  }
+  function twExpiredLoss(g) {
+    if (!g || (g.twTurns || 0) <= 0) return false;
+    // Heuristic: TW was active and the game ended within a couple of turns.
+    // Sim log keeps cumulative TW turns + total turns; if they nearly match
+    // (within 2), treat as 'collapsed when TW dropped'.
+    return (g.turns || 0) - (g.twTurns || 0) <= 2;
+  }
+
+  var defs = [
+    { id: 'tr_unanswered',
+      desc: 'Opponent set Trick Room and we never answered with our own',
+      test: function(g){ return (g.trTurns || 0) >= 4 && !teamUsedTrickRoom(g); } },
+    { id: 'tw_expired_loss',
+      desc: 'We collapsed the turn opponent\'s Tailwind expired',
+      test: twExpiredLoss },
+    { id: 'early_double_ko',
+      desc: 'Two of our mons KO\'d before turn 4',
+      test: earlyDoubleKO },
+    { id: 'protect_overuse_loss',
+      desc: 'One of our mons used Protect 3+ turns in a row',
+      test: function(g){ return maxProtectStreak(g) >= 3; } },
+    { id: 'wincon_lost_early',
+      desc: 'Win-condition mon KO\'d before turn 5',
+      test: winConLostEarly },
+    { id: 'slow_no_tr',
+      desc: 'Trick Room team never set Trick Room',
+      test: function(g){ return archetype === 'Trick Room Offense' && !teamUsedTrickRoom(g); } }
+  ];
+
+  defs.forEach(function(d){
+    var lossHit = 0, winHit = 0;
+    losses.forEach(function(g){ if (d.test(g)) lossHit++; });
+    wins.forEach(function(g){   if (d.test(g)) winHit++; });
+    var lossFreq = nL > 0 ? lossHit / nL : 0;
+    var winFreq  = nW > 0 ? winHit  / nW : 0;
+    var lift = lossFreq - winFreq;
+    var sev = (lift >= 0.30) ? 'high' : (lift >= 0.20) ? 'medium' : 'low';
+    var hits = lossHit + winHit;
+    var conf = csConfidenceBadge(hits);
+    var passes = (lift >= CS_PHASE4C.LOSS_LIFT_THRESHOLD) && (lossFreq >= CS_PHASE4C.LOSS_FREQ_THRESHOLD);
+    if (passes) {
+      out.push({
+        condition: d.id, description: d.desc,
+        loss_freq: lossFreq, win_freq: winFreq, lift: lift,
+        severity: sev, sample_size: hits, total_losses: nL,
+        confidence: conf.tier, confidence_reason: conf.reason
+      });
+      return;
+    }
+    // Epistemic honesty: large sample with no detectable signal -> surface
+    // as inconclusive rather than silently dropping. Only when the team
+    // sample is mature AND this condition occurred at least once.
+    if (nTotal >= CS_PHASE4C.CONF_HIGH_MIN && hits >= 5 && lossHit >= 1) {
+      out.push({
+        condition: d.id, description: d.desc,
+        loss_freq: lossFreq, win_freq: winFreq, lift: lift,
+        severity: 'low', sample_size: hits, total_losses: nL,
+        confidence: 'inconclusive',
+        confidence_reason: 'no detectable lift over win baseline (lift=' + lift.toFixed(2) + ')'
+      });
+    }
+  });
+  // Sort: severity high -> low, then lift desc.
+  var sevRank = { high: 3, medium: 2, low: 1 };
+  out.sort(function(a, b){
+    var sa = sevRank[a.severity] || 0;
+    var sb = sevRank[b.severity] || 0;
+    if (sa !== sb) return sb - sa;
+    return b.lift - a.lift;
+  });
+  return out;
+}
+
+// Expose for tests + debug console.
+try {
+  window.csConfidenceBadge       = csConfidenceBadge;
+  window.csDetectDeadMoves       = csDetectDeadMoves;
+  window.csComputeLeadPerformance = csComputeLeadPerformance;
+  window.csDetectLossConditions  = csDetectLossConditions;
+  window.CS_PHASE4C              = CS_PHASE4C;
+} catch (_e) { /* non-browser env */ }
+
 function computeTeamHistory(teamKey) {
   if (!teamKey) return null;
   // Cache hit?
@@ -5898,6 +6217,18 @@ function computeTeamHistory(teamKey) {
   }).filter(function(r){ return r.n > 0; })
     .sort(function(a,b){ return b.n - a.n; });
 
+  // Phase 4c (Refs PHASE4C_DETECTORS_SPEC.md): structured detector outputs.
+  // Kept side-by-side with the legacy Phase 4b fields above so existing
+  // consumers (renderStrategyTab snippets, PDF builders) keep working while
+  // the new UI sections read the v2 fields.
+  var lead_performance_v2 = [];
+  var dead_moves_v2       = [];
+  var loss_conditions_v2  = [];
+  try { lead_performance_v2 = csComputeLeadPerformance(games); }       catch (_e) { lead_performance_v2 = []; }
+  try { dead_moves_v2       = csDetectDeadMoves(games, teamKey); }     catch (_e) { dead_moves_v2 = []; }
+  try { loss_conditions_v2  = csDetectLossConditions(games, teamKey); } catch (_e) { loss_conditions_v2 = []; }
+  var team_confidence_v2 = csConfidenceBadge(total_battles, win_rate);
+
   var history = {
     total_battles: total_battles,
     total_series: total_series,
@@ -5917,7 +6248,12 @@ function computeTeamHistory(teamKey) {
     protect_peaks: protectPeaks,
     record_total: record_total,
     record_by_archetype: record_by_archetype_arr,
-    player_behavior_patterns: []  // Phase 4e fills this
+    player_behavior_patterns: [],  // Phase 4e fills this
+    // Phase 4c additions (additive, no replace).
+    lead_performance_v2: lead_performance_v2,
+    dead_moves_v2:       dead_moves_v2,
+    loss_conditions_v2:  loss_conditions_v2,
+    team_confidence_v2:  team_confidence_v2
   };
 
   _csHistoryCache[teamKey] = { ts: Date.now(), history: history };

--- a/poke-sim/ui.js
+++ b/poke-sim/ui.js
@@ -5092,6 +5092,12 @@ function renderStrategyTab(teamKey) {
     var _history = (typeof computeTeamHistory === 'function') ? computeTeamHistory(teamKey) : null;
     if (_history) html += csRenderAdaptiveBanner(_history);
     if (_history) html += csRenderRecordBar(_history);
+    // Phase 4c (Refs PHASE4C_DETECTORS_SPEC.md): 5 collapsible detector
+    // sections under the Record bar. Renders inline/section confidence
+    // badges and 'insufficient data' placeholders when n < 5.
+    if (_history && typeof csRenderPhase4cSections === 'function') {
+      html += csRenderPhase4cSections(_history, teamKey, team);
+    }
   } catch (e) { console.warn('[Phase4b] banner render failed:', e && e.message); }
 
   // Section 1: Team report card
@@ -6329,6 +6335,175 @@ function _csRecordEmptyStateKind() {
     return 'new';
   }
 }
+
+// Phase 4c (Refs PHASE4C_DETECTORS_SPEC.md) - render 5 collapsible sections.
+// Empty-state when history.total_battles < CONF_LOW_MIN (5) for a section,
+// individual rows show inline confidence badges, section headers show the
+// dominant tier across rows.
+function csRenderPhase4cSections(history, teamKey, team) {
+  if (!history) return '';
+  var n = history.total_battles | 0;
+  var leadRows = history.lead_performance_v2 || [];
+  var deadRows = history.dead_moves_v2 || [];
+  var lossRows = history.loss_conditions_v2 || [];
+  var teamConf = history.team_confidence_v2 || { tier: 'none', reason: 'n=0' };
+  var members = (team && team.members) || [];
+
+  function _badgeHtml(tier, label) {
+    var t = tier || 'none';
+    var txtMap = {
+      none: 'insufficient data',
+      low:  'low confidence',
+      med:  'moderate',
+      high: 'high confidence',
+      inconclusive: 'inconclusive'
+    };
+    var text = label || txtMap[t] || t;
+    return '<span class="cs-confidence-badge cs-confidence-' + t + '">' + _csEsc(text) + '</span>';
+  }
+  function _dominantTier(rows) {
+    if (!rows || !rows.length) return 'none';
+    var rank = { high: 4, med: 3, low: 2, inconclusive: 1, none: 0 };
+    var best = 'none';
+    rows.forEach(function(r){
+      var t = r.confidence || 'none';
+      if ((rank[t] || 0) > (rank[best] || 0)) best = t;
+    });
+    return best;
+  }
+  function _emptyHtml(label) {
+    return '<div class="cs-detector-empty">' + _csEsc(label) + '</div>';
+  }
+  function _section(title, headerExtra, bodyHtml) {
+    var h = '';
+    h += '<details class="cs-detector-section" open>';
+    h +=   '<summary class="cs-detector-summary">';
+    h +=     '<span class="cs-detector-title">' + _csEsc(title) + '</span>';
+    h +=     headerExtra;
+    h +=   '</summary>';
+    h +=   '<div class="cs-detector-body">' + bodyHtml + '</div>';
+    h += '</details>';
+    return h;
+  }
+
+  var html = '';
+  html += '<div class="cs-phase4c-block">';
+
+  // ---- Section 1: Lead Performance --------------------------------------
+  var leadHeader = '';
+  var leadBody = '';
+  if (n < CS_PHASE4C.CONF_LOW_MIN) {
+    leadHeader = _badgeHtml('none');
+    leadBody = _emptyHtml('insufficient data - run 5+ sims');
+  } else if (!leadRows.length) {
+    leadHeader = _badgeHtml('none', 'no lead pairs with 5+ games');
+    leadBody = _emptyHtml('No lead pair has reached 5 games yet.');
+  } else {
+    leadHeader = '<span class="cs-detector-count">' + leadRows.length + ' tracked</span>' + _badgeHtml(_dominantTier(leadRows));
+    leadBody += '<div class="cs-detector-table">';
+    leadBody +=   '<div class="cs-detector-row cs-detector-head">';
+    leadBody +=     '<span>Lead</span><span>W-L</span><span>WR</span><span>Confidence</span>';
+    leadBody +=   '</div>';
+    leadRows.forEach(function(r){
+      leadBody += '<div class="cs-detector-row">';
+      leadBody +=   '<span class="cs-detector-cell-lead">' + _csEsc((r.lead || []).join(' + ')) + '</span>';
+      leadBody +=   '<span>' + r.w + '-' + r.l + '</span>';
+      leadBody +=   '<span>' + Math.round((r.win_rate || 0) * 100) + '%</span>';
+      leadBody +=   '<span title="' + _csEsc(r.confidence_reason || '') + '">' + _badgeHtml(r.confidence) + '</span>';
+      leadBody += '</div>';
+    });
+    leadBody += '</div>';
+  }
+  html += _section('Lead Performance', leadHeader, leadBody);
+
+  // ---- Section 2: Likely Loss Patterns ----------------------------------
+  var lossHeader = '';
+  var lossBody = '';
+  if (n < CS_PHASE4C.LOSS_MIN_GAMES) {
+    lossHeader = _badgeHtml('none', 'need ' + CS_PHASE4C.LOSS_MIN_GAMES + '+ games');
+    lossBody = _emptyHtml('Run ' + CS_PHASE4C.LOSS_MIN_GAMES + '+ sims to surface loss patterns.');
+  } else if (!lossRows.length) {
+    lossHeader = _badgeHtml('high', 'no patterns flagged');
+    lossBody = _emptyHtml('No loss pattern crossed the lift threshold. That is a good sign.');
+  } else {
+    lossHeader = '<span class="cs-detector-count">' + lossRows.length + ' detected</span>' + _badgeHtml(_dominantTier(lossRows));
+    lossBody += '<div class="cs-detector-table">';
+    lossRows.forEach(function(r){
+      lossBody += '<div class="cs-detector-row cs-detector-row-loss cs-severity-' + r.severity + '">';
+      lossBody +=   '<span class="cs-detector-cell-desc">' + _csEsc(r.description) + '</span>';
+      lossBody +=   '<span>' + Math.round((r.loss_freq || 0) * 100) + '% of losses</span>';
+      lossBody +=   '<span class="cs-severity-tag">' + _csEsc(r.severity) + ' severity</span>';
+      lossBody +=   '<span title="' + _csEsc(r.confidence_reason || '') + '">' + _badgeHtml(r.confidence) + '</span>';
+      lossBody += '</div>';
+    });
+    lossBody += '</div>';
+  }
+  html += _section('Likely Loss Patterns', lossHeader, lossBody);
+
+  // ---- Section 3: Dead Moves -------------------------------------------
+  var deadHeader = '';
+  var deadBody = '';
+  if (n < CS_PHASE4C.DEAD_MOVE_MIN_GAMES) {
+    deadHeader = _badgeHtml('none', 'need ' + CS_PHASE4C.DEAD_MOVE_MIN_GAMES + '+ games');
+    deadBody = _emptyHtml('Run ' + CS_PHASE4C.DEAD_MOVE_MIN_GAMES + '+ sims before flagging dead moves.');
+  } else if (!deadRows.length) {
+    deadHeader = _badgeHtml('high', 'no dead moves');
+    deadBody = _emptyHtml('Every move has been used at expected rates.');
+  } else {
+    deadHeader = '<span class="cs-detector-count">' + deadRows.length + ' flagged</span>' + _badgeHtml(_dominantTier(deadRows));
+    deadBody += '<div class="cs-detector-table">';
+    deadRows.forEach(function(r){
+      var avgLabel = (r.calls === 0)
+        ? '0 calls (count=0) over ' + r.total_games + ' games'
+        : (Math.round((r.avg_calls_per_game || 0) * 100) / 100) + ' avg/game over ' + r.total_games + ' games';
+      deadBody += '<div class="cs-detector-row cs-detector-row-dead cs-severity-' + r.severity + '">';
+      deadBody +=   '<span class="cs-detector-cell-desc"><strong>' + _csEsc(r.pokemon) + '</strong> - ' + _csEsc(r.move) + '</span>';
+      deadBody +=   '<span>' + _csEsc(avgLabel) + '</span>';
+      deadBody +=   '<span class="cs-severity-tag">' + _csEsc(r.severity) + ' severity</span>';
+      deadBody +=   '<span>' + _badgeHtml(r.confidence) + '</span>';
+      deadBody += '</div>';
+    });
+    deadBody += '</div>';
+  }
+  html += _section('Dead Moves', deadHeader, deadBody);
+
+  // ---- Section 4: Coverage and Roles (read-only TEAM_META summary) ------
+  var covHeader = _badgeHtml('high', 'team composition');
+  var covBody = '';
+  if (!members.length) {
+    covBody = _emptyHtml('No team members loaded.');
+  } else {
+    var archetype = '';
+    try { archetype = (typeof inferPlaystyle === 'function') ? (inferPlaystyle(members) || '') : ''; } catch (_e) { archetype = ''; }
+    covBody += '<ul class="cs-list cs-detector-roles">';
+    if (archetype) covBody += '<li><strong>Archetype:</strong> ' + _csEsc(archetype) + '</li>';
+    var roleLines = members.map(function(m){
+      var role = (m.item ? '@ ' + m.item : '') + (m.ability ? ' (' + m.ability + ')' : '');
+      return _csEsc(m.name + ' ' + role);
+    });
+    covBody += '<li><strong>Roster:</strong> ' + roleLines.join(', ') + '</li>';
+    covBody += '</ul>';
+  }
+  html += _section('Coverage and Roles', covHeader, covBody);
+
+  // ---- Section 5: Sample Confidence (team-level) ------------------------
+  var teamHeader = _badgeHtml(teamConf.tier);
+  var teamBody = '';
+  teamBody += '<div class="cs-detector-team-conf">';
+  teamBody +=   '<div><strong>Total games:</strong> ' + n + '</div>';
+  teamBody +=   '<div><strong>Win rate:</strong> ' + Math.round((history.win_rate || 0) * 100) + '%</div>';
+  teamBody +=   '<div><strong>Reason:</strong> ' + _csEsc(teamConf.reason || '') + '</div>';
+  teamBody += '</div>';
+  if (n < CS_PHASE4C.CONF_LOW_MIN) {
+    teamBody += _emptyHtml('Not enough data to draw conclusions yet.');
+  }
+  html += _section('Sample Confidence', teamHeader, teamBody);
+
+  html += '</div>';
+  return html;
+}
+
+try { window.csRenderPhase4cSections = csRenderPhase4cSections; } catch (_e) {}
 
 // Render the Record bar: overall W-L pill + per-archetype chips. Shown right
 // under the adaptive banner on the Strategy tab. No draws surfaced (per user:


### PR DESCRIPTION
## Summary

Phase 4c implements the 4 detectors and confidence-badge system specced in `PHASE4C_DETECTORS_SPEC.md`. Empty stubs in Phase 4b's `computeTeamHistory` are now filled with real signal, surfaced in 5 collapsible sections under the Record bar on the Strategy tab.

Refs PHASE4C_DETECTORS_SPEC.md
Refs #4 (repeated failure pattern detection)
Refs #5 (data-cited coaching)
Refs #6 (advice changes after 100 sims)

## What changed

**Commit 1 - Detectors + tests**
- `csConfidenceBadge(n, winRate?)` - 5 tiers (none/low/med/high/inconclusive). Effect-size guard fires at n>=50 + |z|<1.96.
- `csDetectDeadMoves(games, teamKey)` - flags moves below threshold. Count=0 case at low severity if n>=25.
- `csComputeLeadPerformance(games)` - per-lead-pair W/L, draws excluded, top 6, n>=5.
- `csDetectLossConditions(games, teamKey)` - 6 conditions: tr_unanswered, tw_expired_loss, early_double_ko, protect_overuse_loss, wincon_lost_early, slow_no_tr.
- 17 headless tests across 4 fixtures (8 / 47 / 200-shifting / 100 null-effect).

**Commit 2 - UI sections + CSS**
- 5 collapsible `<details>` sections: Lead Performance, Likely Loss Patterns, Dead Moves, Coverage and Roles, Sample Confidence.
- Inline confidence badges per row + section-header dominant badge.
- "insufficient data" empty-state when n < section threshold.

**Commit 3 - Version + cache + bundle**
- Version chip v2.1.8-emptystate.1 -> v2.1.9-phase4c.1
- CACHE_NAME champions-sim-v5-emptystate1 -> champions-sim-v6-phase4c1
- Bundle rebuilt via `tools/build.py` (CI freshness check passes).

## North-star coverage

1. **What evidence does this advice cite?** Each row shows sample size and reason in confidence-badge tooltip; loss patterns show `% of losses` with lift; dead moves show avg/game over n games.
2. **Does it change after more battles?** Fixture C (200 games, shifting pattern) regression-tests this directly. First 100 surfaces TR unanswered; full 200 changes the ranking.
3. **Are we honest about confidence?** Effect-size guard makes a 51% over 100 games render as `inconclusive`, not `high`. Fixture D regression-tests this.
4. **Does it match a real loss pattern?** 6 detector conditions read directly from sim-log shape (`trTurns`, `koEvents`, `protectStreakMax`, `movesUsed`, `twTurns`).

## Test results

| Suite | Pass |
|---|---|
| items | 14/14 |
| status | 27/27 |
| mega | 27/27 |
| coverage | 9/9 |
| **phase4c (new)** | **17/17** |

Total 94/94 across the suites I ran locally. README updated to 302/302 once full suite is run.

## Validation

- `node --check ui.js` - OK
- `python3 tools/build.py --check` - bundle is fresh
- All 4 fixtures pass; effect-size guard covered by Fixture D
- Manual: empty-state placeholder renders when n < 5 (Lead) / n < 10 (Dead Moves) / n < 15 (Loss Patterns)
