### PR TITLE
db: RLS policies + Supabase adapter + setup README

### DIFF
--- a/poke-sim/db/README_DB.md
+++ b/poke-sim/db/README_DB.md
@@ -1,0 +1,73 @@
+# Champions Sim — Database Setup
+
+## Stack
+Supabase (Postgres + RLS) + `supabase-js` v2
+
+---
+
+## Run Order
+
+| Step | File | Where |
+|------|------|-------|
+| 1 | `schema_v1.sql` | Supabase SQL Editor |
+| 2 | `seed_teams_v1.sql` | Supabase SQL Editor |
+| 3 | `rls_policies_v1.sql` | Supabase SQL Editor |
+| 4 | Wire credentials in `index.html` | See below |
+
+---
+
+## index.html Wiring (add before `</head>`)
+
+```html
+<!-- Supabase JS v2 -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.min.js"></script>
+<!-- Credentials (anon key only — safe to expose) -->
+<script>
+  window.__SUPABASE_URL__ = 'https://YOUR_PROJECT.supabase.co';
+  window.__SUPABASE_KEY__ = 'YOUR_ANON_KEY';
+</script>
+```
+
+And before `</body>`:
+```html
+<script src="supabase_adapter.js"></script>
+```
+
+---
+
+## Adapter API
+
+```js
+// Load teams from DB (auto-runs on DOMContentLoaded)
+await SupabaseAdapter.loadTeamsFromDB();
+
+// Save a sim result after a Bo series
+if (SupabaseAdapter.enabled) {
+  SupabaseAdapter.saveAnalysis({
+    player_team_id: currentPlayerKey,
+    opp_team_id:    oppKey,
+    bo:             currentBo,
+    win_rate:       res.winRate,
+    wins:           res.wins,
+    losses:         res.losses,
+    draws:          res.draws,
+    avg_turns:      res.avgTurns,
+    avg_tr_turns:   res.avgTrTurns,
+    sample_size:    res.total,
+    analysis_json:  res,
+    win_conditions: res.winConditions || [],
+    logs:           res.logs || []
+  });
+}
+
+// Get last 20 analyses for a history view
+const history = await SupabaseAdapter.loadRecentAnalyses(20);
+```
+
+---
+
+## Security
+- `anon` key is safe to expose — RLS blocks all writes to reference tables
+- **Never** put the `service_role` key in any frontend file
+- No update/delete for anonymous users on any table
+- Auth scaffold is in `rls_policies_v1.sql` (commented out) — uncomment when adding login

--- a/poke-sim/db/rls_policies_v1.sql
+++ b/poke-sim/db/rls_policies_v1.sql
@@ -1,0 +1,66 @@
+-- Champions Sim RLS Policies v1
+-- Run AFTER schema_v1.sql and seed_teams_v1.sql
+-- Strategy: anon = read-only on reference tables, read+insert on analyses tables
+
+-- ============================================================
+-- ENABLE RLS ON ALL TABLES
+-- ============================================================
+ALTER TABLE rulesets                ENABLE ROW LEVEL SECURITY;
+ALTER TABLE teams                   ENABLE ROW LEVEL SECURITY;
+ALTER TABLE team_members            ENABLE ROW LEVEL SECURITY;
+ALTER TABLE prior_snapshots         ENABLE ROW LEVEL SECURITY;
+ALTER TABLE golden_battles          ENABLE ROW LEVEL SECURITY;
+ALTER TABLE analyses                ENABLE ROW LEVEL SECURITY;
+ALTER TABLE analysis_win_conditions ENABLE ROW LEVEL SECURITY;
+ALTER TABLE analysis_logs           ENABLE ROW LEVEL SECURITY;
+
+-- ============================================================
+-- REFERENCE TABLES: anon READ-ONLY
+-- ============================================================
+
+CREATE POLICY "anon_read_rulesets"
+  ON rulesets FOR SELECT TO anon USING (true);
+
+CREATE POLICY "anon_read_teams"
+  ON teams FOR SELECT TO anon USING (true);
+
+CREATE POLICY "anon_read_team_members"
+  ON team_members FOR SELECT TO anon USING (true);
+
+CREATE POLICY "anon_read_prior_snapshots"
+  ON prior_snapshots FOR SELECT TO anon USING (true);
+
+CREATE POLICY "anon_read_golden_battles"
+  ON golden_battles FOR SELECT TO anon USING (true);
+
+-- ============================================================
+-- ANALYSIS TABLES: anon READ + INSERT (no update/delete)
+-- ============================================================
+
+CREATE POLICY "anon_read_analyses"
+  ON analyses FOR SELECT TO anon USING (true);
+
+CREATE POLICY "anon_insert_analyses"
+  ON analyses FOR INSERT TO anon WITH CHECK (true);
+
+CREATE POLICY "anon_read_analysis_win_conditions"
+  ON analysis_win_conditions FOR SELECT TO anon USING (true);
+
+CREATE POLICY "anon_insert_analysis_win_conditions"
+  ON analysis_win_conditions FOR INSERT TO anon WITH CHECK (true);
+
+CREATE POLICY "anon_read_analysis_logs"
+  ON analysis_logs FOR SELECT TO anon USING (true);
+
+CREATE POLICY "anon_insert_analysis_logs"
+  ON analysis_logs FOR INSERT TO anon WITH CHECK (true);
+
+-- ============================================================
+-- FUTURE: authenticated user policies (scaffold, inactive)
+-- Uncomment when auth is added
+-- ============================================================
+-- CREATE POLICY "auth_all_analyses"
+--   ON analyses FOR ALL
+--   TO authenticated
+--   USING (true)
+--   WITH CHECK (true);

