### PR TITLE
[M8]: Starting Implementation

### DIFF
--- a/MASTER_PROMPT.md
+++ b/MASTER_PROMPT.md
@@ -37,6 +37,8 @@ git push --force
 
 | Date | Who | Action | Notes |
 |---|---|---|---|
+| 2026-05-11 | @alfredocox | M8 implementation: `loadPriorSnapshot` + `applyPrior` engine wiring + 10 TDD cases GREEN | POK-24. Adapter queries `prior_snapshots` table (fail-soft). Engine `buildAnalysisPayload` accepts `ctx.prior` → populates `prior_id`, `hidden_info_model`, enriched `hidden_info_priors`. Mock infra updated with `lte()` filter + select filtering. Bundle rebuilt (930KB). `sw.js` bumped to v15-m8-priors. |
+| 2026-05-11 | @alfredocox | Live app bundle fix: removed `</script>` from JS comment in `supabase_adapter.js` | Root cause: literal `</script>` in comment caused HTML parser to close `<script>` block early when inlined by `build-bundle.py`. Defense-in-depth: `sanitize_inline_js()` added to build script. |
 | 2026-05-09 | @alfredocox | M4/M5 test fixes + live DB testing CI configuration | Fixed async handling in tests, updated mock infrastructure, added RLS policies. CI now runs db_m*.js with live Supabase credentials. GitHub secrets: SUPABASE_URL, SUPABASE_ANON_KEY. |
 | 2026-05-09 | @alfredocox | M7 implementation: golden_battles deterministic regression runner + fixture + 8 test cases | POK-23. VM context, SHA256 trace hashes, --generate flag. CI enabled for db_m*.js. |
 | 2026-05-09 | @alfredocox | M6 implementation: `loadAnalysesForPlayer` + `loadAnalysisLogs` + history UI in Replay Log tab | POK-22. Lazy-load logs on expand. Filter chips (all/win/loss/clutch). 10 TDD cases rewritten. |
@@ -327,16 +329,16 @@ Pokemon-Champions-Sim-Planner/
 │   ├── supabase_adapter.js         ← Supabase sync layer — loadTeams, saveAnalysis, getMatchupHistory
 │   ├── strategy-injectable.js      ← injectable coaching strategy layer
 │   ├── legality.js                 ← VGC legality checker
-│   ├── sw.js                       ← PWA service worker (CACHE_NAME: champions-sim-v9-m3-init-wired)
+│   ├── sw.js                       ← PWA service worker (CACHE_NAME: champions-sim-v15-m8-priors)
 │   ├── manifest.json
 │   ├── icon-192.png / icon-512.png
-│   ├── pokemon-champion-2026.html  ← REBUILT BUNDLE (never edit directly — ~918 KB)
+│   ├── pokemon-champion-2026.html  ← REBUILT BUNDLE (never edit directly — ~930 KB)
 │   ├── db/
 │   │   ├── schema_v1.sql           ← 8-table Supabase schema (updated 2026-04-27: added metadata col)
 │   │   ├── seed_teams_v2.sql       ← ✅ USE THIS — 13 tournament teams, complete data (42 KB)
 │   │   ├── seed_teams_v1.sql       ← ⚠️ DEPRECATED — superseded by v2, do not use
 │   │   ├── rls_policies_v1.sql     ← Row Level Security policies (run third) — HAS MERGE CONFLICT
-│   │   ├── migrations/             ← migration scripts folder
+│   │   ├── migrations/             ← migration scripts folder (includes M8 usage_data + seed)
 │   │   └── README_DB.md            ← full setup checklist + adapter API docs — HAS MERGE CONFLICT
 │   ├── tools/
 │   │   ├── build-bundle.py         ← canonical bundle rebuild (always use this)
@@ -347,7 +349,14 @@ Pokemon-Champions-Sim-Planner/
 │       ├── ui_storage_integration_tests.js  ← 33 cases
 │       ├── items_tests.js / status_tests.js / mega_tests.js
 │       ├── coverage_tests.js / audit.js
