### PR TITLE
security: harden anon INSERT RLS policies — replace WITH CHECK (true) with scoped predicates

### DIFF
--- a/poke-sim/db/rls_policies_v1.sql
+++ b/poke-sim/db/rls_policies_v1.sql
@@ -1,6 +1,7 @@
 -- Champions Sim RLS Policies v1
 -- Run AFTER schema_v1.sql and seed_teams_v1.sql
--- Strategy: anon = read-only on reference tables, read+insert on analyses tables
+-- Strategy: anon = read-only on reference tables, scoped insert on analyses tables
+-- Updated 2026-05-09: replaced WITH CHECK (true) with scoped predicates (security hardening)
 
 -- ============================================================
 -- ENABLE RLS ON ALL TABLES
@@ -34,26 +35,70 @@ CREATE POLICY "anon_read_golden_battles"
   ON golden_battles FOR SELECT TO anon USING (true);
 
 -- ============================================================
--- ANALYSIS TABLES: anon READ + INSERT (no update/delete)
+-- ANALYSIS TABLES: anon READ (open) + scoped INSERT
+-- WITH CHECK (true) removed -- replaced with real predicates
 -- ============================================================
 
+-- ------------------------------------------------------------
+-- analyses: enforce required fields, FK presence, numeric bounds,
+--           and wins+losses+draws = sample_size integrity check
+-- ------------------------------------------------------------
 CREATE POLICY "anon_read_analyses"
   ON analyses FOR SELECT TO anon USING (true);
 
+DROP POLICY IF EXISTS "anon_insert_analyses" ON analyses;
 CREATE POLICY "anon_insert_analyses"
-  ON analyses FOR INSERT TO anon WITH CHECK (true);
+  ON analyses FOR INSERT TO anon
+  WITH CHECK (
+    analysis_id        IS NOT NULL
+    AND engine_version IS NOT NULL AND engine_version <> ''
+    AND ruleset_id     IS NOT NULL AND ruleset_id     <> ''
+    AND player_team_id IS NOT NULL AND player_team_id <> ''
+    AND opp_team_id    IS NOT NULL AND opp_team_id    <> ''
+    AND policy_model   IS NOT NULL AND policy_model   <> ''
+    AND sample_size BETWEEN 1 AND 10000
+    AND bo          IN (1, 3, 5, 10)
+    AND win_rate    BETWEEN 0.0 AND 1.0
+    AND wins   >= 0
+    AND losses >= 0
+    AND draws  >= 0
+    AND avg_turns  > 0
+    AND (wins + losses + draws) = sample_size
+  );
 
+-- ------------------------------------------------------------
+-- analysis_win_conditions: label not empty, count positive
+-- ------------------------------------------------------------
 CREATE POLICY "anon_read_analysis_win_conditions"
   ON analysis_win_conditions FOR SELECT TO anon USING (true);
 
+DROP POLICY IF EXISTS "anon_insert_analysis_win_conditions" ON analysis_win_conditions;
 CREATE POLICY "anon_insert_analysis_win_conditions"
-  ON analysis_win_conditions FOR INSERT TO anon WITH CHECK (true);
+  ON analysis_win_conditions FOR INSERT TO anon
+  WITH CHECK (
+    analysis_id IS NOT NULL
+    AND label   IS NOT NULL AND label <> ''
+    AND count   > 0
+  );
 
+-- ------------------------------------------------------------
+-- analysis_logs: result enum-locked, index/turns bounded,
+--                tr_turns cannot exceed turns
+-- ------------------------------------------------------------
 CREATE POLICY "anon_read_analysis_logs"
   ON analysis_logs FOR SELECT TO anon USING (true);
 
+DROP POLICY IF EXISTS "anon_insert_analysis_logs" ON analysis_logs;
 CREATE POLICY "anon_insert_analysis_logs"
-  ON analysis_logs FOR INSERT TO anon WITH CHECK (true);
+  ON analysis_logs FOR INSERT TO anon
+  WITH CHECK (
+    analysis_id IS NOT NULL
+    AND log_index BETWEEN 0 AND 9999
+    AND result IN ('win', 'loss', 'draw')
+    AND turns    BETWEEN 1 AND 500
+    AND tr_turns BETWEEN 0 AND turns
+    AND log IS NOT NULL
+  );
 
 -- ============================================================
 -- FUTURE: authenticated user policies (scaffold, inactive)


### PR DESCRIPTION
## Problem

All three `anon INSERT` policies on analysis tables used `WITH CHECK (true)`, which is effectively no restriction — any unauthenticated caller could insert any row with any values. This triggers the **RLS Policy Always True** lint rule and creates real risk:
- Storage exhaustion via bulk arbitrary inserts
- Analytics pollution (fake win rates, bogus log entries)
- Potential indirect abuse depending on downstream processing

Affected policies:
- `anon_insert_analyses` on `public.analyses`
- `anon_insert_analysis_win_conditions` on `public.analysis_win_conditions`
- `anon_insert_analysis_logs` on `public.analysis_logs`

## Fix

Replaced all three `WITH CHECK (true)` predicates with column-bound constraints derived from the actual schema.

### `analyses`
- Required FK fields (`ruleset_id`, `player_team_id`, `opp_team_id`) must be non-null and non-empty
- `sample_size` between 1 and 10,000
- `bo` locked to valid values: `IN (1, 3, 5, 10)`
- `win_rate` between 0.0 and 1.0
- `avg_turns > 0`
- **Integrity check:** `wins + losses + draws = sample_size`

### `analysis_win_conditions`
- `analysis_id` not null
- `label` not empty
- `count > 0`

### `analysis_logs`
- `result` enum-locked to `'win'`, `'loss'`, `'draw'`
- `log_index` between 0 and 9,999
- `turns` between 1 and 500
- `tr_turns` between 0 and `turns` (cannot exceed total turns)
- `log` not null

## Verification (run in Supabase SQL editor after applying)

```sql
-- Confirm RLS enabled on all three tables
SELECT tablename, rowsecurity FROM pg_tables
WHERE tablename IN ('analyses','analysis_win_conditions','analysis_logs');

-- Should FAIL: result not in enum
INSERT INTO analysis_logs (analysis_id, log_index, result, turns, tr_turns, log)
VALUES ('00000000-0000-0000-0000-000000000000', 0, 'hack', 5, 0, '{}');

-- Should FAIL: wins + losses != sample_size
INSERT INTO analyses (analysis_id, engine_version, ruleset_id, player_team_id, opp_team_id,
  policy_model, sample_size, bo, win_rate, wins, losses, draws, avg_turns, avg_tr_turns, analysis_json)
VALUES (gen_random_uuid(), 'v1', 'reg-g', 'player', 'mega_altaria',
  'random', 10, 3, 0.5, 99, 1, 0, 7.2, 1.1, '{}');
```

## No application code changes

`supabase_adapter.js` already sends correctly-formed payloads that satisfy all these predicates. No client-side changes needed.

## Files changed
- `poke-sim/db/rls_policies_v1.sql`