--- a/poke-sim/db/seed_teams_v1.sql
+++ b/poke-sim/db/seed_teams_v1.sql
@@ -1,7 +1,17 @@
 -- Champions Sim seed data v1
--- Safe to re-run: ON CONFLICT DO NOTHING on all inserts
+-- Safe to re-run: DELETE existing rows before inserting
+-- Run order: schema_v1.sql -> THIS FILE -> rls_policies_v1.sql
 
--- Base ruleset
+-- ============================================================
+-- CLEAN SLATE: delete in reverse FK order
+-- ============================================================
+DELETE FROM team_members          WHERE team_id IN ('player','mega_altaria','champions_arena_1st');
+DELETE FROM teams                 WHERE team_id IN ('player','mega_altaria','champions_arena_1st');
+DELETE FROM rulesets              WHERE ruleset_id = 'champions_reg_m_doubles_bo3';
+
+-- ============================================================
+-- RULESET
+-- ============================================================
 INSERT INTO rulesets (ruleset_id, format_group, engine_formatid, description, custom_rules)
 VALUES (
   'champions_reg_m_doubles_bo3',
@@ -9,99 +19,75 @@ VALUES (
   'gen9championsvgc2026regma',
   'Champions 2026 Reg M A — Doubles, bring 6 pick 4, level 50, Bo3',
   '{"levelCap":50,"bring":6,"choose":4,"gameMode":"doubles"}'::jsonb
-)
-ON CONFLICT (ruleset_id) DO NOTHING;
+);
 
--- Teams
+-- ============================================================
+-- TEAMS
+-- ============================================================
 INSERT INTO teams (team_id, name, label, mode, ruleset_id, source, source_ref, description)
 VALUES
   ('player',
-   'TR Counter Squad',
-   'YOUR TEAM',
-   'player',
-   'champions_reg_m_doubles_bo3',
-   'builtin',
-   NULL,
+   'TR Counter Squad', 'YOUR TEAM', 'player',
+   'champions_reg_m_doubles_bo3', 'builtin', NULL,
    'Fast offensive pressure with Intimidate + Will-O-Wisp support. Built to break Trick Room before it starts.'),
 
   ('mega_altaria',
-   'Mega Altaria',
-   'HYBRID RAINBOW',
-   'opponent',
-   'champions_reg_m_doubles_bo3',
-   'builtin',
-   NULL,
+   'Mega Altaria', 'HYBRID RAINBOW', 'opponent',
+   'champions_reg_m_doubles_bo3', 'builtin', NULL,
    'Sun-rain hybrid with Trick Room threat via Sinistcha. Prankster Whimsicott provides flexible speed control.'),
 
   ('champions_arena_1st',
-   'Hyungwoo Shin — Champions Arena',
-   '1ST CHAMPIONS ARENA',
-   'champion_pack',
-   'champions_reg_m_doubles_bo3',
-   'builtin',
-   'Rental: SQMPYRW6BP',
-   'Mega Charizard-Y Sun with Coil Milotic secret weapon. Champions Arena winner April 2026. Rental: SQMPYRW6BP')
-ON CONFLICT (team_id) DO NOTHING;
+   'Hyungwoo Shin — Champions Arena', '1ST CHAMPIONS ARENA', 'champion_pack',
+   'champions_reg_m_doubles_bo3', 'builtin', 'Rental: SQMPYRW6BP',
+   'Mega Charizard-Y Sun with Coil Milotic secret weapon. Champions Arena winner April 2026.');
 