-│       └── t9j8-t9j16_tests.js
+│       ├── t9j8-t9j16_tests.js
+│       ├── db_m4_save_tests.js              ← 18 cases (M4 persist analyses)
+│       ├── db_m5_import_tests.js            ← 12 cases (M5 import teams)
+│       ├── db_m6_history_tests.js           ← 10 cases (M6 history tab)
+│       ├── db_m7_golden_battles_tests.js    ← 8 cases (M7 golden battles)
+│       ├── db_m8_priors_tests.js            ← 10 cases (M8 prior snapshots)
+│       ├── _db_helpers.js                   ← shared mock infra for DB tests
+│       └── fixtures/                        ← test fixtures (golden_battles.json, prior_snapshot_sample.json)
 └── MASTER_PROMPT.md
 ```
 
@@ -421,7 +430,7 @@ The SQL files exist but have **NOT been executed** in Supabase yet. Tables do no
 | teams, team_members, pokemon, moves, rulesets, matchups | ✅ open | ✅ open (test data only) |
 | analyses, analysis_logs, analysis_win_conditions | ✅ open | ✅ open (no auth required — accepted risk) |
 
-### 🎯 CURRENT DB INTEGRATION STATUS (2026-05-09)
+### 🎯 CURRENT DB INTEGRATION STATUS (2026-05-11)
 
 #### ✅ **COMPLETED MODULES**
 - **M1**: Adapter wiring (PR #161) - ✅ MERGED
@@ -429,12 +438,26 @@ The SQL files exist but have **NOT been executed** in Supabase yet. Tables do no
 - **M3**: DB source of truth (PR #163) - ✅ MERGED
 - **M4**: Persist analyses - ✅ IMPLEMENTED + 18/18 tests passing
 - **M5**: Import teams persist - ✅ IMPLEMENTED + 12/12 tests passing
+- **M6**: History tab reads from DB - ✅ IMPLEMENTED + 10/10 tests passing
+- **M7**: Golden battles regression runner - ✅ IMPLEMENTED + 8/8 tests passing
+- **M8**: Prior snapshots for hidden-info inference - ✅ IMPLEMENTED + 10/10 tests passing
 
-#### 🔧 **M4/M5 IMPLEMENTATION DETAILS**
+#### 🔧 **M8 IMPLEMENTATION DETAILS (2026-05-11)**
+- **Adapter**: `loadPriorSnapshot(format, targetMonth)` queries `prior_snapshots` table, returns latest snapshot with `month ≤ targetMonth`. Fail-soft returns `null`.
+- **Engine**: `applyPrior(prior)` builds enriched `hidden_info_priors` from Smogon usage data. `buildAnalysisPayload` accepts `ctx.prior` → sets `prior_id`, `hidden_info_model`.
+- **Schema**: `prior_snapshots.usage_data` JSONB column added (migration: `2026_05_11_m8_add_usage_data_column.sql`)
+- **Seed data**: 3 months of VGC 2026 Reg M usage stats (migration: `2026_05_11_m8_seed_prior_snapshots.sql`)
+- **Mock infra**: `_db_helpers.js` updated with `lte()` filter, select-time eq/lte/order/limit filtering, `prior_snapshots` table
+- **Test file**: `poke-sim/tests/db_m8_priors_tests.js` — 10 cases with async test runner
+- **Fixture**: `poke-sim/tests/fixtures/prior_snapshot_sample.json` — 3 snapshots
+
+#### 🔧 **M4-M7 IMPLEMENTATION DETAILS**
 - **M4**: `_buildAnalysisPayload()` in `ui.js` + `saveAnalysis()` calls after simulation
 - **M5**: `_upsertTeamToDB()` in `ui.js` + `saveTeam()` adapter method
+- **M6**: `loadAnalysesForPlayer()` + `loadAnalysisLogs()` + history UI in Replay Log tab
+- **M7**: `golden_battles_runner.js` + deterministic trace hashes + `golden_battles.json` fixture
 - **Test Infrastructure**: Fixed async handling, updated mock promises, added RLS policies
-- **Bundle**: Rebuilt `pokemon-champion-2026.html` with M4/M5 implementations
+- **Bundle**: Rebuilt `pokemon-champion-2026.html` with all implementations (930KB)
 
 #### 🚀 **LIVE DB TESTING CONFIGURATION**
 - **CI Updated**: `.github/workflows/ci.yml` now runs `db_m*.js` with live Supabase
@@ -450,10 +473,15 @@ The SQL files exist but have **NOT been executed** in Supabase yet. Tables do no
 - Tests will create real data in production Supabase when live testing enabled
 
 #### 📋 **NEXT STEPS**
-1. Add GitHub secrets for Supabase credentials
-2. Consider restricting RLS policies for production safety
-3. Add test cleanup to prevent database pollution
-4. Implement M6-M9 modules (fan out after M3)
+1. Run M8 SQL migrations on Supabase: `2026_05_11_m8_add_usage_data_column.sql` then `2026_05_11_m8_seed_prior_snapshots.sql`
+2. Implement M9 (RLS hardening, advisor sweep, baseline migration) — last module
+3. Consider restricting RLS policies for production safety
+4. Add test cleanup to prevent database pollution
+
+#### 📊 **TEST SUITE TOTALS (2026-05-11)**
+- M4: 18/18, M5: 12/12, M6: 10/10, M7: 8/8, M8: 10/10 = **58/58 DB tests GREEN**
+- 343+ engine test cases
+- 40 storage adapter tests + 33 UI integration tests
 
 ---
 
@@ -515,7 +543,7 @@ cd poke-sim; python tools\build-bundle.py
 
 1. **Resolve all merge conflicts** in `supabase_adapter.js`, `rls_policies_v1.sql`, `README_DB.md`
 2. **Rebuild bundle:** `cd poke-sim && python3 tools/build-bundle.py`
-3. **Bump CACHE_NAME in sw.js:** format `champions-sim-v{major}-{tag}` — current: `champions-sim-v9-m3-init-wired` → next: `champions-sim-v10-m4-save-analysis`
+3. **Bump CACHE_NAME in sw.js:** format `champions-sim-v{major}-{tag}` — current: `champions-sim-v15-m8-priors`
 4. **Commit both artifacts:** `git add poke-sim/pokemon-champion-2026.html poke-sim/sw.js`
 5. **Push and wait for CI green:** Bundle Freshness Check + Cache Bump Check both must pass
 

--- a/poke-sim/engine.js
+++ b/poke-sim/engine.js
@@ -2383,6 +2383,34 @@ function wilsonCI(wins, n, z = 1.96) {
   ];
 }
 
+// M8: Build hidden_info_priors from a prior snapshot (Smogon usage data).
+// Returns an enriched priors object if prior is valid, or the default stub.
+function applyPrior(prior) {
+  if (!prior || !prior.usage_data) {
+    return {
+      note:   'All opponent set details taken as declared in TEAMS definition. No hidden-set priors applied.',
+      source: 'exact-input',
+      items:  'declared',
+      evs:    'declared',
+      tera:   'declared',
+      moves:  'declared'
+    };
+  }
+  return {
+    note:    'Hidden-info priors applied from ' + prior.source + ' (' + prior.month + ')',
+    source:  prior.source,
+    prior_id: prior.prior_id,
+    month:   prior.month,
+    items:   'usage-weighted',
+    evs:     'usage-weighted',
+    tera:    'usage-weighted',
+    moves:   'usage-weighted',
+    species_usage: prior.usage_data.species || [],
+    item_usage:    prior.usage_data.items   || [],
+    move_usage:    prior.usage_data.moves   || []
+  };
+}
+
 function buildAnalysisPayload(rawResult, ctx = {}) {
   const n   = rawResult.wins + rawResult.losses + (rawResult.draws || 0);
   const ci  = wilsonCI(rawResult.wins, n);
@@ -2403,14 +2431,11 @@ function buildAnalysisPayload(rawResult, ctx = {}) {
       player:   rawResult.playerTeam || ctx.playerTeamKey || 'player',
       opponent: rawResult.oppTeam    || ctx.oppTeamKey    || 'unknown'
     },
-    hidden_info_priors: {
-      note:   'All opponent set details taken as declared in TEAMS definition. No hidden-set priors applied.',
-      source: 'exact-input',
-      items:  'declared',
-      evs:    'declared',
-      tera:   'declared',
-      moves:  'declared'
-    },
+    prior_id:           (ctx.prior && ctx.prior.prior_id) || null,
+    hidden_info_model:   (ctx.prior && ctx.prior.source && ctx.prior.month)
+                           ? ctx.prior.source + '-' + ctx.prior.month
+                           : null,
+    hidden_info_priors:  applyPrior(ctx.prior || null),
     seed_policy:    rawResult.seeds ? 'per-battle-mulberry32' : 'legacy-unseed',
     sample_size:    rawResult.sampleSize || n,
     bo_mode:        ctx.bo || null,

--- a/poke-sim/pokemon-champion-2026.html
+++ b/poke-sim/pokemon-champion-2026.html
@@ -8640,6 +8640,34 @@ function wilsonCI(wins, n, z = 1.96) {
   ];
 }
 
+// M8: Build hidden_info_priors from a prior snapshot (Smogon usage data).
+// Returns an enriched priors object if prior is valid, or the default stub.
+function applyPrior(prior) {
+  if (!prior || !prior.usage_data) {
+    return {
+      note:   'All opponent set details taken as declared in TEAMS definition. No hidden-set priors applied.',
+      source: 'exact-input',
+      items:  'declared',
+      evs:    'declared',
+      tera:   'declared',
+      moves:  'declared'
+    };
+  }
+  return {
+    note:    'Hidden-info priors applied from ' + prior.source + ' (' + prior.month + ')',
+    source:  prior.source,
+    prior_id: prior.prior_id,
+    month:   prior.month,
+    items:   'usage-weighted',
+    evs:     'usage-weighted',
+    tera:    'usage-weighted',
+    moves:   'usage-weighted',
+    species_usage: prior.usage_data.species || [],
+    item_usage:    prior.usage_data.items   || [],
+    move_usage:    prior.usage_data.moves   || []
+  };
+}
+
 function buildAnalysisPayload(rawResult, ctx = {}) {
   const n   = rawResult.wins + rawResult.losses + (rawResult.draws || 0);
   const ci  = wilsonCI(rawResult.wins, n);
@@ -8660,14 +8688,11 @@ function buildAnalysisPayload(rawResult, ctx = {}) {
       player:   rawResult.playerTeam || ctx.playerTeamKey || 'player',
       opponent: rawResult.oppTeam    || ctx.oppTeamKey    || 'unknown'
     },
-    hidden_info_priors: {
-      note:   'All opponent set details taken as declared in TEAMS definition. No hidden-set priors applied.',
-      source: 'exact-input',
-      items:  'declared',
-      evs:    'declared',
-      tera:   'declared',
-      moves:  'declared'
-    },
+    prior_id:           (ctx.prior && ctx.prior.prior_id) || null,
+    hidden_info_model:   (ctx.prior && ctx.prior.source && ctx.prior.month)
+                           ? ctx.prior.source + '-' + ctx.prior.month
+                           : null,
+    hidden_info_priors:  applyPrior(ctx.prior || null),
     seed_policy:    rawResult.seeds ? 'per-battle-mulberry32' : 'legacy-unseed',
     sample_size:    rawResult.sampleSize || n,
     bo_mode:        ctx.bo || null,
@@ -16257,6 +16282,29 @@ if (typeof window !== 'undefined') {
     }
   }
 
+  // ── M8: Load prior snapshot for hidden-info inference ───────────────────
+  // Returns the most recent prior_snapshots row for the given format where
+  // month ≤ targetMonth. Returns null if none found or on error (fail-soft).
+  async function loadPriorSnapshot(format, targetMonth) {
+    var sb = getClient();
+    if (!sb) return null;
+    try {
+      var { data, error } = await sb
+        .from('prior_snapshots')
+        .select('*')
+        .eq('format', format)
+        .lte('month', targetMonth)
+        .order('month', { ascending: false })
+        .limit(1)
+        .single();
+      if (error) throw error;
+      return data || null;
+    } catch (err) {
+      console.warn('[SupabaseAdapter] loadPriorSnapshot failed.', err && err.message);
+      return null;
+    }
+  }
+
   // ── Public API ────────────────────────────────────────────────────────────
   window.SupabaseAdapter = {
     enabled:            ENABLED,
@@ -16267,7 +16315,8 @@ if (typeof window !== 'undefined') {
     loadRecentAnalyses,
     saveTeam,
     loadAnalysesForPlayer,
-    loadAnalysisLogs
+    loadAnalysisLogs,
+    loadPriorSnapshot
   };
 
   // M3 NOTE: Auto-merge of DB teams into TEAMS has moved to ui.js's

--- a/poke-sim/supabase_adapter.js
+++ b/poke-sim/supabase_adapter.js
@@ -329,6 +329,29 @@
     }
   }
 
+  // ── M8: Load prior snapshot for hidden-info inference ───────────────────
+  // Returns the most recent prior_snapshots row for the given format where
+  // month ≤ targetMonth. Returns null if none found or on error (fail-soft).
+  async function loadPriorSnapshot(format, targetMonth) {
+    var sb = getClient();
+    if (!sb) return null;
+    try {
+      var { data, error } = await sb
+        .from('prior_snapshots')
+        .select('*')
+        .eq('format', format)
+        .lte('month', targetMonth)
+        .order('month', { ascending: false })
+        .limit(1)
+        .single();
+      if (error) throw error;
+      return data || null;
+    } catch (err) {
+      console.warn('[SupabaseAdapter] loadPriorSnapshot failed.', err && err.message);
+      return null;
+    }
+  }
+
   // ── Public API ────────────────────────────────────────────────────────────
   window.SupabaseAdapter = {
     enabled:            ENABLED,
@@ -339,7 +362,8 @@
     loadRecentAnalyses,
     saveTeam,
     loadAnalysesForPlayer,
-    loadAnalysisLogs
+    loadAnalysisLogs,
+    loadPriorSnapshot
   };
 
   // M3 NOTE: Auto-merge of DB teams into TEAMS has moved to ui.js's

--- a/poke-sim/sw.js
+++ b/poke-sim/sw.js
@@ -17,7 +17,7 @@
 // v8-supabase-live [2026-04-27] — Supabase DB fully wired (real URL + anon key in supabase_adapter.js)
 // v7-phase4c2      — previous
 
-const CACHE_NAME = 'champions-sim-v14-fix-bundle-script-break';
+const CACHE_NAME = 'champions-sim-v15-m8-priors';
 const SPRITE_CACHE = 'champions-sprites-v1';
 
 const APP_ASSETS = [

--- a/poke-sim/tests/_db_helpers.js
+++ b/poke-sim/tests/_db_helpers.js
@@ -34,6 +34,8 @@ function _resetMockState(seed) {
   // M5 tables
   if (!mockState.teams)                   mockState.teams = [];
   if (!mockState.team_members)            mockState.team_members = [];
+  // M8 tables
+  if (!mockState.prior_snapshots)         mockState.prior_snapshots = [];
   // Convenience top-level mirrors for T-save-11
   mockState.wins = 0; mockState.losses = 0; mockState.draws = 0;
 }
@@ -50,6 +52,11 @@ function _chain(table, state) {
   var pendingInsert = null;
   var pendingDelete = false;
   var eqFilters = [];
+  var lteFilters = [];
+  var pendingSelect = false;
+  var orderCol = null;
+  var orderAsc = true;
+  var limitN = null;
 
   function _resolveResult() {
     if (mockErrorMode) {
@@ -87,19 +94,43 @@ function _chain(table, state) {
       }
       return { data: inserted, error: null };
     }
+    // Apply eq and lte filters for SELECT queries
+    var filtered = rows.slice();
+    if (pendingSelect && (eqFilters.length > 0 || lteFilters.length > 0)) {
+      eqFilters.forEach(function(f) {
+        filtered = filtered.filter(function(row) { return row[f.col] === f.val; });
+      });
+      lteFilters.forEach(function(f) {
+        filtered = filtered.filter(function(row) { return row[f.col] <= f.val; });
+      });
+      // Apply ordering
+      if (orderCol) {
+        filtered.sort(function(a, b) {
+          if (a[orderCol] < b[orderCol]) return orderAsc ? -1 : 1;
+          if (a[orderCol] > b[orderCol]) return orderAsc ? 1 : -1;
+          return 0;
+        });
+      }
+      // Apply limit
+      if (limitN !== null) {
+        filtered = filtered.slice(0, limitN);
+      }
+      return { data: filtered, error: null };
+    }
     return { data: rows, error: null };
   }
 
   var self = {
-    select: function () { return self; },
+    select: function () { pendingSelect = true; return self; },
     insert: function (rows) { pendingInsert = rows; return self; },
     upsert: function (rows) { pendingInsert = rows; return self; },
     update: function () { return self; },
     delete: function () { pendingDelete = true; return self; },
     eq:     function (col, val) { eqFilters.push({ col: col, val: val }); return self; },
+    lte:    function (col, val) { lteFilters.push({ col: col, val: val }); return self; },
     in:     function () { return self; },
-    order:  function () { return self; },
-    limit:  function () { return self; },
+    order:  function (col, opts) { orderCol = col; orderAsc = opts && opts.ascending !== undefined ? opts.ascending : true; return self; },
+    limit:  function (n) { limitN = n; return self; },
     single: function () { var r = _resolveResult(); return Promise.resolve({ data: (r.data && r.data[0]) || null, error: r.error }); },
     then:   function (resolve) { 
       var result = _resolveResult();


### PR DESCRIPTION
<!-- Thanks for contributing. Please fill out this checklist. -->

## Summary

<!-- What does this PR change? One or two sentences. -->

## Linked Issues

<!-- Use `Refs #N` not `Fixes #N` (we close issues manually after verifying evidence). -->
Refs #

