### PR TITLE
docs: P0 DB setup README — step-by-step guide for Alfredo

### DIFF
--- a/poke-sim/db/README_DB.md
+++ b/poke-sim/db/README_DB.md
@@ -1,17 +1,37 @@
 # Champions Sim — Database Setup
 
+> **🔴 STATUS: P0 IN PROGRESS**  
+> GitHub Issue: [#158 — Finish Supabase DB Integration](https://github.com/alfredocox/Pokemon-Champions-Sim-Planner/issues/158)  
+> Owner: Alfredo  
+> Blocker: Lina must accept collaborator invite first.
+
+---
+
 ## Stack
 Supabase (Postgres + RLS) + `supabase-js` v2
 
 ---
 
-## Run Order
+## Files in This Folder
 
-| Step | File | Where |
-|------|------|-------|
-| 1 | `schema_v1.sql` | Supabase SQL Editor |
-| 2 | `seed_teams_v1.sql` | Supabase SQL Editor |
-| 3 | `rls_policies_v1.sql` | Supabase SQL Editor |
+| File | Purpose | Status |
+|---|---|---|
+| `schema_v1.sql` | Creates all 8 tables | ✅ Ready to run |
+| `seed_teams_v1.sql` | Seeds all 13 tournament teams | ✅ Ready to run |
+| `rls_policies_v1.sql` | Row-level security policies | ✅ Ready to run |
+| `README_DB.md` | This file | — |
+
+App layer: `poke-sim/storage_adapter.js` — needs Supabase wiring finalized.
+
+---
+
+## Run Order (Supabase SQL Editor)
+
+| Step | File | Notes |
+|---|---|---|
+| 1 | `schema_v1.sql` | Creates tables — run first |
+| 2 | `seed_teams_v1.sql` | Loads 13 teams — verify rows in Table Editor after |
+| 3 | `rls_policies_v1.sql` | Locks down security — run last |
 | 4 | Wire credentials in `index.html` | See below |
 
 ---
@@ -32,6 +52,19 @@ And before `</body>`:
 ```html
 <script src="supabase_adapter.js"></script>
 ```
+
+> ⚠️ Replace `YOUR_PROJECT` and `YOUR_ANON_KEY` with real values.  
+> ⛔ Never put the `service_role` key here — anon key only.
+
+---
+
+## Where to Find Your Keys
+
+1. Go to your Supabase project dashboard
+2. Left sidebar → **Settings** → **API**
+3. Copy:
+   - **Project URL** → `https://xxxxxxxxxxxx.supabase.co`
+   - **anon public** key → long `eyJhbGci...` string
 
 ---
 
@@ -60,14 +93,31 @@ if (SupabaseAdapter.enabled) {
   });
 }
 
-// Get last 20 analyses for a history view
+// Get last 20 analyses for history view
 const history = await SupabaseAdapter.loadRecentAnalyses(20);
 ```
 
 ---
 
-## Security
-- `anon` key is safe to expose — RLS blocks all writes to reference tables
-- **Never** put the `service_role` key in any frontend file
-- No update/delete for anonymous users on any table
+## Security Rules
+
+- `anon` key is safe to expose in client code — RLS blocks unauthorized writes
+- **Never** put the `service_role` key in any frontend file or commit it to GitHub
+- Anonymous users: read-only on reference/team tables, insert-only on analysis/log tables
+- No update or delete for anonymous users on any table
 - Auth scaffold is in `rls_policies_v1.sql` (commented out) — uncomment when adding login
+
+---
+
+## Verification Checklist (Alfredo)
+
+- [ ] Supabase project created and URL/key available
+- [ ] `schema_v1.sql` executed — tables visible in Table Editor
+- [ ] `seed_teams_v1.sql` executed — 13 rows in `teams` table
+- [ ] `rls_policies_v1.sql` executed — RLS enabled on all tables
+- [ ] `index.html` wired with Supabase client
+- [ ] App reads seeded teams from Supabase on load
+- [ ] Sim analysis write succeeds and persists on refresh
+- [ ] App falls back gracefully when Supabase is unavailable
+- [ ] No secrets committed to GitHub
+- [ ] Comment posted on Issue [#158](https://github.com/alfredocox/Pokemon-Champions-Sim-Planner/issues/158) confirming completion


### PR DESCRIPTION
## What this PR does

Updates `poke-sim/db/README_DB.md` with:

- 🔴 **P0 status badge** linking directly to Issue [#158](https://github.com/alfredocox/Pokemon-Champions-Sim-Planner/issues/158)
- **File inventory table** showing all 4 DB files and their current status
- **Explicit run order** for schema → seed → RLS → wiring
- **index.html wiring instructions** with exact code to paste
- **Where to find Supabase keys** (step-by-step)
- **Security rules** — anon key OK to expose, never commit service_role
- **Verification checklist** Alfredo checks off to close Issue #158

## Why

This gives Alfredo everything he needs in one place without digging through chat history or old notes. Ties directly to the P0 issue so progress is trackable.

## Related
Closes context for Issue #158 (issue stays open until DB work is verified complete).