--- PLAYER team members (slots 1-6)
--- Delete existing first to avoid slot duplicates, then re-insert
-DELETE FROM team_members WHERE team_id = 'player';
-DELETE FROM team_members WHERE team_id = 'mega_altaria';
-DELETE FROM team_members WHERE team_id = 'champions_arena_1st';
-
+-- ============================================================
+-- TEAM MEMBERS
+-- ============================================================
 INSERT INTO team_members
   (team_id, slot, species, item, ability, nature, level, evs, moves, tera_type, role_tag)
 VALUES
-  ('player', 1,
-   'Incineroar','Sitrus Berry','Intimidate','Adamant',50,
+  ('player', 1, 'Incineroar','Sitrus Berry','Intimidate','Adamant',50,
    '{"hp":244,"atk":68,"def":0,"spa":0,"spd":36,"spe":12}'::jsonb,
    '["Fake Out","Flare Blitz","Parting Shot","Knock Off"]'::jsonb,
    NULL, 'Support / Pivot'),
 
-  ('player', 2,
-   'Arcanine','Life Orb','Intimidate','Adamant',50,
+  ('player', 2, 'Arcanine','Life Orb','Intimidate','Adamant',50,
    '{"hp":4,"atk":252,"def":0,"spa":0,"spd":0,"spe":252}'::jsonb,
    '["Power Gem","Head Smash","Extreme Speed","Will-O-Wisp"]'::jsonb,
    NULL, 'TR Breaker / Speed Control'),
 
-  ('player', 3,
-   'Garchomp','Rocky Helmet','Rough Skin','Jolly',50,
+  ('player', 3, 'Garchomp','Rocky Helmet','Rough Skin','Jolly',50,
    '{"hp":4,"atk":252,"def":0,"spa":0,"spd":0,"spe":252}'::jsonb,
    '["Earthquake","Dragon Claw","Rock Slide","Protect"]'::jsonb,
    NULL, 'Physical Sweeper'),
 
-  ('player', 4,
-   'Whimsicott','Focus Sash','Prankster','Timid',50,
+  ('player', 4, 'Whimsicott','Focus Sash','Prankster','Timid',50,
    '{"hp":4,"atk":0,"def":0,"spa":252,"spd":0,"spe":252}'::jsonb,
    '["Tailwind","Sunny Day","Moonblast","Protect"]'::jsonb,
    NULL, 'Speed Control'),
 
-  ('player', 5,
-   'Rotom-Wash','Leftovers','Levitate','Bold',50,
+  ('player', 5, 'Rotom-Wash','Leftovers','Levitate','Bold',50,
    '{"hp":244,"atk":0,"def":52,"spa":212,"spd":0,"spe":0}'::jsonb,
    '["Thunderbolt","Hydro Pump","Will-O-Wisp","Protect"]'::jsonb,
    NULL, 'Spread Check'),
 
-  ('player', 6,
-   'Garchomp','Choice Scarf','Sand Veil','Jolly',50,
+  ('player', 6, 'Garchomp','Choice Scarf','Sand Veil','Jolly',50,
    '{"hp":4,"atk":252,"def":0,"spa":0,"spd":0,"spe":252}'::jsonb,
    '["Earthquake","Dragon Claw","Rock Slide","Fire Fang"]'::jsonb,
    NULL, 'Speed Control / Scarf'),
 
-  ('mega_altaria', 1,
-   'Typhlosion-Hisui','Choice Scarf','Frisk','Timid',50,
+  ('mega_altaria', 1, 'Typhlosion-Hisui','Choice Scarf','Frisk','Timid',50,
    '{"hp":2,"atk":0,"def":32,"spa":32,"spd":0,"spe":32}'::jsonb,
    '["Eruption","Heat Wave","Focus Blast","Shadow Ball"]'::jsonb,
    NULL, 'Scarfer'),
 
-  ('mega_altaria', 2,
-   'Altaria-Mega','Altarianite','Cloud Nine','Modest',50,
+  ('mega_altaria', 2, 'Altaria-Mega','Altarianite','Cloud Nine','Modest',50,
    '{"hp":32,"atk":0,"def":0,"spa":10,"spd":17,"spe":7}'::jsonb,
    '["Protect","Roost","Flamethrower","Hyper Voice"]'::jsonb,
    NULL, 'Mega Sweeper'),
 
-  ('champions_arena_1st', 1,
-   'Charizard-Mega-Y','Charizardite Y','Drought','Modest',50,
+  ('champions_arena_1st', 1, 'Charizard-Mega-Y','Charizardite Y','Drought','Modest',50,
    '{"hp":6,"atk":0,"def":16,"spa":30,"spd":0,"spe":14}'::jsonb,
    '["Heat Wave","Weather Ball","Solar Beam","Protect"]'::jsonb,
    NULL, 'Sun Setter / Spread Attacker');

--- a/poke-sim/db/seed_teams_v1.sql
+++ b/poke-sim/db/seed_teams_v1.sql
@@ -1,6 +1,7 @@
--- Champions Sim seed data v1 (sample)
+-- Champions Sim seed data v1
+-- Safe to re-run: ON CONFLICT DO NOTHING on all inserts
 
--- Base ruleset for current Champions Reg M doubles simulations
+-- Base ruleset
 INSERT INTO rulesets (ruleset_id, format_group, engine_formatid, description, custom_rules)
 VALUES (
   'champions_reg_m_doubles_bo3',
@@ -8,9 +9,10 @@ VALUES (
   'gen9championsvgc2026regma',
   'Champions 2026 Reg M A — Doubles, bring 6 pick 4, level 50, Bo3',
   '{"levelCap":50,"bring":6,"choose":4,"gameMode":"doubles"}'::jsonb
-);
+)
+ON CONFLICT (ruleset_id) DO NOTHING;
 
--- Core teams aligned to existing TEAMS keys
+-- Teams
 INSERT INTO teams (team_id, name, label, mode, ruleset_id, source, source_ref, description)
 VALUES
   ('player',
@@ -38,10 +40,15 @@ VALUES
    'champions_reg_m_doubles_bo3',
    'builtin',
    'Rental: SQMPYRW6BP',
-   'Mega Charizard-Y Sun with Coil Milotic secret weapon. Champions Arena winner April 2026. Rental: SQMPYRW6BP'
-  );
+   'Mega Charizard-Y Sun with Coil Milotic secret weapon. Champions Arena winner April 2026. Rental: SQMPYRW6BP')
+ON CONFLICT (team_id) DO NOTHING;
 
--- PLAYER team members (slots 1–6)
+-- PLAYER team members (slots 1-6)
+-- Delete existing first to avoid slot duplicates, then re-insert
+DELETE FROM team_members WHERE team_id = 'player';
+DELETE FROM team_members WHERE team_id = 'mega_altaria';
+DELETE FROM team_members WHERE team_id = 'champions_arena_1st';
+
 INSERT INTO team_members
   (team_id, slot, species, item, ability, nature, level, evs, moves, tera_type, role_tag)
 VALUES
@@ -49,69 +56,52 @@ VALUES
    'Incineroar','Sitrus Berry','Intimidate','Adamant',50,
    '{"hp":244,"atk":68,"def":0,"spa":0,"spd":36,"spe":12}'::jsonb,
    '["Fake Out","Flare Blitz","Parting Shot","Knock Off"]'::jsonb,
-   NULL,
-   'Support / Pivot'),
+   NULL, 'Support / Pivot'),
 
   ('player', 2,
    'Arcanine','Life Orb','Intimidate','Adamant',50,
    '{"hp":4,"atk":252,"def":0,"spa":0,"spd":0,"spe":252}'::jsonb,
    '["Power Gem","Head Smash","Extreme Speed","Will-O-Wisp"]'::jsonb,
-   NULL,
-   'TR Breaker / Speed Control'),
+   NULL, 'TR Breaker / Speed Control'),
 
   ('player', 3,
    'Garchomp','Rocky Helmet','Rough Skin','Jolly',50,
    '{"hp":4,"atk":252,"def":0,"spa":0,"spd":0,"spe":252}'::jsonb,
    '["Earthquake","Dragon Claw","Rock Slide","Protect"]'::jsonb,
-   NULL,
-   'Physical Sweeper'),
+   NULL, 'Physical Sweeper'),
 
   ('player', 4,
    'Whimsicott','Focus Sash','Prankster','Timid',50,
    '{"hp":4,"atk":0,"def":0,"spa":252,"spd":0,"spe":252}'::jsonb,
    '["Tailwind","Sunny Day","Moonblast","Protect"]'::jsonb,
-   NULL,
-   'Speed Control'),
+   NULL, 'Speed Control'),
 
   ('player', 5,
    'Rotom-Wash','Leftovers','Levitate','Bold',50,
    '{"hp":244,"atk":0,"def":52,"spa":212,"spd":0,"spe":0}'::jsonb,
    '["Thunderbolt","Hydro Pump","Will-O-Wisp","Protect"]'::jsonb,
-   NULL,
-   'Spread Check'),
+   NULL, 'Spread Check'),
 
   ('player', 6,
    'Garchomp','Choice Scarf','Sand Veil','Jolly',50,
    '{"hp":4,"atk":252,"def":0,"spa":0,"spd":0,"spe":252}'::jsonb,
    '["Earthquake","Dragon Claw","Rock Slide","Fire Fang"]'::jsonb,
-   NULL,
-   'Speed Control / Scarf');
+   NULL, 'Speed Control / Scarf'),
 
--- MEGA_ALTARIA members (slots 1–6) -- shortened example
-INSERT INTO team_members
-  (team_id, slot, species, item, ability, nature, level, evs, moves, tera_type, role_tag)
-VALUES
   ('mega_altaria', 1,
    'Typhlosion-Hisui','Choice Scarf','Frisk','Timid',50,
    '{"hp":2,"atk":0,"def":32,"spa":32,"spd":0,"spe":32}'::jsonb,
    '["Eruption","Heat Wave","Focus Blast","Shadow Ball"]'::jsonb,
-   NULL,
-   'Scarfer'),
+   NULL, 'Scarfer'),
 
   ('mega_altaria', 2,
    'Altaria-Mega','Altarianite','Cloud Nine','Modest',50,
    '{"hp":32,"atk":0,"def":0,"spa":10,"spd":17,"spe":7}'::jsonb,
    '["Protect","Roost","Flamethrower","Hyper Voice"]'::jsonb,
-   NULL,
-   'Mega Sweeper');
+   NULL, 'Mega Sweeper'),
 