## Type of Change

- [ ] Bug fix (engine, data, or UI)
- [ ] Mechanic correction (cite primary source below)
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] Test / tooling

## Primary Source Citations

<!-- Required for any mechanic or data change. Link Game8, Bulbapedia, RotomLabs, Victory Road, Serebii, or an official patch note. -->

-
-

## Files Touched

<!-- Tick the ones modified. -->
- [ ] `poke-sim/data.js`
- [ ] `poke-sim/engine.js`
- [ ] `poke-sim/ui.js`
- [ ] `poke-sim/style.css`
- [ ] `poke-sim/index.html`
- [ ] `poke-sim/legality.js`
- [ ] `poke-sim/strategy-injectable.js`
- [ ] `poke-sim/pokemon-champion-2026.html` (rebuilt bundle)
- [ ] Root-level spec / doc (`CHAMPIONS_MECHANICS_SPEC.md`, etc.)

## Test Evidence

<!-- Paste output or link to artifacts. -->

- [ ] Syntax check: `node -c data.js engine.js ui.js` passes
- [ ] Coverage tests: `/tmp/coverage_tests.js` = N/N
- [ ] Audit run: `/tmp/audit.js` = 0 JS errors, XXXX battles, Ys elapsed
- [ ] Bundle rebuilt: `python3 tools/build.py` ran from repo root, size recorded: `pokemon-champion-2026.html` = NNN KB
- [ ] Bundle freshness CI check passes (green checkmark on this PR)

```
<!-- paste key test output here -->
```

## Breaking / Behavior Changes

<!-- Describe any win-rate shifts, UI flow changes, or data shape changes. If none, say "None". -->

## Checklist

- [ ] Followed the draft-first rule for non-trivial changes (diff draft reviewed before source edits)
- [ ] No em-dashes in commit messages
- [ ] New globals referenced during init use `var` (TDZ-safe)
- [ ] Updated `CHAMPIONS_MECHANICS_SPEC.md` if mechanic behavior changed
- [ ] If `engine.js`, `data.js`, `ui.js`, `style.css`, `index.html`, or `strategy-injectable.js` changed: ran `python3 tools/build.py` and committed `pokemon-champion-2026.html`
- [ ] If `engine.js`, `data.js`, `ui.js`, `style.css` changed: ran `./tools/release.sh <tag>` and committed `sw.js`
- [ ] Updated `MASTER_PROMPT.md` to reflect this change (new feature, ticket, or infra update)
