### PR TITLE
Enable GitHub Pages workflow deployment

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -25,6 +25,8 @@ jobs:
       - uses: actions/checkout@v4
 
       - uses: actions/configure-pages@v5
+        with:
+          enablement: true
 
       - name: Inject Supabase anon runtime config
         env:


### PR DESCRIPTION
Adds the configure-pages enablement flag so the Pages workflow can create/enable the Pages site on first deploy. The workflow already injects SUPABASE_URL and SUPABASE_ANON_KEY from repo secrets into the Pages artifact without committing credentials.