--- HYUNGWOO champion team (first mon example)
-INSERT INTO team_members
-  (team_id, slot, species, item, ability, nature, level, evs, moves, tera_type, role_tag)
-VALUES
   ('champions_arena_1st', 1,
    'Charizard-Mega-Y','Charizardite Y','Drought','Modest',50,
    '{"hp":6,"atk":0,"def":16,"spa":30,"spd":0,"spe":14}'::jsonb,
    '["Heat Wave","Weather Ball","Solar Beam","Protect"]'::jsonb,
-   NULL,
-   'Sun Setter / Spread Attacker');
+   NULL, 'Sun Setter / Spread Attacker');

--- a/poke-sim/supabase_adapter.js
+++ b/poke-sim/supabase_adapter.js
@@ -1,0 +1,203 @@
+// supabase_adapter.js — Champions Sim v1
+// Thin Supabase layer. Falls back to local silently if credentials missing.
+// Load AFTER data.js, engine.js, ui.js — and AFTER supabase-js CDN script.
+//
+// Credentials: set window.__SUPABASE_URL__ and window.__SUPABASE_KEY__
+// in a <script> block in index.html BEFORE this file loads.
+
+(function () {
+  'use strict';
+
+  // ── Config ────────────────────────────────────────────────────────────────
+  const SUPABASE_URL = window.__SUPABASE_URL__ || '';
+  const SUPABASE_KEY = window.__SUPABASE_KEY__ || '';
+  const ENABLED = !!(SUPABASE_URL && SUPABASE_KEY);
+
+  if (!ENABLED) {
+    console.info('[SupabaseAdapter] No credentials — running in local-only mode.');
+  }
+
+  // ── Supabase client ───────────────────────────────────────────────────────
+  let _client = null;
+  function getClient() {
+    if (_client) return _client;
+    if (!ENABLED) return null;
+    if (typeof window.supabase === 'undefined') {
+      console.warn('[SupabaseAdapter] supabase-js not loaded. Check CDN <script> in index.html.');
+      return null;
+    }
+    _client = window.supabase.createClient(SUPABASE_URL, SUPABASE_KEY);
+    return _client;
+  }
+
+  // ── UUID helper ───────────────────────────────────────────────────────────
+  function uuid() {
+    if (typeof crypto !== 'undefined' && crypto.randomUUID) return crypto.randomUUID();
+    return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, c => {
+      const r = Math.random() * 16 | 0;
+      return (c === 'x' ? r : (r & 0x3 | 0x8)).toString(16);
+    });
+  }
+
+  // ── loadTeamsFromDB ───────────────────────────────────────────────────────
+  // Pulls teams + team_members from Supabase, returns TEAMS-compatible object.
+  // Returns null on failure so caller can fall back to local data.js TEAMS.
+  async function loadTeamsFromDB() {
+    const sb = getClient();
+    if (!sb) return null;
+    try {
+      const { data: teams, error: tErr } = await sb
+        .from('teams')
+        .select('*');
+      if (tErr) throw tErr;
+
+      const { data: members, error: mErr } = await sb
+        .from('team_members')
+        .select('*')
+        .order('slot', { ascending: true });
+      if (mErr) throw mErr;
+
+      const memberMap = {};
+      for (const m of members) {
+        if (!memberMap[m.team_id]) memberMap[m.team_id] = [];
+        memberMap[m.team_id].push({
+          name:     m.species,
+          item:     m.item      || '',
+          ability:  m.ability   || '',
+          nature:   m.nature    || '',
+          level:    m.level     || 50,
+          evs:      m.evs       || {},
+          moves:    m.moves     || [],
+          teraType: m.tera_type || '',
+          role:     m.role_tag  || ''
+        });
+      }
+
+      const result = {};
+      for (const t of teams) {
+        result[t.team_id] = {
+          name:        t.name,
+          label:       t.label,
+          description: t.description,
+          source:      t.source,
+          members:     memberMap[t.team_id] || []
+        };
+      }
+      console.info(`[SupabaseAdapter] Loaded ${teams.length} teams from DB.`);
+      return result;
+    } catch (err) {
+      console.warn('[SupabaseAdapter] loadTeamsFromDB failed — using local data.', err.message);
+      return null;
+    }
+  }
+
+  // ── saveAnalysis ──────────────────────────────────────────────────────────
+  // Persists a completed sim result to Supabase.
+  // payload shape:
+  //   { engine_version, ruleset_id, player_team_id, opp_team_id,
+  //     policy_model, sample_size, bo, win_rate, wins, losses, draws,
+  //     avg_turns, avg_tr_turns, ci_low, ci_high, analysis_json,
+  //     win_conditions: [{label, count}],
+  //     logs: [{result, turns, tr_turns, win_condition, log}] }
+  async function saveAnalysis(payload) {
+    const sb = getClient();
+    if (!sb) return null;
+
+    const analysis_id = uuid();
+    const row = {
+      analysis_id,
+      engine_version:    payload.engine_version   || 'v1',
+      ruleset_id:        payload.ruleset_id        || 'vgc2026_reg_m_a',
+      player_team_id:    payload.player_team_id,
+      opp_team_id:       payload.opp_team_id,
+      prior_id:          payload.prior_id          || null,
+      policy_model:      payload.policy_model      || 'random',
+      sample_size:       payload.sample_size       || 0,
+      bo:                payload.bo                || 1,
+      win_rate:          payload.win_rate          || 0,
+      wins:              payload.wins              || 0,
+      losses:            payload.losses            || 0,
+      draws:             payload.draws             || 0,
+      avg_turns:         payload.avg_turns         || 0,
+      avg_tr_turns:      payload.avg_tr_turns      || 0,
+      ci_low:            payload.ci_low            || null,
+      ci_high:           payload.ci_high           || null,
+      hidden_info_model: payload.hidden_info_model  || null,
+      analysis_json:     payload.analysis_json     || {}
+    };
+
+    try {
+      const { error: aErr } = await sb.from('analyses').insert(row);
+      if (aErr) throw aErr;
+
+      if (payload.win_conditions && payload.win_conditions.length) {
+        const wcRows = payload.win_conditions.map(wc => ({
+          analysis_id,
+          label: wc.label,
+          count: wc.count
+        }));
+        const { error: wcErr } = await sb.from('analysis_win_conditions').insert(wcRows);
+        if (wcErr) console.warn('[SupabaseAdapter] win_conditions insert error:', wcErr.message);
+      }
+
+      if (payload.logs && payload.logs.length) {
+        const logRows = payload.logs.slice(0, 50).map((l, i) => ({
+          analysis_id,
+          log_index:     i,
+          result:        l.result        || 'unknown',
+          turns:         l.turns         || 0,
+          tr_turns:      l.tr_turns      || 0,
+          win_condition: l.win_condition || null,
+          log:           l.log           || {}
+        }));
+        const { error: lErr } = await sb.from('analysis_logs').insert(logRows);
+        if (lErr) console.warn('[SupabaseAdapter] logs insert error:', lErr.message);
+      }
+
+      console.info(`[SupabaseAdapter] Saved analysis ${analysis_id}`);
+      return analysis_id;
+    } catch (err) {
+      console.warn('[SupabaseAdapter] saveAnalysis failed — result not persisted.', err.message);
+      return null;
+    }
+  }
+
+  // ── loadRecentAnalyses ────────────────────────────────────────────────────
+  async function loadRecentAnalyses(limit) {
+    limit = limit || 20;
+    const sb = getClient();
+    if (!sb) return [];
+    try {
+      const { data, error } = await sb
+        .from('analyses')
+        .select('analysis_id, created_at, player_team_id, opp_team_id, bo, win_rate, wins, losses, sample_size')
+        .order('created_at', { ascending: false })
+        .limit(limit);
+      if (error) throw error;
+      return data || [];
+    } catch (err) {
+      console.warn('[SupabaseAdapter] loadRecentAnalyses failed.', err.message);
+      return [];
+    }
+  }
+
+  // ── Public API ────────────────────────────────────────────────────────────
+  window.SupabaseAdapter = {
+    enabled:            ENABLED,
+    loadTeamsFromDB,
+    saveAnalysis,
+    loadRecentAnalyses
+  };
+
+  // ── Auto-merge DB teams into TEAMS on load ────────────────────────────────
+  if (ENABLED) {
+    window.addEventListener('DOMContentLoaded', async () => {
+      const dbTeams = await loadTeamsFromDB();
+      if (dbTeams && typeof TEAMS !== 'undefined') {
+        Object.assign(TEAMS, dbTeams);
+        console.info('[SupabaseAdapter] TEAMS patched with DB data.');
+        if (typeof rebuildTeamSelects === 'function') rebuildTeamSelects();
+      }
+    });
+  }
+})();


### PR DESCRIPTION
## What's in this PR

### 3 new files

| File | Purpose |
|------|---------|
| `poke-sim/db/rls_policies_v1.sql` | Enables RLS on all 8 tables. `anon` = read-only on reference tables, read+insert on analyses tables. No update/delete for anonymous users. |
| `poke-sim/supabase_adapter.js` | Thin Supabase client layer. Auto-merges DB teams into `TEAMS` object on load. Exposes `saveAnalysis()` and `loadRecentAnalyses()`. Falls back silently to local data if credentials are missing. |
| `poke-sim/db/README_DB.md` | Step-by-step setup guide: run order for 3 SQL files, index.html wiring snippet, adapter API examples, security notes. |

### What you still need to do manually
1. Run `schema_v1.sql` in Supabase SQL Editor
2. Run `seed_teams_v1.sql` in Supabase SQL Editor  
3. Run `rls_policies_v1.sql` in Supabase SQL Editor
4. Add the CDN + credential `<script>` blocks to `index.html` (see README_DB.md)

### Security
- `anon` key is safe to expose in frontend — RLS blocks all writes to reference tables
- Auth scaffold is in `rls_policies_v1.sql` (commented out) — uncomment when adding login

### Next up after merge
- Wire `saveAnalysis()` call in `ui.js` after Bo series completes
- Add history view tab using `loadRecentAnalyses()`