### PR TITLE
Align shared 29-team catalog and DB seed

### DIFF
--- a/poke-sim/MASTER_PROMPT.md
+++ b/poke-sim/MASTER_PROMPT.md
@@ -43,7 +43,7 @@ Pokemon-Champions-Sim-Planner/
 ├── poke-sim/
 │   ├── index.html                  ← main app shell, all tabs, PWA meta tags, SW reg
 │   ├── style.css                   ← full mobile-first dark theme
-│   ├── data.js                     ← BASE_STATS, POKEMON_TYPES_DB (500+ mons), TEAMS (13 teams)
+│   ├── data.js                     ← BASE_STATS, POKEMON_TYPES_DB (500+ mons), TEAMS (29 teams)
 │   ├── engine.js                   ← battle sim engine, Bo series runner, damage formula
 │   ├── ui.js                       ← all UI logic, team selects, import/export, pilot guide, PDF
 │   ├── storage_adapter.js          ← localStorage wrapper API (Issue #79, PR #134/#135/#137)
@@ -56,7 +56,8 @@ Pokemon-Champions-Sim-Planner/
 │   ├── pokemon-champion-2026.html  ← REBUILT BUNDLE (never edit directly — 710 KB)
 │   ├── db/
 │   │   ├── schema_v1.sql           ← 8-table Supabase schema (run first)
-│   │   ├── seed_teams_v1.sql       ← 13 tournament teams seed data (run second)
+│   │   ├── seed_teams_v2.sql       ← Generated 29-team fresh-DB/reference seed
+│   │   ├── migrations/             ← Timestamped migrations, including the 2026-05-24 non-destructive shared seed repair
 │   │   ├── rls_policies_v1.sql     ← Row Level Security policies (run third)
 │   │   └── README_DB.md
 │   ├── tools/
@@ -96,26 +97,27 @@ cd poke-sim && npx serve .
 
 ## SUPABASE DATABASE LAYER — CURRENT STATUS
 
-### Live status (2026-04-27)
-Supabase project `ymlahqnshgiarpbgxehp` (us-west-2, Postgres 17.6, ACTIVE_HEALTHY) is up. Schema, seed, and RLS were applied via the SQL editor. The adapter is scaffolded but NOT yet wired into the runtime — that's what the active integration branch handles.
+### Live status (2026-05-24)
+Supabase project `ymlahqnshgiarpbgxehp` (us-west-2, Postgres 17.6, ACTIVE_HEALTHY) is up. Schema, RLS, adapter wiring, and analysis persistence are active. Current canonical seed target is 29 teams; existing live DBs with analysis history should use `poke-sim/db/migrations/2026_05_24_align_shared_29_team_catalog.sql` instead of delete-first seed files.
 
 ### What exists in the repo
 | File | Status |
 |---|---|
 | `poke-sim/db/schema_v1.sql` | ✅ Applied — 8 tables live (`rulesets`, `teams`, `team_members`, `prior_snapshots`, `golden_battles`, `analyses`, `analysis_win_conditions`, `analysis_logs`) |
-| `poke-sim/db/seed_teams_v1.sql` | ⚠️ Applied — only 3 of 22 teams seeded; M2 backfills the remaining 19 |
+| `poke-sim/db/seed_teams_v2.sql` | Generated 29-team fresh-DB/reference seed; do not use delete-first seed files on live DBs with analysis history |
+| `poke-sim/db/migrations/2026_05_24_align_shared_29_team_catalog.sql` | Non-destructive live DB seed alignment path |
 | `poke-sim/db/rls_policies_v1.sql` | ✅ Applied — anon SELECT everywhere, anon INSERT only on `analyses*` |
 | `poke-sim/supabase_adapter.js` | ✅ In repo — `loadTeamsFromDB`, `saveAnalysis`, `loadRecentAnalyses`. Global is `window.SupabaseAdapter` (NOT `supabase`). |
 | `poke-sim/POKE_SIM_DB_INTEGRATION_PLAN_v2.md` | ✅ Canonical 9-module plan, supersedes v1 drafts |
 | `poke-sim/POKE_SIM_DB_INTEGRATION_TDD_PLAN.md` | ✅ TDD companion plan — ~111 cases across 8 suites, RED-then-GREEN per module |
 
-### Active integration branch — `integration/poke-sim-db`
-All 9 module impls land on this branch. Each module is its own PR; merge into `main` only after the module's tests are GREEN.
+### Historical integration branch — `integration/poke-sim-db`
+This table is retained as rollout context. Current DB seed work should follow live GitHub issues/PRs and the 29-team shared seed state.
 
 | Module | Linear | Status |
 |---|---|---|
-| **M1** Wire adapter + supabase-js CDN into `index.html` and bundle | [POK-17](https://linear.app/poke-e-sim/issue/POK-17) | 🟡 In review (PR #161) |
-| M2 Backfill team seed 3 → 22 + add `teams.metadata jsonb` | [POK-18](https://linear.app/poke-e-sim/issue/POK-18) | Pending |
+| **M1** Wire adapter + supabase-js CDN into `index.html` and bundle | [POK-17](https://linear.app/poke-e-sim/issue/POK-17) | Historical rollout item; adapter wiring is active |
+| M2 Backfill team seed | [POK-18](https://linear.app/poke-e-sim/issue/POK-18) | Current repo seed target is 29 teams; use non-destructive repair for live DBs |
 | M3 `loadTeamsFromDB` becomes awaited source of truth on init | [POK-19](https://linear.app/poke-e-sim/issue/POK-19) | Pending |
 | M4 Persist `runBoSeries` results via `SupabaseAdapter.saveAnalysis` | [POK-20](https://linear.app/poke-e-sim/issue/POK-20) | Pending |
 | M5 Persist imported / Set-Editor teams (upsert teams + team_members) | [POK-21](https://linear.app/poke-e-sim/issue/POK-21) | Pending |
@@ -376,10 +378,10 @@ The old top-level `var COVERAGE_CHECKS` workaround is gone. Keep the lazy-init p
 
 ---
 
-## NEXT ACTIONS (as of 2026-04-27)
+## NEXT ACTIONS (as of 2026-05-24)
 
-1. **Land M1 (PR #161)** — wires `supabase_adapter.js` + supabase-js CDN into `index.html` and the bundle. Gate: all 16 cases in `db_m1_wiring_tests.js` GREEN, plus the existing 302-case engine suite still GREEN.
-2. **Open M2** ([POK-18](https://linear.app/poke-e-sim/issue/POK-18)) — backfill team seed 3 → 22 + add `teams.metadata jsonb`. Gate: `db_m2_seed_tests.js` GREEN; `select count(*) from teams` returns 22 in Supabase.
+1. **M1 historical rollout completed** — adapter wiring is active.
+2. **M2 seed alignment** ([POK-18](https://linear.app/poke-e-sim/issue/POK-18)) — align live DB to the reviewed 29-team seed with `2026_05_24_align_shared_29_team_catalog.sql`. Gate: `db_m2_seed_tests.js` GREEN; `select count(*) from teams` returns 29 in Supabase.
 3. **Open M3** ([POK-19](https://linear.app/poke-e-sim/issue/POK-19)) — `loadTeamsFromDB` becomes the awaited source of truth on init. Gate: `db_m3_init_tests.js` GREEN; offline fallback verified.
 4. **Open M4** ([POK-20](https://linear.app/poke-e-sim/issue/POK-20)) — persist `runBoSeries` results via `SupabaseAdapter.saveAnalysis`. Gate: `db_m4_save_tests.js` GREEN; one row in `analyses` per Bo run.
 5. After M4 lands: fan out M5/M6/M7 in parallel; finish with M9 hardening. M8 stays deferred.
@@ -448,10 +450,10 @@ RUN_LIVE_DB=1 SUPABASE_URL='https://ymlahqnshgiarpbgxehp.supabase.co' SUPABASE_K
     node tests/db_m2_seed_tests.js
 ```
 
-### Updated NEXT ACTIONS (as of 2026-04-27 22:19 EDT)
-1. ✅ **M1 landed** — PR #161 green, awaiting merge.
-2. **Move POK-17 → In Review → Done** in Linear once PR #161 merges.
-3. **Start M2 (POK-18)** — verify `seed_teams_v1.sql` loaded in Supabase (`ymlahqnshgiarpbgxehp`); run `db_m2_seed_tests.js` with `RUN_LIVE_DB=1` to flip RED → GREEN; backfill team seed 3 → 22; add `teams.metadata jsonb`.
+### Updated NEXT ACTIONS (as of 2026-05-24)
+1. ✅ **M1 historical rollout completed** — adapter wiring is active.
+2. **Seed repair / alignment (POK-18)** — run `db_m2_seed_tests.js` with `RUN_LIVE_DB=1` when credentials are available; current expected count is 29 teams.
+3. **Apply shared seed repair** — after review/merge, run `2026_05_24_align_shared_29_team_catalog.sql` through the Supabase DB Migration workflow.
 4. **M3 (POK-19)** — `loadTeamsFromDB` becomes awaited source of truth on init; offline fallback verified.
 5. **M4 (POK-20)** — persist `runBoSeries` results via `SupabaseAdapter.saveAnalysis`.
 6. **M9 stretch** — wire `tests/_run_all_db.sh` into `.github/workflows/` so DB suites run on every PR (currently only bundle-freshness + cache-bump checks run).

--- a/poke-sim/data.js
+++ b/poke-sim/data.js
@@ -1020,7 +1020,7 @@ const TEAMS = {
         "evs": {
           "hp": 2,
           "atk": 0,
-          "def": 0,
+          "def": 32,
           "spa": 32,
           "spd": 0,
           "spe": 32
@@ -1119,7 +1119,7 @@ const TEAMS = {
       },
       {
         "name": "Sinistcha",
-        "item": "Mental Herb",
+        "item": "Sitrus Berry",
         "ability": "Hospitality",
         "nature": "Bold",
         "evs": {
@@ -1394,7 +1394,7 @@ const TEAMS = {
       },
       {
         "name": "Farigiraf",
-        "item": "Sitrus Berry",
+        "item": "Mental Herb",
         "ability": "Armor Tail",
         "nature": "Relaxed",
         "evs": {
@@ -1415,7 +1415,7 @@ const TEAMS = {
       },
       {
         "name": "Sinistcha",
-        "item": "Mental Herb",
+        "item": "Sitrus Berry",
         "ability": "Hospitality",
         "nature": "Bold",
         "evs": {
@@ -2132,7 +2132,7 @@ const TEAMS = {
       },
       {
         "name": "Milotic",
-        "item": "Mystic Water",
+        "item": "Leftovers",
         "ability": "Competitive",
         "nature": "Calm",
         "evs": {
@@ -2153,7 +2153,7 @@ const TEAMS = {
       },
       {
         "name": "Sinistcha",
-        "item": "Mental Herb",
+        "item": "Sitrus Berry",
         "ability": "Hospitality",
         "nature": "Bold",
         "evs": {
@@ -3055,7 +3055,7 @@ const TEAMS = {
         "ability": "Defiant",
         "nature": "Adamant",
         "nature_source": "archetype_default",
-        "evs": {"hp": 4, "atk": 252, "def": 0, "spa": 0, "spd": 0, "spe": 252},
+        "evs": {"hp": 1, "atk": 32, "def": 0, "spa": 0, "spd": 0, "spe": 32},
         "ev_source": "archetype_default",
         "moves": ["Kowtow Cleave", "Sucker Punch", "Low Kick", "Protect"],
         "tera": "Dark",
@@ -3104,7 +3104,7 @@ const TEAMS = {
         "ability": "Unnerve",
         "nature": "Jolly",
         "nature_source": "archetype_default",
-        "evs": {"hp": 4, "atk": 252, "def": 0, "spa": 0, "spd": 0, "spe": 252},
+        "evs": {"hp": 1, "atk": 32, "def": 0, "spa": 0, "spd": 0, "spe": 32},
         "ev_source": "archetype_default",
         "moves": ["Tailwind", "Dual Wingbeat", "Rock Slide", "Protect"],
         "tera": "Flying",
@@ -3149,7 +3149,7 @@ const TEAMS = {
         "ability": "Mega Sol",
         "nature": "Modest",
         "nature_source": "archetype_default",
-        "evs": {"hp": 4, "atk": 0, "def": 0, "spa": 252, "spd": 0, "spe": 252},
+        "evs": {"hp": 1, "atk": 0, "def": 0, "spa": 32, "spd": 0, "spe": 32},
         "ev_source": "archetype_default",
         "moves": ["Solar Beam", "Weather Ball", "Dazzling Gleam", "Protect"],
         "tera": "Fairy",
@@ -3185,7 +3185,7 @@ const TEAMS = {
         "ability": "Adaptability",
         "nature": "Adamant",
         "nature_source": "archetype_default",
-        "evs": {"hp": 4, "atk": 252, "def": 0, "spa": 0, "spd": 0, "spe": 252},
+        "evs": {"hp": 1, "atk": 32, "def": 0, "spa": 0, "spd": 0, "spe": 32},
         "ev_source": "archetype_default",
         "moves": ["Wave Crash", "Flip Turn", "Aqua Jet", "Last Respects"],
         "tera": "Ghost",
@@ -3197,7 +3197,7 @@ const TEAMS = {
         "ability": "Drizzle",
         "nature": "Modest",
         "nature_source": "archetype_default",
-        "evs": {"hp": 252, "atk": 0, "def": 4, "spa": 252, "spd": 0, "spe": 0},
+        "evs": {"hp": 32, "atk": 0, "def": 1, "spa": 32, "spd": 0, "spe": 0},
         "ev_source": "archetype_default",
         "moves": ["Weather Ball", "Hurricane", "Tailwind", "Protect"],
         "tera": "Ghost",
@@ -3209,7 +3209,7 @@ const TEAMS = {
         "ability": "Unburden",
         "nature": "Jolly",
         "nature_source": "archetype_default",
-        "evs": {"hp": 4, "atk": 252, "def": 0, "spa": 0, "spd": 0, "spe": 252},
+        "evs": {"hp": 1, "atk": 32, "def": 0, "spa": 0, "spd": 0, "spe": 32},
         "ev_source": "archetype_default",
         "moves": ["Close Combat", "Dire Claw", "Fake Out", "Protect"],
         "tera": "Stellar",
@@ -3292,7 +3292,7 @@ const TEAMS = {
         "ability": "Unburden",
         "nature": "Jolly",
         "nature_source": "archetype_default",
-        "evs": {"hp": 4, "atk": 252, "def": 0, "spa": 0, "spd": 0, "spe": 252},
+        "evs": {"hp": 1, "atk": 32, "def": 0, "spa": 0, "spd": 0, "spe": 32},
         "ev_source": "archetype_default",
         "moves": ["Close Combat", "Dire Claw", "Fake Out", "Coaching"],
         "tera": "Fighting",
@@ -3412,7 +3412,7 @@ const TEAMS = {
         "ability": "Defiant",
         "nature": "Adamant",
         "nature_source": "archetype_default",
-        "evs": {"hp": 4, "atk": 252, "def": 0, "spa": 0, "spd": 0, "spe": 252},
+        "evs": {"hp": 1, "atk": 32, "def": 0, "spa": 0, "spd": 0, "spe": 32},
         "ev_source": "archetype_default",
         "moves": ["Kowtow Cleave", "Sucker Punch", "Iron Head", "Swords Dance"],
         "tera": "Dark",
@@ -3469,7 +3469,7 @@ const TEAMS = {
         "ability": "Gale Wings",
         "nature": "Jolly",
         "nature_source": "archetype_default",
-        "evs": {"hp": 4, "atk": 252, "def": 0, "spa": 0, "spd": 0, "spe": 252},
+        "evs": {"hp": 1, "atk": 32, "def": 0, "spa": 0, "spd": 0, "spe": 32},
         "ev_source": "archetype_default",
         "moves": ["Protect", "Dual Wingbeat", "Flare Blitz", "Tailwind"],
         "tera": "Flying",
@@ -3481,7 +3481,7 @@ const TEAMS = {
         "ability": "Rough Skin",
         "nature": "Jolly",
         "nature_source": "archetype_default",
-        "evs": {"hp": 4, "atk": 252, "def": 0, "spa": 0, "spd": 0, "spe": 252},
+        "evs": {"hp": 1, "atk": 32, "def": 0, "spa": 0, "spd": 0, "spe": 32},
         "ev_source": "archetype_default",
         "moves": ["Protect", "Rock Slide", "Earthquake", "Dragon Claw"],
         "tera": "Steel",
@@ -3529,7 +3529,7 @@ const TEAMS = {
         "ability": "Fairy Aura",
         "nature": "Timid",
         "nature_source": "archetype_default",
-        "evs": {"hp": 4, "atk": 0, "def": 0, "spa": 252, "spd": 0, "spe": 252},
+        "evs": {"hp": 1, "atk": 0, "def": 0, "spa": 32, "spd": 0, "spe": 32},
         "ev_source": "archetype_default",
         "moves": ["Protect", "Light of Ruin", "Dazzling Gleam", "Moonblast"],
         "tera": "Fairy",
@@ -3574,7 +3574,7 @@ const TEAMS = {
         "ability": "Adaptability",
         "nature": "Adamant",
         "nature_source": "archetype_default",
-        "evs": {"hp": 4, "atk": 252, "def": 0, "spa": 0, "spd": 0, "spe": 252},
+        "evs": {"hp": 1, "atk": 32, "def": 0, "spa": 0, "spd": 0, "spe": 32},
         "ev_source": "archetype_default",
         "moves": ["Wave Crash", "Last Respects", "Icy Wind", "Flip Turn"],
         "tera": "Water",
@@ -3796,7 +3796,7 @@ const TEAMS = {
         "ability": "Stance Change",
         "nature": "Brave",
         "nature_source": "archetype_default",
-        "evs": {"hp": 252, "atk": 0, "def": 4, "spa": 252, "spd": 0, "spe": 0},
+        "evs": {"hp": 32, "atk": 0, "def": 1, "spa": 32, "spd": 0, "spe": 0},
         "ev_source": "archetype_default",
         "ivs": { "hp":31, "atk":31, "def":31, "spa":31, "spd":31, "spe":0 },
         "moves": ["Poltergeist", "Close Combat", "Shadow Sneak", "King's Shield"],
@@ -3821,7 +3821,7 @@ const TEAMS = {
         "ability": "Rough Skin",
         "nature": "Jolly",
         "nature_source": "archetype_default",
-        "evs": {"hp": 4, "atk": 252, "def": 0, "spa": 0, "spd": 0, "spe": 252},
+        "evs": {"hp": 1, "atk": 32, "def": 0, "spa": 0, "spd": 0, "spe": 32},
         "ev_source": "archetype_default",
         "moves": ["Dragon Claw", "Earthquake", "Rock Slide", "Protect"],
         "tera": "Ground",
@@ -3833,7 +3833,7 @@ const TEAMS = {
         "ability": "Defiant",
         "nature": "Adamant",
         "nature_source": "archetype_default",
-        "evs": {"hp": 4, "atk": 252, "def": 0, "spa": 0, "spd": 0, "spe": 252},
+        "evs": {"hp": 1, "atk": 32, "def": 0, "spa": 0, "spd": 0, "spe": 32},
         "ev_source": "archetype_default",
         "moves": ["Kowtow Cleave", "Sucker Punch", "Low Kick", "Protect"],
         "tera": "Dark",
@@ -3845,11 +3845,326 @@ const TEAMS = {
         "ability": "Adaptability",
         "nature": "Adamant",
         "nature_source": "archetype_default",
-        "evs": {"hp": 4, "atk": 252, "def": 0, "spa": 0, "spd": 0, "spe": 252},
+        "evs": {"hp": 1, "atk": 32, "def": 0, "spa": 0, "spd": 0, "spe": 32},
         "ev_source": "archetype_default",
         "moves": ["Wave Crash", "Last Respects", "Aqua Jet", "Protect"],
         "tera": "Water",
         "role": "Revenge Killer"
+      }
+    ]
+  },
+  "fedecampovgc_aerodactyl_ariados": {
+    "name": "FedeCampoVGC — Aerodactyl Ariados",
+    "label": "MAY META",
+    "style": "speed_sun_pressure",
+    "description": "Current May 2026 public meta-index roster built around Mega Aerodactyl + Mega Charizard Y pressure. Rental: AV7NTVGB10.",
+    "champion_pack_id": "fedecampovgc_aerodactyl_ariados_may2026_v1",
+    "format": "champions",
+    "formatid": "champions-vgc-2026-regma",
+    "gametype": "doubles",
+    "ruleset": ["Species Clause", "Item Clause", "Bring 6 Pick 4", "Level 50"],
+    "source": "preloaded",
+    "origin": {
+      "url": "https://pokemonchampionsmeta.net/",
+      "player": "Federico Camporesi",
+      "event": "Public meta index (May 1, 2026) · rental AV7NTVGB10"
+    },
+    "provenance": {
+      "roster_source": "pokemon_champions_meta_index",
+      "spread_source": "archetype_default",
+      "author": "Federico Camporesi",
+      "url": "https://pokemonchampionsmeta.net/",
+      "status": "species-forms-verified-sets-inferred"
+    },
+    "legality_status": "legal_inferred",
+    "legality_notes": "Species/forms verified from the current public Champions meta index. Full sets are inferred because the index does not expose a raw export in-repo.",
+    "assumption_register": [
+      "Species/forms verified from the public May 1, 2026 Champions meta index entry.",
+      "Items, abilities, moves, EVs, natures, and Tera types were inferred from current Reg M-A archetypes.",
+      "Team carries two Mega-capable species; actual per-game Mega choice remains player-selected in battle."
+    ],
+    "members": [
+      {
+        "name": "Ariados",
+        "item": "Focus Sash",
+        "ability": "Insomnia",
+        "nature": "Adamant",
+        "nature_source": "archetype_default",
+        "evs": {"hp": 1, "atk": 32, "def": 0, "spa": 0, "spd": 0, "spe": 32},
+        "ev_source": "archetype_default",
+        "moves": ["Lunge", "Poison Jab", "Sucker Punch", "Protect"],
+        "tera": "Poison",
+        "role": "Utility Pressure"
+      },
+      {
+        "name": "Aerodactyl-Mega",
+        "item": "Aerodactylite",
+        "ability": "Tough Claws",
+        "nature": "Jolly",
+        "nature_source": "archetype_default",
+        "evs": {"hp": 1, "atk": 32, "def": 0, "spa": 0, "spd": 0, "spe": 32},
+        "ev_source": "archetype_default",
+        "moves": ["Tailwind", "Dual Wingbeat", "Rock Slide", "Protect"],
+        "tera": "Flying",
+        "role": "Mega Speed Control"
+      },
+      {
+        "name": "Charizard-Mega-Y",
+        "item": "Charizardite Y",
+        "ability": "Drought",
+        "nature": "Timid",
+        "nature_source": "archetype_default",
+        "evs": {"hp": 1, "atk": 0, "def": 0, "spa": 32, "spd": 0, "spe": 32},
+        "ev_source": "archetype_default",
+        "moves": ["Heat Wave", "Solar Beam", "Overheat", "Protect"],
+        "tera": "Fire",
+        "role": "Sun Breaker"
+      },
+      {
+        "name": "Basculegion",
+        "item": "Choice Scarf",
+        "ability": "Adaptability",
+        "nature": "Adamant",
+        "nature_source": "archetype_default",
+        "evs": {"hp": 1, "atk": 32, "def": 0, "spa": 0, "spd": 0, "spe": 32},
+        "ev_source": "archetype_default",
+        "moves": ["Wave Crash", "Last Respects", "Aqua Jet", "Flip Turn"],
+        "tera": "Ghost",
+        "role": "Scarf Cleaner"
+      },
+      {
+        "name": "Sylveon",
+        "item": "Leftovers",
+        "ability": "Pixilate",
+        "nature": "Modest",
+        "nature_source": "archetype_default",
+        "evs": {"hp": 32, "atk": 0, "def": 1, "spa": 32, "spd": 0, "spe": 0},
+        "ev_source": "archetype_default",
+        "moves": ["Hyper Voice", "Moonblast", "Helping Hand", "Protect"],
+        "tera": "Fairy",
+        "role": "Fairy Support"
+      },
+      {
+        "name": "Sneasler",
+        "item": "White Herb",
+        "ability": "Unburden",
+        "nature": "Jolly",
+        "nature_source": "archetype_default",
+        "evs": {"hp": 1, "atk": 32, "def": 0, "spa": 0, "spd": 0, "spe": 32},
+        "ev_source": "archetype_default",
+        "moves": ["Close Combat", "Dire Claw", "Fake Out", "Protect"],
+        "tera": "Fighting",
+        "role": "Unburden Sweeper"
+      }
+    ]
+  },
+  "swirlingroses_meganium_vivillon": {
+    "name": "swirlingroses — Meganium Vivillon Balance",
+    "label": "MAY REPLAY",
+    "style": "balance_speed",
+    "description": "May 6, 2026 Champions replay-preview roster with Sneasler / Basculegion / Incineroar / Kingambit / Meganium / Vivillon-Continental.",
+    "champion_pack_id": "swirlingroses_meganium_vivillon_may2026_v1",
+    "format": "champions",
+    "formatid": "champions-vgc-2026-regma",
+    "gametype": "doubles",
+    "ruleset": ["Species Clause", "Item Clause", "Bring 6 Pick 4", "Level 50"],
+    "source": "preloaded",
+    "origin": {
+      "url": "https://replay.pokemonshowdown.com/gen9championsvgc2026regma-2603247306",
+      "player": "swirlingroses",
+      "event": "Pokémon Showdown replay preview (Tournament battle, May 6, 2026)"
+    },
+    "provenance": {
+      "roster_source": "pokemon_showdown_replay_preview",
+      "spread_source": "archetype_default",
+      "author": "swirlingroses",
+      "url": "https://replay.pokemonshowdown.com/gen9championsvgc2026regma-2603247306",
+      "status": "species-verified-sets-inferred"
+    },
+    "legality_status": "legal_inferred",
+    "legality_notes": "Six species verified from the replay preview team line. Full sets are inferred because replay preview does not expose items, moves, or spreads.",
+    "assumption_register": [
+      "Only the six species were verified from the replay preview.",
+      "Items, abilities, moves, EVs, natures, and Tera types were inferred from current Reg M-A archetypes.",
+      "Vivillon-Continental uses Vivillon's canonical statline and typing; regional wing pattern is cosmetic for sim purposes."
+    ],
+    "members": [
+      {
+        "name": "Sneasler",
+        "item": "White Herb",
+        "ability": "Unburden",
+        "nature": "Jolly",
+        "nature_source": "archetype_default",
+        "evs": {"hp": 1, "atk": 32, "def": 0, "spa": 0, "spd": 0, "spe": 32},
+        "ev_source": "archetype_default",
+        "moves": ["Close Combat", "Dire Claw", "Fake Out", "Protect"],
+        "tera": "Fighting",
+        "role": "Unburden Sweeper"
+      },
+      {
+        "name": "Basculegion",
+        "item": "Mystic Water",
+        "ability": "Adaptability",
+        "nature": "Adamant",
+        "nature_source": "archetype_default",
+        "evs": {"hp": 1, "atk": 32, "def": 0, "spa": 0, "spd": 0, "spe": 32},
+        "ev_source": "archetype_default",
+        "moves": ["Wave Crash", "Last Respects", "Aqua Jet", "Protect"],
+        "tera": "Water",
+        "role": "Physical Cleaner"
+      },
+      {
+        "name": "Incineroar",
+        "item": "Sitrus Berry",
+        "ability": "Intimidate",
+        "nature": "Careful",
+        "nature_source": "archetype_default",
+        "evs": {"hp": 32, "atk": 1, "def": 0, "spa": 0, "spd": 32, "spe": 0},
+        "ev_source": "archetype_default",
+        "moves": ["Fake Out", "Parting Shot", "Flare Blitz", "Knock Off"],
+        "tera": "Ghost",
+        "role": "Pivot"
+      },
+      {
+        "name": "Kingambit",
+        "item": "Black Glasses",
+        "ability": "Defiant",
+        "nature": "Adamant",
+        "nature_source": "archetype_default",
+        "evs": {"hp": 1, "atk": 32, "def": 0, "spa": 0, "spd": 0, "spe": 32},
+        "ev_source": "archetype_default",
+        "moves": ["Kowtow Cleave", "Sucker Punch", "Low Kick", "Protect"],
+        "tera": "Dark",
+        "role": "Late-Game Cleaner"
+      },
+      {
+        "name": "Meganium",
+        "item": "Leftovers",
+        "ability": "Overgrow",
+        "nature": "Calm",
+        "nature_source": "archetype_default",
+        "evs": {"hp": 32, "atk": 0, "def": 1, "spa": 0, "spd": 32, "spe": 0},
+        "ev_source": "archetype_default",
+        "moves": ["Giga Drain", "Dazzling Gleam", "Leech Seed", "Protect"],
+        "tera": "Fairy",
+        "role": "Bulky Support"
+      },
+      {
+        "name": "Vivillon-Continental",
+        "item": "Focus Sash",
+        "ability": "Compound Eyes",
+        "nature": "Timid",
+        "nature_source": "archetype_default",
+        "evs": {"hp": 1, "atk": 0, "def": 0, "spa": 32, "spd": 0, "spe": 32},
+        "ev_source": "archetype_default",
+        "moves": ["Sleep Powder", "Hurricane", "Tailwind", "Protect"],
+        "tera": "Flying",
+        "role": "Fast Utility"
+      }
+    ]
+  },
+  "prro_t_floette_aerodactyl": {
+    "name": "Prro-T — Floette Aerodactyl Pressure",
+    "label": "MAY REPLAY",
+    "style": "fast_pressure",
+    "description": "May 8, 2026 Champions Bo3 replay-preview roster with Floette-Eternal / Aerodactyl / Incineroar / Garchomp / Sneasler / Basculegion.",
+    "champion_pack_id": "prro_t_floette_aerodactyl_may2026_v1",
+    "format": "champions",
+    "formatid": "champions-vgc-2026-regma",
+    "gametype": "doubles",
+    "ruleset": ["Species Clause", "Item Clause", "Bring 6 Pick 4", "Level 50"],
+    "source": "preloaded",
+    "origin": {
+      "url": "https://replay.pokemonshowdown.com/gen9championsvgc2026regma-2604413910",
+      "player": "Prro-T",
+      "event": "Pokémon Showdown replay preview (Bo3 Game 2, May 8, 2026)"
+    },
+    "provenance": {
+      "roster_source": "pokemon_showdown_replay_preview",
+      "spread_source": "archetype_default",
+      "author": "Prro-T",
+      "url": "https://replay.pokemonshowdown.com/gen9championsvgc2026regma-2604413910",
+      "status": "species-verified-sets-inferred"
+    },
+    "legality_status": "legal_inferred",
+    "legality_notes": "Six species verified from the replay preview team line. Full sets are inferred because replay preview does not expose items, moves, or spreads.",
+    "assumption_register": [
+      "Only the six species were verified from the replay preview.",
+      "Repo canonical naming normalizes replay-preview Floette-Eternal to Floette (Eternal Flower).",
+      "Items, abilities, moves, EVs, natures, and Tera types were inferred from current Reg M-A archetypes."
+    ],
+    "members": [
+      {
+        "name": "Floette (Eternal Flower)",
+        "item": "Fairy Feather",
+        "ability": "Flower Veil",
+        "nature": "Timid",
+        "nature_source": "archetype_default",
+        "evs": {"hp": 1, "atk": 0, "def": 0, "spa": 32, "spd": 0, "spe": 32},
+        "ev_source": "archetype_default",
+        "moves": ["Light of Ruin", "Dazzling Gleam", "Moonblast", "Protect"],
+        "tera": "Fairy",
+        "role": "Fairy Breaker"
+      },
+      {
+        "name": "Aerodactyl",
+        "item": "Focus Sash",
+        "ability": "Unnerve",
+        "nature": "Jolly",
+        "nature_source": "archetype_default",
+        "evs": {"hp": 1, "atk": 32, "def": 0, "spa": 0, "spd": 0, "spe": 32},
+        "ev_source": "archetype_default",
+        "moves": ["Tailwind", "Dual Wingbeat", "Rock Slide", "Protect"],
+        "tera": "Flying",
+        "role": "Speed Control"
+      },
+      {
+        "name": "Incineroar",
+        "item": "Chople Berry",
+        "ability": "Intimidate",
+        "nature": "Careful",
+        "nature_source": "archetype_default",
+        "evs": {"hp": 32, "atk": 1, "def": 0, "spa": 0, "spd": 32, "spe": 0},
+        "ev_source": "archetype_default",
+        "moves": ["Fake Out", "Parting Shot", "Flare Blitz", "Darkest Lariat"],
+        "tera": "Ghost",
+        "role": "Pivot"
+      },
+      {
+        "name": "Garchomp",
+        "item": "Soft Sand",
+        "ability": "Rough Skin",
+        "nature": "Jolly",
+        "nature_source": "archetype_default",
+        "evs": {"hp": 1, "atk": 32, "def": 0, "spa": 0, "spd": 0, "spe": 32},
+        "ev_source": "archetype_default",
+        "moves": ["Earthquake", "Dragon Claw", "Rock Slide", "Protect"],
+        "tera": "Ground",
+        "role": "Physical Pressure"
+      },
+      {
+        "name": "Sneasler",
+        "item": "White Herb",
+        "ability": "Unburden",
+        "nature": "Jolly",
+        "nature_source": "archetype_default",
+        "evs": {"hp": 1, "atk": 32, "def": 0, "spa": 0, "spd": 0, "spe": 32},
+        "ev_source": "archetype_default",
+        "moves": ["Close Combat", "Dire Claw", "Fake Out", "Protect"],
+        "tera": "Fighting",
+        "role": "Unburden Sweeper"
+      },
+      {
+        "name": "Basculegion",
+        "item": "Choice Scarf",
+        "ability": "Adaptability",
+        "nature": "Adamant",
+        "nature_source": "archetype_default",
+        "evs": {"hp": 1, "atk": 32, "def": 0, "spa": 0, "spd": 0, "spe": 32},
+        "ev_source": "archetype_default",
+        "moves": ["Wave Crash", "Last Respects", "Aqua Jet", "Flip Turn"],
+        "tera": "Ghost",
+        "role": "Scarf Cleaner"
       }
     ]
   },

--- a/poke-sim/db/README_DB.md
+++ b/poke-sim/db/README_DB.md
@@ -1,9 +1,10 @@
 # Champions Sim — Database Setup
 
-> **🔴 STATUS: P0 IN PROGRESS**
+> **STATUS: ACTIVE ALIGNMENT**
+> Last verified: 2026-05-24.
 > GitHub Issue: [#158 — Finish Supabase DB Integration](https://github.com/alfredocox/Pokemon-Champions-Sim-Planner/issues/158)
-> Owner: Alfredo
-> Blocker: Supabase project not yet provisioned. Lina must accept collaborator invite first.
+> Owner: Alfredo.
+> Current canonical team seed target is 29 teams, matching the Y Factor alignment branch.
 
 ---
 
@@ -17,11 +18,12 @@ Supabase (Postgres + RLS) + `supabase-js` v2
 | File | Purpose | Status |
 |---|---|---|
 | `schema_v1.sql` | Creates all 8 tables | ✅ Updated 2026-04-27 — added `metadata` column to `teams` |
-| `seed_teams_v2.sql` | Seeds all 13 tournament teams | ✅ Use v2 (42 KB) — supersedes v1 |
+| `seed_teams_v2.sql` | Generated seed for all 29 repo teams | Fresh-DB/reference seed only; delete-first shape is unsafe on live DBs with analysis history |
 | `rls_policies_v1.sql` | Row-level security policies | ✅ Ready to run |
+| `migrations/2026_05_24_align_shared_29_team_catalog.sql` | Non-destructive 29-team shared catalog alignment | Preferred live-DB migration after this alignment PR |
 | `README_DB.md` | This file | — |
 
-> ⚠️ Use `seed_teams_v2.sql` — NOT `seed_teams_v1.sql`. v2 has complete data for all 13 teams.
+> Do not run the delete-first `seed_teams_v2.sql` or `2026_04_28_seed_teams_v2.sql` against a live DB that already has `analyses` rows. Use `2026_05_24_align_shared_29_team_catalog.sql` instead.
 
 App layer: `poke-sim/supabase_adapter.js` — fully implemented. Browser credentials are injected at runtime through ignored local files or CI secrets; real keys must not be committed.
 UI wiring: `poke-sim/ui.js` already loads DB teams on startup and persists analyses after battle runs when the adapter is enabled.
@@ -33,10 +35,16 @@ UI wiring: `poke-sim/ui.js` already loads DB teams on startup and persists analy
 | Step | File | Notes |
 |---|---|---|
 | 1 | `schema_v1.sql` | Creates all 8 tables — run first |
-| 2 | `seed_teams_v2.sql` | Loads 13 teams — verify 13 rows in Table Editor after |
+| 2 | `seed_teams_v2.sql` | Fresh DB/reference only; loads 29 canonical teams |
 | 3 | `rls_policies_v1.sql` | Locks down security — run last |
-| 4 | Wire local or CI credentials | See below |
-| 5 | Wire `saveAnalysis()` in `ui.js` | See Adapter API section below |
+| 4 | `migrations/2026_05_24_align_shared_29_team_catalog.sql` | Existing/live DB repair path; safe with analysis FK history |
+| 5 | Wire local or CI credentials | See below |
+
+## Current Seed Repair Status (2026-05-24)
+
+- Current repo source of truth: `poke-sim/data.js` with 29 `TEAMS` entries.
+- The shared 29-team alignment migration is intentionally non-destructive for `teams` and `rulesets`: it uses UPSERTs and only replaces `team_members` for canonical repo team IDs.
+- The older generated seed files are still useful for fresh DB/bootstrap review, but their delete-first shape can fail or partially apply on a DB with existing `analyses` FK references.
 
 ---
 
@@ -223,15 +231,17 @@ The M10 live DB snapshot warning should be gone once the remote schema includes 
 | File | Purpose |
 |---|---|
 | `2026_04_27_baseline_v1.sql` | Baseline: 8 tables, indexes, triggers |
+| `2026_04_28_seed_teams_v2.sql` | Generated delete-first seed for 29 teams; do not use on live DBs with analysis history |
 | `2026_05_12_align_reg_ma_meta_sources.sql` | Adds `prior_snapshots.usage_data` if missing and seeds the current public Reg M-A source-alignment snapshot |
+| `2026_05_24_align_shared_29_team_catalog.sql` | Non-destructive shared 29-team catalog alignment for existing live DBs |
 
 ---
 
 ## Verification Checklist (Alfredo)
 
-- [ ] Supabase project created and URL/key available
+- [x] Supabase project created and URL/key available in CI
 - [ ] `schema_v1.sql` executed — tables visible in Table Editor
-- [ ] `seed_teams_v2.sql` executed — 13 rows in `teams` table
+- [ ] Current canonical seed alignment verified — 29 rows in `teams` table after `2026_05_24_align_shared_29_team_catalog.sql` runs
 - [ ] `rls_policies_v1.sql` executed — RLS enabled on all tables
 - [x] Supabase CDN `<script>` loads synchronously before `supabase_adapter.js` in `index.html`
 - [ ] Local browser smoke uses ignored `local-credentials.js`

--- a/poke-sim/db/migrations/2026_04_28_seed_teams_v2.sql
+++ b/poke-sim/db/migrations/2026_04_28_seed_teams_v2.sql
@@ -1,11 +1,11 @@
 -- Champions Sim seed data v2 (auto-generated)
--- Source: poke-sim/data.js (TEAMS literal, 26 teams)
+-- Source: poke-sim/data.js (TEAMS literal, 29 teams)
 -- Generator: poke-sim/tools/generate_seed_from_data.py
 -- DO NOT EDIT BY HAND. Re-run the generator and commit the diff.
 -- Run order: schema_v1.sql -> 2026_04_28_add_teams_metadata_column.sql -> THIS FILE -> rls_policies_v1.sql
 
 -- ============================================================
--- CLEAN SLATE: delete in reverse FK order (all 26 team IDs)
+-- CLEAN SLATE: delete in reverse FK order (all 29 team IDs)
 -- ============================================================
 DELETE FROM team_members WHERE team_id IN (
   'player',
@@ -30,6 +30,9 @@ DELETE FROM team_members WHERE team_id IN (
   'benny_v_mega_froslass',
   'lukasjoel1_sand_gengar',
   'hiroto_imai_snow',
+  'fedecampovgc_aerodactyl_ariados',
+  'swirlingroses_meganium_vivillon',
+  'prro_t_floette_aerodactyl',
   'fabulous_sunroom',
   'sand_bulky_offense',
   'fire_ice_fullroom',
@@ -58,6 +61,9 @@ DELETE FROM teams WHERE team_id IN (
   'benny_v_mega_froslass',
   'lukasjoel1_sand_gengar',
   'hiroto_imai_snow',
+  'fedecampovgc_aerodactyl_ariados',
+  'swirlingroses_meganium_vivillon',
+  'prro_t_floette_aerodactyl',
   'fabulous_sunroom',
   'sand_bulky_offense',
   'fire_ice_fullroom',
@@ -78,7 +84,7 @@ VALUES (
 );
 
 -- ============================================================
--- TEAMS (all 26)
+-- TEAMS (all 29)
 -- ============================================================
 INSERT INTO teams (team_id, name, label, mode, ruleset_id, source, source_ref, description)
 VALUES
@@ -104,6 +110,9 @@ VALUES
   ('benny_v_mega_froslass', 'Benny V — Mega Froslass Wide League', 'WIDE LEAGUE', 'opponent', 'champions_reg_m_doubles_bo3', 'builtin', 'benny_v_champions_regma_v1', 'Mega Froslass Snow Cloak Blizzard + Basculegion Choice Scarf Last Respects + Kingambit closer. Benny V Wide League SNR #84 Rank #2 13-1-0.'),
   ('lukasjoel1_sand_gengar', 'lukasjoel1 — Sand + Mega Gengar ZGG', 'ZGG CUP', 'opponent', 'champions_reg_m_doubles_bo3', 'builtin', 'lukasjoel1_champions_regma_v1', 'Tyranitar Sand Stream + Garchomp Sand Veil + Mega Gengar Shadow Tag trap core. lukasjoel1 ZGG #1 $200 Rank #2 13-2-0.'),
   ('hiroto_imai_snow', 'Hiroto Imai — Snow + Mega Lopunny', 'CHAMPIONS CUP', 'opponent', 'champions_reg_m_doubles_bo3', 'builtin', 'hiroto_imai_snow_champions_regma_v1', 'Vanilluxe Snow Warning + Choice Scarf Blizzard spam, Mega Lopunny Fake Out disruption, Aegislash Stance Change. Hiroto Imai Champions Arena Rank #75.'),
+  ('fedecampovgc_aerodactyl_ariados', 'FedeCampoVGC — Aerodactyl Ariados', 'MAY META', 'opponent', 'champions_reg_m_doubles_bo3', 'builtin', 'fedecampovgc_aerodactyl_ariados_may2026_v1', 'Current May 2026 public meta-index roster built around Mega Aerodactyl + Mega Charizard Y pressure. Rental: AV7NTVGB10.'),
+  ('swirlingroses_meganium_vivillon', 'swirlingroses — Meganium Vivillon Balance', 'MAY REPLAY', 'opponent', 'champions_reg_m_doubles_bo3', 'builtin', 'swirlingroses_meganium_vivillon_may2026_v1', 'May 6, 2026 Champions replay-preview roster with Sneasler / Basculegion / Incineroar / Kingambit / Meganium / Vivillon-Continental.'),
+  ('prro_t_floette_aerodactyl', 'Prro-T — Floette Aerodactyl Pressure', 'MAY REPLAY', 'opponent', 'champions_reg_m_doubles_bo3', 'builtin', 'prro_t_floette_aerodactyl_may2026_v1', 'May 8, 2026 Champions Bo3 replay-preview roster with Floette-Eternal / Aerodactyl / Incineroar / Garchomp / Sneasler / Basculegion.'),
   ('fabulous_sunroom', 'Fabulous Sunroom', 'SAMPLE TEAM', 'opponent', 'champions_reg_m_doubles_bo3', 'builtin', 'fabulous_sunroom_champions_regma_v1', 'Calibration sunroom built from public sample-team archetypes and shipped legal catalog sets.'),
   ('sand_bulky_offense', 'Sand Bulky Offense', 'SAMPLE TEAM', 'opponent', 'champions_reg_m_doubles_bo3', 'builtin', 'sand_bulky_offense_champions_regma_v1', 'Calibration sand offense built from shipped legal catalog sets and public sample-team archetypes.'),
   ('fire_ice_fullroom', 'Fire and Ice Fullroom', 'SAMPLE TEAM', 'opponent', 'champions_reg_m_doubles_bo3', 'builtin', 'fire_ice_fullroom_champions_regma_v1', 'Calibration room team built from shipped legal catalog sets and public sample-team archetypes.'),
@@ -124,12 +133,12 @@ INSERT INTO team_members (team_id, slot, species, item, ability, nature, level, 
 
 -- mega_altaria
 INSERT INTO team_members (team_id, slot, species, item, ability, nature, level, evs, moves, tera_type, role_tag) VALUES
-  ('mega_altaria', 1, 'Typhlosion-Hisui', 'Choice Scarf', 'Frisk', 'Timid', 50, '{"atk":0,"def":0,"hp":2,"spa":32,"spd":0,"spe":32}'::jsonb, '["Eruption","Heat Wave","Focus Blast","Shadow Ball"]'::jsonb, NULL, 'Scarfer'),
+  ('mega_altaria', 1, 'Typhlosion-Hisui', 'Choice Scarf', 'Frisk', 'Timid', 50, '{"atk":0,"def":32,"hp":2,"spa":32,"spd":0,"spe":32}'::jsonb, '["Eruption","Heat Wave","Focus Blast","Shadow Ball"]'::jsonb, NULL, 'Scarfer'),
   ('mega_altaria', 2, 'Altaria-Mega', 'Altarianite', 'Cloud Nine', 'Modest', 50, '{"atk":0,"def":0,"hp":32,"spa":10,"spd":17,"spe":7}'::jsonb, '["Protect","Roost","Flamethrower","Hyper Voice"]'::jsonb, NULL, 'Mega Sweeper'),
   ('mega_altaria', 3, 'Whimsicott', 'Focus Sash', 'Prankster', 'Serious', 50, '{"atk":0,"def":1,"hp":1,"spa":32,"spd":0,"spe":32}'::jsonb, '["Protect","Sunny Day","Tailwind","Moonblast"]'::jsonb, NULL, 'Speed Control'),
   ('mega_altaria', 4, 'Rotom-Wash', 'Leftovers', 'Levitate', 'Modest', 50, '{"atk":0,"def":10,"hp":32,"spa":23,"spd":0,"spe":1}'::jsonb, '["Protect","Will-O-Wisp","Thunderbolt","Hydro Pump"]'::jsonb, NULL, 'Spread Attacker'),
   ('mega_altaria', 5, 'Sableye', 'Black Glasses', 'Prankster', 'Calm', 50, '{"atk":0,"def":8,"hp":32,"spa":0,"spd":26,"spe":0}'::jsonb, '["Reflect","Light Screen","Recover","Foul Play"]'::jsonb, NULL, 'Screen Setter'),
-  ('mega_altaria', 6, 'Sinistcha', 'Mental Herb', 'Hospitality', 'Bold', 50, '{"atk":0,"def":30,"hp":32,"spa":1,"spd":1,"spe":2}'::jsonb, '["Trick Room","Life Dew","Rage Powder","Matcha Gotcha"]'::jsonb, NULL, 'TR Setter');
+  ('mega_altaria', 6, 'Sinistcha', 'Sitrus Berry', 'Hospitality', 'Bold', 50, '{"atk":0,"def":30,"hp":32,"spa":1,"spd":1,"spe":2}'::jsonb, '["Trick Room","Life Dew","Rage Powder","Matcha Gotcha"]'::jsonb, NULL, 'TR Setter');
 
 -- mega_dragonite
 INSERT INTO team_members (team_id, slot, species, item, ability, nature, level, evs, moves, tera_type, role_tag) VALUES
@@ -145,8 +154,8 @@ INSERT INTO team_members (team_id, slot, species, item, ability, nature, level, 
   ('mega_houndoom', 1, 'Houndoom-Mega', 'Houndoominite', 'Solar Power', 'Timid', 50, '{"atk":0,"def":0,"hp":1,"spa":32,"spd":1,"spe":32}'::jsonb, '["Protect","Scorching Sands","Dark Pulse","Heat Wave"]'::jsonb, NULL, 'Mega Sweeper'),
   ('mega_houndoom', 2, 'Torkoal', 'Charcoal', 'Drought', 'Quiet', 50, '{"atk":0,"def":1,"hp":32,"spa":32,"spd":1,"spe":0}'::jsonb, '["Protect","Helping Hand","Heat Wave","Eruption"]'::jsonb, NULL, 'Sun Setter'),
   ('mega_houndoom', 3, 'Whimsicott', 'Focus Sash', 'Prankster', 'Modest', 50, '{"atk":0,"def":0,"hp":32,"spa":32,"spd":1,"spe":1}'::jsonb, '["Trick Room","Tailwind","Sunny Day","Moonblast"]'::jsonb, NULL, 'TR/Speed Control'),
-  ('mega_houndoom', 4, 'Farigiraf', 'Sitrus Berry', 'Armor Tail', 'Relaxed', 50, '{"atk":0,"def":20,"hp":26,"spa":1,"spd":19,"spe":0}'::jsonb, '["Trick Room","Helping Hand","Psychic Noise","Hyper Voice"]'::jsonb, NULL, 'TR Setter'),
-  ('mega_houndoom', 5, 'Sinistcha', 'Mental Herb', 'Hospitality', 'Bold', 50, '{"atk":0,"def":31,"hp":32,"spa":1,"spd":1,"spe":1}'::jsonb, '["Trick Room","Rage Powder","Life Dew","Matcha Gotcha"]'::jsonb, NULL, 'TR Setter'),
+  ('mega_houndoom', 4, 'Farigiraf', 'Mental Herb', 'Armor Tail', 'Relaxed', 50, '{"atk":0,"def":20,"hp":26,"spa":1,"spd":19,"spe":0}'::jsonb, '["Trick Room","Helping Hand","Psychic Noise","Hyper Voice"]'::jsonb, NULL, 'TR Setter'),
+  ('mega_houndoom', 5, 'Sinistcha', 'Sitrus Berry', 'Hospitality', 'Bold', 50, '{"atk":0,"def":31,"hp":32,"spa":1,"spd":1,"spe":1}'::jsonb, '["Trick Room","Rage Powder","Life Dew","Matcha Gotcha"]'::jsonb, NULL, 'TR Setter'),
   ('mega_houndoom', 6, 'Drampa-Mega', 'Drampanite', 'Cloud Nine', 'Quiet', 50, '{"atk":0,"def":2,"hp":32,"spa":32,"spd":0,"spe":0}'::jsonb, '["Draco Meteor","Hyper Voice","Heat Wave","Thunderbolt"]'::jsonb, NULL, 'Mega Sweeper');
 
 -- rin_sand
@@ -188,8 +197,8 @@ INSERT INTO team_members (team_id, slot, species, item, ability, nature, level, 
 -- champions_arena_2nd
 INSERT INTO team_members (team_id, slot, species, item, ability, nature, level, evs, moves, tera_type, role_tag) VALUES
   ('champions_arena_2nd', 1, 'Charizard-Mega-X', 'Charizardite X', 'Tough Claws', 'Adamant', 50, '{"atk":21,"def":1,"hp":14,"spa":0,"spd":1,"spe":29}'::jsonb, '["Flare Blitz","Dragon Claw","Dragon Dance","Protect"]'::jsonb, NULL, 'Setup Sweeper'),
-  ('champions_arena_2nd', 2, 'Milotic', 'Mystic Water', 'Competitive', 'Calm', 50, '{"atk":0,"def":22,"hp":29,"spa":1,"spd":0,"spe":14}'::jsonb, '["Icy Wind","Scald","Protect","Recover"]'::jsonb, NULL, 'Speed Control / Pivot'),
-  ('champions_arena_2nd', 3, 'Sinistcha', 'Mental Herb', 'Hospitality', 'Bold', 50, '{"atk":0,"def":5,"hp":31,"spa":1,"spd":29,"spe":0}'::jsonb, '["Matcha Gotcha","Rage Powder","Life Dew","Trick Room"]'::jsonb, NULL, 'TR Setter / Redirect'),
+  ('champions_arena_2nd', 2, 'Milotic', 'Leftovers', 'Competitive', 'Calm', 50, '{"atk":0,"def":22,"hp":29,"spa":1,"spd":0,"spe":14}'::jsonb, '["Icy Wind","Scald","Protect","Recover"]'::jsonb, NULL, 'Speed Control / Pivot'),
+  ('champions_arena_2nd', 3, 'Sinistcha', 'Sitrus Berry', 'Hospitality', 'Bold', 50, '{"atk":0,"def":5,"hp":31,"spa":1,"spd":29,"spe":0}'::jsonb, '["Matcha Gotcha","Rage Powder","Life Dew","Trick Room"]'::jsonb, NULL, 'TR Setter / Redirect'),
   ('champions_arena_2nd', 4, 'Tyranitar-Mega', 'Tyranitarite', 'Sand Stream', 'Adamant', 50, '{"atk":26,"def":1,"hp":17,"spa":0,"spd":1,"spe":21}'::jsonb, '["Rock Slide","Crunch","High Horsepower","Protect"]'::jsonb, NULL, 'Sand Setter / Physical Attacker'),
   ('champions_arena_2nd', 5, 'Incineroar', 'Sitrus Berry', 'Intimidate', 'Adamant', 50, '{"atk":5,"def":10,"hp":30,"spa":0,"spd":10,"spe":11}'::jsonb, '["Flare Blitz","Throat Chop","Fake Out","Parting Shot"]'::jsonb, NULL, 'Support / Pivot'),
   ('champions_arena_2nd', 6, 'Sneasler', 'White Herb', 'Unburden', 'Adamant', 50, '{"atk":32,"def":0,"hp":0,"spa":0,"spd":2,"spe":32}'::jsonb, '["Dire Claw","Fake Out","Close Combat","Coaching"]'::jsonb, NULL, 'Unburden Sweeper');
@@ -242,27 +251,27 @@ INSERT INTO team_members (team_id, slot, species, item, ability, nature, level, 
 -- perish_trap_gengar
 INSERT INTO team_members (team_id, slot, species, item, ability, nature, level, evs, moves, tera_type, role_tag) VALUES
   ('perish_trap_gengar', 1, 'Gengar-Mega', 'Gengarite', 'Shadow Tag', 'Timid', 50, '{"atk":0,"def":0,"hp":4,"spa":252,"spd":0,"spe":252}'::jsonb, '["Shadow Ball","Sludge Bomb","Perish Song","Protect"]'::jsonb, NULL, 'Mega Trapper'),
-  ('perish_trap_gengar', 2, 'Kingambit', 'Black Glasses', 'Defiant', 'Adamant', 50, '{"atk":252,"def":0,"hp":4,"spa":0,"spd":0,"spe":252}'::jsonb, '["Kowtow Cleave","Sucker Punch","Low Kick","Protect"]'::jsonb, NULL, 'Late-Game Sweeper'),
+  ('perish_trap_gengar', 2, 'Kingambit', 'Black Glasses', 'Defiant', 'Adamant', 50, '{"atk":32,"def":0,"hp":1,"spa":0,"spd":0,"spe":32}'::jsonb, '["Kowtow Cleave","Sucker Punch","Low Kick","Protect"]'::jsonb, NULL, 'Late-Game Sweeper'),
   ('perish_trap_gengar', 3, 'Sinistcha', 'Sitrus Berry', 'Hospitality', 'Relaxed', 50, '{"atk":0,"def":252,"hp":252,"spa":4,"spd":0,"spe":0}'::jsonb, '["Matcha Gotcha","Trick Room","Rage Powder","Protect"]'::jsonb, NULL, 'Redirection Support'),
   ('perish_trap_gengar', 4, 'Incineroar', 'Chople Berry', 'Intimidate', 'Careful', 50, '{"atk":4,"def":0,"hp":252,"spa":0,"spd":252,"spe":0}'::jsonb, '["Flare Blitz","Protect","Parting Shot","Fake Out"]'::jsonb, NULL, 'Pivot / Fake Out'),
   ('perish_trap_gengar', 5, 'Kommo-o', 'Leftovers', 'Overcoat', 'Modest', 50, '{"atk":0,"def":0,"hp":4,"spa":252,"spd":0,"spe":252}'::jsonb, '["Clanging Scales","Aura Sphere","Clangorous Soul","Protect"]'::jsonb, NULL, 'Late Cleaner'),
-  ('perish_trap_gengar', 6, 'Aerodactyl', 'Focus Sash', 'Unnerve', 'Jolly', 50, '{"atk":252,"def":0,"hp":4,"spa":0,"spd":0,"spe":252}'::jsonb, '["Tailwind","Dual Wingbeat","Rock Slide","Protect"]'::jsonb, NULL, 'Speed Control');
+  ('perish_trap_gengar', 6, 'Aerodactyl', 'Focus Sash', 'Unnerve', 'Jolly', 50, '{"atk":32,"def":0,"hp":1,"spa":0,"spd":0,"spe":32}'::jsonb, '["Tailwind","Dual Wingbeat","Rock Slide","Protect"]'::jsonb, NULL, 'Speed Control');
 
 -- rain_offense
 INSERT INTO team_members (team_id, slot, species, item, ability, nature, level, evs, moves, tera_type, role_tag) VALUES
-  ('rain_offense', 1, 'Meganium-Mega', 'Meganiumite', 'Mega Sol', 'Modest', 50, '{"atk":0,"def":0,"hp":4,"spa":252,"spd":0,"spe":252}'::jsonb, '["Solar Beam","Weather Ball","Dazzling Gleam","Protect"]'::jsonb, NULL, 'Mega Attacker'),
+  ('rain_offense', 1, 'Meganium-Mega', 'Meganiumite', 'Mega Sol', 'Modest', 50, '{"atk":0,"def":0,"hp":1,"spa":32,"spd":0,"spe":32}'::jsonb, '["Solar Beam","Weather Ball","Dazzling Gleam","Protect"]'::jsonb, NULL, 'Mega Attacker'),
   ('rain_offense', 2, 'Sableye', 'Lum Berry', 'Prankster', 'Calm', 50, '{"atk":0,"def":4,"hp":252,"spa":0,"spd":252,"spe":0}'::jsonb, '["Foul Play","Rain Dance","Light Screen","Encore"]'::jsonb, NULL, 'Prankster Support'),
   ('rain_offense', 3, 'Archaludon', 'Sitrus Berry', 'Stamina', 'Modest', 50, '{"atk":0,"def":0,"hp":4,"spa":252,"spd":0,"spe":252}'::jsonb, '["Electro Shot","Draco Meteor","Flash Cannon","Protect"]'::jsonb, NULL, 'Rain SpA'),
-  ('rain_offense', 4, 'Basculegion', 'Choice Scarf', 'Adaptability', 'Adamant', 50, '{"atk":252,"def":0,"hp":4,"spa":0,"spd":0,"spe":252}'::jsonb, '["Wave Crash","Flip Turn","Aqua Jet","Last Respects"]'::jsonb, NULL, 'Scarf Sweeper'),
-  ('rain_offense', 5, 'Pelipper', 'Focus Sash', 'Drizzle', 'Modest', 50, '{"atk":0,"def":4,"hp":252,"spa":252,"spd":0,"spe":0}'::jsonb, '["Weather Ball","Hurricane","Tailwind","Protect"]'::jsonb, NULL, 'Weather Setter'),
-  ('rain_offense', 6, 'Sneasler', 'White Herb', 'Unburden', 'Jolly', 50, '{"atk":252,"def":0,"hp":4,"spa":0,"spd":0,"spe":252}'::jsonb, '["Close Combat","Dire Claw","Fake Out","Protect"]'::jsonb, NULL, 'Unburden Sweeper');
+  ('rain_offense', 4, 'Basculegion', 'Choice Scarf', 'Adaptability', 'Adamant', 50, '{"atk":32,"def":0,"hp":1,"spa":0,"spd":0,"spe":32}'::jsonb, '["Wave Crash","Flip Turn","Aqua Jet","Last Respects"]'::jsonb, NULL, 'Scarf Sweeper'),
+  ('rain_offense', 5, 'Pelipper', 'Focus Sash', 'Drizzle', 'Modest', 50, '{"atk":0,"def":1,"hp":32,"spa":32,"spd":0,"spe":0}'::jsonb, '["Weather Ball","Hurricane","Tailwind","Protect"]'::jsonb, NULL, 'Weather Setter'),
+  ('rain_offense', 6, 'Sneasler', 'White Herb', 'Unburden', 'Jolly', 50, '{"atk":32,"def":0,"hp":1,"spa":0,"spd":0,"spe":32}'::jsonb, '["Close Combat","Dire Claw","Fake Out","Protect"]'::jsonb, NULL, 'Unburden Sweeper');
 
 -- trick_room_golurk
 INSERT INTO team_members (team_id, slot, species, item, ability, nature, level, evs, moves, tera_type, role_tag) VALUES
   ('trick_room_golurk', 1, 'Incineroar', 'Shuca Berry', 'Intimidate', 'Careful', 50, '{"atk":4,"def":0,"hp":252,"spa":0,"spd":252,"spe":0}'::jsonb, '["Flare Blitz","Throat Chop","Parting Shot","Fake Out"]'::jsonb, NULL, 'Pivot'),
   ('trick_room_golurk', 2, 'Farigiraf', 'Sitrus Berry', 'Armor Tail', 'Relaxed', 50, '{"atk":0,"def":4,"hp":252,"spa":252,"spd":0,"spe":0}'::jsonb, '["Hyper Voice","Psychic","Helping Hand","Trick Room"]'::jsonb, NULL, 'TR Setter'),
   ('trick_room_golurk', 3, 'Golurk-Mega', 'Golurkite', 'Iron Fist', 'Brave', 50, '{"atk":0,"def":4,"hp":252,"spa":252,"spd":0,"spe":0}'::jsonb, '["Protect","Headlong Rush","Poltergeist","Ice Punch"]'::jsonb, NULL, 'Mega TR Sweeper'),
-  ('trick_room_golurk', 4, 'Sneasler', 'White Herb', 'Unburden', 'Jolly', 50, '{"atk":252,"def":0,"hp":4,"spa":0,"spd":0,"spe":252}'::jsonb, '["Close Combat","Dire Claw","Fake Out","Coaching"]'::jsonb, NULL, 'Unburden'),
+  ('trick_room_golurk', 4, 'Sneasler', 'White Herb', 'Unburden', 'Jolly', 50, '{"atk":32,"def":0,"hp":1,"spa":0,"spd":0,"spe":32}'::jsonb, '["Close Combat","Dire Claw","Fake Out","Coaching"]'::jsonb, NULL, 'Unburden'),
   ('trick_room_golurk', 5, 'Torkoal', 'Charcoal', 'Drought', 'Quiet', 50, '{"atk":0,"def":4,"hp":252,"spa":252,"spd":0,"spe":0}'::jsonb, '["Protect","Heat Wave","Eruption","Weather Ball"]'::jsonb, NULL, 'TR Attacker'),
   ('trick_room_golurk', 6, 'Venusaur', 'Focus Sash', 'Chlorophyll', 'Modest', 50, '{"atk":0,"def":0,"hp":4,"spa":252,"spd":0,"spe":252}'::jsonb, '["Protect","Leaf Storm","Sludge Bomb","Sleep Powder"]'::jsonb, NULL, 'Sun Abuser / Sash');
 
@@ -272,21 +281,21 @@ INSERT INTO team_members (team_id, slot, species, item, ability, nature, level, 
   ('sun_offense_charizard', 2, 'Hatterene', 'Fairy Feather', 'Magic Bounce', 'Relaxed', 50, '{"atk":0,"def":4,"hp":252,"spa":252,"spd":0,"spe":0}'::jsonb, '["Psychic","Trick Room","Dazzling Gleam","Protect"]'::jsonb, NULL, 'TR Setter'),
   ('sun_offense_charizard', 3, 'Farigiraf', 'Sitrus Berry', 'Armor Tail', 'Relaxed', 50, '{"atk":0,"def":4,"hp":252,"spa":252,"spd":0,"spe":0}'::jsonb, '["Hyper Voice","Trick Room","Psychic","Protect"]'::jsonb, NULL, 'TR Setter 2'),
   ('sun_offense_charizard', 4, 'Torkoal', 'Charcoal', 'Drought', 'Modest', 50, '{"atk":0,"def":4,"hp":252,"spa":252,"spd":0,"spe":0}'::jsonb, '["Eruption","Weather Ball","Earth Power","Protect"]'::jsonb, NULL, 'Sun Setter'),
-  ('sun_offense_charizard', 5, 'Kingambit', 'Black Glasses', 'Defiant', 'Adamant', 50, '{"atk":252,"def":0,"hp":4,"spa":0,"spd":0,"spe":252}'::jsonb, '["Kowtow Cleave","Sucker Punch","Iron Head","Swords Dance"]'::jsonb, NULL, 'Sweeper'),
+  ('sun_offense_charizard', 5, 'Kingambit', 'Black Glasses', 'Defiant', 'Adamant', 50, '{"atk":32,"def":0,"hp":1,"spa":0,"spd":0,"spe":32}'::jsonb, '["Kowtow Cleave","Sucker Punch","Iron Head","Swords Dance"]'::jsonb, NULL, 'Sweeper'),
   ('sun_offense_charizard', 6, 'Charizard-Mega-Y', 'Charizardite Y', 'Solar Power', 'Modest', 50, '{"atk":0,"def":0,"hp":4,"spa":252,"spd":0,"spe":252}'::jsonb, '["Heat Wave","Overheat","Solar Beam","Protect"]'::jsonb, NULL, 'Mega Attacker');
 
 -- z2r_feitosa_mega_floette
 INSERT INTO team_members (team_id, slot, species, item, ability, nature, level, evs, moves, tera_type, role_tag) VALUES
-  ('z2r_feitosa_mega_floette', 1, 'Talonflame', 'Sharp Beak', 'Gale Wings', 'Jolly', 50, '{"atk":252,"def":0,"hp":4,"spa":0,"spd":0,"spe":252}'::jsonb, '["Protect","Dual Wingbeat","Flare Blitz","Tailwind"]'::jsonb, NULL, 'Priority Tailwind'),
-  ('z2r_feitosa_mega_floette', 2, 'Garchomp', 'Roseli Berry', 'Rough Skin', 'Jolly', 50, '{"atk":252,"def":0,"hp":4,"spa":0,"spd":0,"spe":252}'::jsonb, '["Protect","Rock Slide","Earthquake","Dragon Claw"]'::jsonb, NULL, 'Physical Attacker'),
+  ('z2r_feitosa_mega_floette', 1, 'Talonflame', 'Sharp Beak', 'Gale Wings', 'Jolly', 50, '{"atk":32,"def":0,"hp":1,"spa":0,"spd":0,"spe":32}'::jsonb, '["Protect","Dual Wingbeat","Flare Blitz","Tailwind"]'::jsonb, NULL, 'Priority Tailwind'),
+  ('z2r_feitosa_mega_floette', 2, 'Garchomp', 'Roseli Berry', 'Rough Skin', 'Jolly', 50, '{"atk":32,"def":0,"hp":1,"spa":0,"spd":0,"spe":32}'::jsonb, '["Protect","Rock Slide","Earthquake","Dragon Claw"]'::jsonb, NULL, 'Physical Attacker'),
   ('z2r_feitosa_mega_floette', 3, 'Basculegion', 'Sitrus Berry', 'Adaptability', 'Adamant', 50, '{"atk":252,"def":0,"hp":4,"spa":0,"spd":0,"spe":252}'::jsonb, '["Protect","Liquidation","Last Respects","Aqua Jet"]'::jsonb, NULL, 'Revenge Killer'),
   ('z2r_feitosa_mega_floette', 4, 'Kingambit', 'Black Glasses', 'Defiant', 'Adamant', 50, '{"atk":252,"def":0,"hp":4,"spa":0,"spd":0,"spe":252}'::jsonb, '["Protect","Sucker Punch","Iron Head","Kowtow Cleave"]'::jsonb, NULL, 'Late-Game Cleaner'),
   ('z2r_feitosa_mega_floette', 5, 'Sneasler', 'White Herb', 'Unburden', 'Jolly', 50, '{"atk":252,"def":0,"hp":4,"spa":0,"spd":0,"spe":252}'::jsonb, '["Protect","Close Combat","Gunk Shot","Fake Out"]'::jsonb, NULL, 'Fast Attacker'),
-  ('z2r_feitosa_mega_floette', 6, 'Floette (Eternal Flower)-Mega', 'Floettite', 'Fairy Aura', 'Timid', 50, '{"atk":0,"def":0,"hp":4,"spa":252,"spd":0,"spe":252}'::jsonb, '["Protect","Light of Ruin","Dazzling Gleam","Moonblast"]'::jsonb, NULL, 'Mega Special Wall-Breaker');
+  ('z2r_feitosa_mega_floette', 6, 'Floette (Eternal Flower)-Mega', 'Floettite', 'Fairy Aura', 'Timid', 50, '{"atk":0,"def":0,"hp":1,"spa":32,"spd":0,"spe":32}'::jsonb, '["Protect","Light of Ruin","Dazzling Gleam","Moonblast"]'::jsonb, NULL, 'Mega Special Wall-Breaker');
 
 -- benny_v_mega_froslass
 INSERT INTO team_members (team_id, slot, species, item, ability, nature, level, evs, moves, tera_type, role_tag) VALUES
-  ('benny_v_mega_froslass', 1, 'Basculegion', 'Choice Scarf', 'Adaptability', 'Adamant', 50, '{"atk":252,"def":0,"hp":4,"spa":0,"spd":0,"spe":252}'::jsonb, '["Wave Crash","Last Respects","Icy Wind","Flip Turn"]'::jsonb, NULL, 'Scarf Sweeper'),
+  ('benny_v_mega_froslass', 1, 'Basculegion', 'Choice Scarf', 'Adaptability', 'Adamant', 50, '{"atk":32,"def":0,"hp":1,"spa":0,"spd":0,"spe":32}'::jsonb, '["Wave Crash","Last Respects","Icy Wind","Flip Turn"]'::jsonb, NULL, 'Scarf Sweeper'),
   ('benny_v_mega_froslass', 2, 'Kingambit', 'Black Glasses', 'Defiant', 'Adamant', 50, '{"atk":252,"def":0,"hp":4,"spa":0,"spd":0,"spe":252}'::jsonb, '["Kowtow Cleave","Sucker Punch","Swords Dance","Protect"]'::jsonb, NULL, 'Late-Game Cleaner'),
   ('benny_v_mega_froslass', 3, 'Rotom-Heat', 'Leftovers', 'Levitate', 'Bold', 50, '{"atk":0,"def":252,"hp":252,"spa":0,"spd":4,"spe":0}'::jsonb, '["Thunderbolt","Overheat","Will-O-Wisp","Protect"]'::jsonb, NULL, 'Burn Support'),
   ('benny_v_mega_froslass', 4, 'Froslass-Mega', 'Froslassite', 'Snow Cloak', 'Timid', 50, '{"atk":0,"def":0,"hp":4,"spa":252,"spd":0,"spe":252}'::jsonb, '["Blizzard","Shadow Ball","Taunt","Protect"]'::jsonb, NULL, 'Mega Snow Attacker'),
@@ -305,11 +314,38 @@ INSERT INTO team_members (team_id, slot, species, item, ability, nature, level, 
 -- hiroto_imai_snow
 INSERT INTO team_members (team_id, slot, species, item, ability, nature, level, evs, moves, tera_type, role_tag) VALUES
   ('hiroto_imai_snow', 1, 'Lopunny-Mega', 'Lopunnite', 'Limber', 'Jolly', 50, '{"atk":252,"def":0,"hp":4,"spa":0,"spd":0,"spe":252}'::jsonb, '["Close Combat","Fake Out","Encore","Protect"]'::jsonb, NULL, 'Mega Fake Out'),
-  ('hiroto_imai_snow', 2, 'Aegislash', 'Spell Tag', 'Stance Change', 'Brave', 50, '{"atk":0,"def":4,"hp":252,"spa":252,"spd":0,"spe":0}'::jsonb, '["Poltergeist","Close Combat","Shadow Sneak","King''s Shield"]'::jsonb, NULL, 'Stance Attacker'),
+  ('hiroto_imai_snow', 2, 'Aegislash', 'Spell Tag', 'Stance Change', 'Brave', 50, '{"atk":0,"def":1,"hp":32,"spa":32,"spd":0,"spe":0}'::jsonb, '["Poltergeist","Close Combat","Shadow Sneak","King''s Shield"]'::jsonb, NULL, 'Stance Attacker'),
   ('hiroto_imai_snow', 3, 'Vanilluxe', 'Choice Scarf', 'Snow Warning', 'Modest', 50, '{"atk":0,"def":0,"hp":4,"spa":252,"spd":0,"spe":252}'::jsonb, '["Blizzard","Icy Wind","Freeze-Dry","Ice Shard"]'::jsonb, NULL, 'Snow Setter / Scarf'),
-  ('hiroto_imai_snow', 4, 'Garchomp', 'White Herb', 'Rough Skin', 'Jolly', 50, '{"atk":252,"def":0,"hp":4,"spa":0,"spd":0,"spe":252}'::jsonb, '["Dragon Claw","Earthquake","Rock Slide","Protect"]'::jsonb, NULL, 'Physical Attacker'),
-  ('hiroto_imai_snow', 5, 'Kingambit', 'Chople Berry', 'Defiant', 'Adamant', 50, '{"atk":252,"def":0,"hp":4,"spa":0,"spd":0,"spe":252}'::jsonb, '["Kowtow Cleave","Sucker Punch","Low Kick","Protect"]'::jsonb, NULL, 'Late-Game Cleaner'),
-  ('hiroto_imai_snow', 6, 'Basculegion', 'Sitrus Berry', 'Adaptability', 'Adamant', 50, '{"atk":252,"def":0,"hp":4,"spa":0,"spd":0,"spe":252}'::jsonb, '["Wave Crash","Last Respects","Aqua Jet","Protect"]'::jsonb, NULL, 'Revenge Killer');
+  ('hiroto_imai_snow', 4, 'Garchomp', 'White Herb', 'Rough Skin', 'Jolly', 50, '{"atk":32,"def":0,"hp":1,"spa":0,"spd":0,"spe":32}'::jsonb, '["Dragon Claw","Earthquake","Rock Slide","Protect"]'::jsonb, NULL, 'Physical Attacker'),
+  ('hiroto_imai_snow', 5, 'Kingambit', 'Chople Berry', 'Defiant', 'Adamant', 50, '{"atk":32,"def":0,"hp":1,"spa":0,"spd":0,"spe":32}'::jsonb, '["Kowtow Cleave","Sucker Punch","Low Kick","Protect"]'::jsonb, NULL, 'Late-Game Cleaner'),
+  ('hiroto_imai_snow', 6, 'Basculegion', 'Sitrus Berry', 'Adaptability', 'Adamant', 50, '{"atk":32,"def":0,"hp":1,"spa":0,"spd":0,"spe":32}'::jsonb, '["Wave Crash","Last Respects","Aqua Jet","Protect"]'::jsonb, NULL, 'Revenge Killer');
+
+-- fedecampovgc_aerodactyl_ariados
+INSERT INTO team_members (team_id, slot, species, item, ability, nature, level, evs, moves, tera_type, role_tag) VALUES
+  ('fedecampovgc_aerodactyl_ariados', 1, 'Ariados', 'Focus Sash', 'Insomnia', 'Adamant', 50, '{"atk":32,"def":0,"hp":1,"spa":0,"spd":0,"spe":32}'::jsonb, '["Lunge","Poison Jab","Sucker Punch","Protect"]'::jsonb, NULL, 'Utility Pressure'),
+  ('fedecampovgc_aerodactyl_ariados', 2, 'Aerodactyl-Mega', 'Aerodactylite', 'Tough Claws', 'Jolly', 50, '{"atk":32,"def":0,"hp":1,"spa":0,"spd":0,"spe":32}'::jsonb, '["Tailwind","Dual Wingbeat","Rock Slide","Protect"]'::jsonb, NULL, 'Mega Speed Control'),
+  ('fedecampovgc_aerodactyl_ariados', 3, 'Charizard-Mega-Y', 'Charizardite Y', 'Drought', 'Timid', 50, '{"atk":0,"def":0,"hp":1,"spa":32,"spd":0,"spe":32}'::jsonb, '["Heat Wave","Solar Beam","Overheat","Protect"]'::jsonb, NULL, 'Sun Breaker'),
+  ('fedecampovgc_aerodactyl_ariados', 4, 'Basculegion', 'Choice Scarf', 'Adaptability', 'Adamant', 50, '{"atk":32,"def":0,"hp":1,"spa":0,"spd":0,"spe":32}'::jsonb, '["Wave Crash","Last Respects","Aqua Jet","Flip Turn"]'::jsonb, NULL, 'Scarf Cleaner'),
+  ('fedecampovgc_aerodactyl_ariados', 5, 'Sylveon', 'Leftovers', 'Pixilate', 'Modest', 50, '{"atk":0,"def":1,"hp":32,"spa":32,"spd":0,"spe":0}'::jsonb, '["Hyper Voice","Moonblast","Helping Hand","Protect"]'::jsonb, NULL, 'Fairy Support'),
+  ('fedecampovgc_aerodactyl_ariados', 6, 'Sneasler', 'White Herb', 'Unburden', 'Jolly', 50, '{"atk":32,"def":0,"hp":1,"spa":0,"spd":0,"spe":32}'::jsonb, '["Close Combat","Dire Claw","Fake Out","Protect"]'::jsonb, NULL, 'Unburden Sweeper');
+
+-- swirlingroses_meganium_vivillon
+INSERT INTO team_members (team_id, slot, species, item, ability, nature, level, evs, moves, tera_type, role_tag) VALUES
+  ('swirlingroses_meganium_vivillon', 1, 'Sneasler', 'White Herb', 'Unburden', 'Jolly', 50, '{"atk":32,"def":0,"hp":1,"spa":0,"spd":0,"spe":32}'::jsonb, '["Close Combat","Dire Claw","Fake Out","Protect"]'::jsonb, NULL, 'Unburden Sweeper'),
+  ('swirlingroses_meganium_vivillon', 2, 'Basculegion', 'Mystic Water', 'Adaptability', 'Adamant', 50, '{"atk":32,"def":0,"hp":1,"spa":0,"spd":0,"spe":32}'::jsonb, '["Wave Crash","Last Respects","Aqua Jet","Protect"]'::jsonb, NULL, 'Physical Cleaner'),
+  ('swirlingroses_meganium_vivillon', 3, 'Incineroar', 'Sitrus Berry', 'Intimidate', 'Careful', 50, '{"atk":1,"def":0,"hp":32,"spa":0,"spd":32,"spe":0}'::jsonb, '["Fake Out","Parting Shot","Flare Blitz","Knock Off"]'::jsonb, NULL, 'Pivot'),
+  ('swirlingroses_meganium_vivillon', 4, 'Kingambit', 'Black Glasses', 'Defiant', 'Adamant', 50, '{"atk":32,"def":0,"hp":1,"spa":0,"spd":0,"spe":32}'::jsonb, '["Kowtow Cleave","Sucker Punch","Low Kick","Protect"]'::jsonb, NULL, 'Late-Game Cleaner'),
+  ('swirlingroses_meganium_vivillon', 5, 'Meganium', 'Leftovers', 'Overgrow', 'Calm', 50, '{"atk":0,"def":1,"hp":32,"spa":0,"spd":32,"spe":0}'::jsonb, '["Giga Drain","Dazzling Gleam","Leech Seed","Protect"]'::jsonb, NULL, 'Bulky Support'),
+  ('swirlingroses_meganium_vivillon', 6, 'Vivillon-Continental', 'Focus Sash', 'Compound Eyes', 'Timid', 50, '{"atk":0,"def":0,"hp":1,"spa":32,"spd":0,"spe":32}'::jsonb, '["Sleep Powder","Hurricane","Tailwind","Protect"]'::jsonb, NULL, 'Fast Utility');
+
+-- prro_t_floette_aerodactyl
+INSERT INTO team_members (team_id, slot, species, item, ability, nature, level, evs, moves, tera_type, role_tag) VALUES
+  ('prro_t_floette_aerodactyl', 1, 'Floette (Eternal Flower)', 'Fairy Feather', 'Flower Veil', 'Timid', 50, '{"atk":0,"def":0,"hp":1,"spa":32,"spd":0,"spe":32}'::jsonb, '["Light of Ruin","Dazzling Gleam","Moonblast","Protect"]'::jsonb, NULL, 'Fairy Breaker'),
+  ('prro_t_floette_aerodactyl', 2, 'Aerodactyl', 'Focus Sash', 'Unnerve', 'Jolly', 50, '{"atk":32,"def":0,"hp":1,"spa":0,"spd":0,"spe":32}'::jsonb, '["Tailwind","Dual Wingbeat","Rock Slide","Protect"]'::jsonb, NULL, 'Speed Control'),
+  ('prro_t_floette_aerodactyl', 3, 'Incineroar', 'Chople Berry', 'Intimidate', 'Careful', 50, '{"atk":1,"def":0,"hp":32,"spa":0,"spd":32,"spe":0}'::jsonb, '["Fake Out","Parting Shot","Flare Blitz","Darkest Lariat"]'::jsonb, NULL, 'Pivot'),
+  ('prro_t_floette_aerodactyl', 4, 'Garchomp', 'Soft Sand', 'Rough Skin', 'Jolly', 50, '{"atk":32,"def":0,"hp":1,"spa":0,"spd":0,"spe":32}'::jsonb, '["Earthquake","Dragon Claw","Rock Slide","Protect"]'::jsonb, NULL, 'Physical Pressure'),
+  ('prro_t_floette_aerodactyl', 5, 'Sneasler', 'White Herb', 'Unburden', 'Jolly', 50, '{"atk":32,"def":0,"hp":1,"spa":0,"spd":0,"spe":32}'::jsonb, '["Close Combat","Dire Claw","Fake Out","Protect"]'::jsonb, NULL, 'Unburden Sweeper'),
+  ('prro_t_floette_aerodactyl', 6, 'Basculegion', 'Choice Scarf', 'Adaptability', 'Adamant', 50, '{"atk":32,"def":0,"hp":1,"spa":0,"spd":0,"spe":32}'::jsonb, '["Wave Crash","Last Respects","Aqua Jet","Flip Turn"]'::jsonb, NULL, 'Scarf Cleaner');
 
 -- fabulous_sunroom
 INSERT INTO team_members (team_id, slot, species, item, ability, nature, level, evs, moves, tera_type, role_tag) VALUES

--- a/poke-sim/db/migrations/2026_05_24_align_shared_29_team_catalog.sql
+++ b/poke-sim/db/migrations/2026_05_24_align_shared_29_team_catalog.sql
@@ -1,12 +1,66 @@
--- Champions Sim seed data v2 (auto-generated)
--- Source: poke-sim/data.js (TEAMS literal, 29 teams)
--- Generator: poke-sim/tools/generate_seed_from_data.py
--- DO NOT EDIT BY HAND. Re-run the generator and commit the diff.
--- Run order: schema_v1.sql -> 2026_04_28_add_teams_metadata_column.sql -> THIS FILE -> rls_policies_v1.sql
+-- Align shared 29-team catalog across Y Factor, Alfredo, and live Supabase.
+-- Source: poke-sim/data.js TEAMS literal and generated seed_teams_v2.sql (29 teams).
+-- Purpose: make the live DB match the shared reviewed catalog without deleting referenced teams.
+-- Safe shape: transaction + ruleset/team UPSERTs + team_members replace for canonical team IDs only.
+-- No schema changes. No secrets. No destructive delete from teams/rulesets.
 
--- ============================================================
--- CLEAN SLATE: delete in reverse FK order (all 29 team IDs)
--- ============================================================
+BEGIN;
+
+INSERT INTO rulesets (ruleset_id, format_group, engine_formatid, description, custom_rules)
+VALUES (
+  'champions_reg_m_doubles_bo3',
+  'Champion',
+  'gen9championsvgc2026regma',
+  'Champions 2026 Reg M A — Doubles, bring 6 pick 4, level 50, Bo3',
+  '{"bring":6,"choose":4,"gameMode":"doubles","levelCap":50}'::jsonb
+)
+ON CONFLICT (ruleset_id) DO UPDATE SET
+  format_group = EXCLUDED.format_group,
+  engine_formatid = EXCLUDED.engine_formatid,
+  description = EXCLUDED.description,
+  custom_rules = EXCLUDED.custom_rules;
+
+INSERT INTO teams (team_id, name, label, mode, ruleset_id, source, source_ref, description)
+VALUES
+  ('player', 'TR Counter Squad', 'YOUR TEAM', 'player', 'champions_reg_m_doubles_bo3', 'builtin', 'player_tr_counter_v1', 'Fast offensive pressure with Intimidate + Will-O-Wisp support. Built to break Trick Room before it starts.'),
+  ('mega_altaria', 'Mega Altaria', 'HYBRID RAINBOW', 'opponent', 'champions_reg_m_doubles_bo3', 'builtin', 'mega_altaria_champions_regma_v1', 'Sun-rain hybrid with Trick Room threat via Sinistcha. Prankster Whimsicott provides flexible speed control.'),
+  ('mega_dragonite', 'Mega Dragonite', 'HYBRID RAINBOW', 'opponent', 'champions_reg_m_doubles_bo3', 'builtin', 'mega_dragonite_champions_regma_v1', 'Rain team with Mega Dragonite as the primary sweeper. Basculegion Adaptability + Archaludon Electro Shot under rain.'),
+  ('mega_houndoom', 'Mega Houndoom', 'HYBRID RAINBOW', 'opponent', 'champions_reg_m_doubles_bo3', 'builtin', 'mega_houndoom_champions_regma_v1', 'Sun + Trick Room hybrid. Mega Houndoom Solar Power nukes under sun. Flexible TR setters in Sinistcha, Farigiraf, Whimsicott.'),
+  ('rin_sand', 'Rin Sand', 'RIN', 'opponent', 'champions_reg_m_doubles_bo3', 'builtin', 'rin_sand_champions_regma_v1', 'Sand offense with Tyranitar + Excadrill core. Sneasler Unburden for burst speed. Dragapult for speed and spread.'),
+  ('suica_sun', 'Suica Sun', 'SUICA', 'opponent', 'champions_reg_m_doubles_bo3', 'builtin', 'suica_sun_champions_regma_v1', 'Charizard Y sun offense. Sneasler + Basculegion revenge killers. Incineroar provides Intimidate support.'),
+  ('cofagrigus_tr', 'Cofagrigus TR', 'TRICK ROOM', 'opponent', 'champions_reg_m_doubles_bo3', 'builtin', 'cofagrigus_tr_champions_regma_v1', 'Classic Trick Room team. Cofagrigus + Sinistcha lead sets TR. Slow, powerful sweepers underneath.'),
+  ('champions_arena_1st', 'Hyungwoo Shin — Champions Arena', '1ST CHAMPIONS ARENA', 'champion_pack', 'champions_reg_m_doubles_bo3', 'builtin', 'champions_arena_1st_v1', 'Mega Charizard-Y Sun with Coil Milotic secret weapon. Champions Arena winner April 2026. Rental: SQMPYRW6BP'),
+  ('champions_arena_2nd', 'Jorge Tabuyo — Champions Arena Finalist', '2ND CHAMPIONS ARENA', 'champion_pack', 'champions_reg_m_doubles_bo3', 'builtin', 'champions_arena_2nd_v1', 'Double Mega Charizard-X + Tyranitar with Sinistcha TR fallback. Rental: P08QQ5NU9C'),
+  ('champions_arena_3rd', 'Juan Benítez — Champions Arena Top 3', '3RD CHAMPIONS ARENA', 'champion_pack', 'champions_reg_m_doubles_bo3', 'builtin', 'champions_arena_3rd_v1', 'Mega Charizard-Y + Max Speed Kingambit tech. Prankster Whimsicott + Scarf Garchomp. Rental: KN6SNLGUPA'),
+  ('chuppa_balance', 'Chuppa Cross IV — Pittsburgh Champion', 'REGIONAL WINNER', 'champion_pack', 'champions_reg_m_doubles_bo3', 'builtin', 'chuppa_balance_sv_v1', 'Adaptability Basculegion + Last Respects win-con. Pittsburgh Regional champion. Focus Sash + Maushold Follow Me.'),
+  ('aurora_veil_froslass', 'Mega Froslass — Aurora Veil', 'VEIL TEAM', 'opponent', 'champions_reg_m_doubles_bo3', 'builtin', 'aurora_veil_froslass_champions_regma_v1', 'Mega Froslass Snow Warning sets instant Aurora Veil. Dragonite + Kingambit behind veil. High win-condition team.'),
+  ('kingambit_sneasler', 'Kingambit + Sneasler Core', 'META CORE', 'opponent', 'champions_reg_m_doubles_bo3', 'builtin', 'kingambit_sneasler_sv_v1', 'The #1 ranked meta core in Reg M-A. 1,329 teams tracked. Defiant Kingambit punishes Intimidate; Unburden Sneasler cleans up.'),
+  ('custom_1776995210260', 'Froslass''s Team', 'CUSTOM', 'opponent', 'champions_reg_m_doubles_bo3', 'builtin', NULL, 'Imported via Showdown paste'),
+  ('perish_trap_gengar', 'Perish Trap — Mega Gengar', 'PERISH TRAP', 'opponent', 'champions_reg_m_doubles_bo3', 'builtin', 'perish_trap_gengar_champions_regma_v1', 'Mega Gengar Shadow Tag + Perish Song trap core. Sinistcha Rage Powder redirection stalls opponents through perish countdown. Francesco Rasini Champions Arena Top 12.'),
+  ('rain_offense', 'Rain Offense — Mega Meganium', 'RAIN', 'opponent', 'champions_reg_m_doubles_bo3', 'builtin', 'rain_offense_meganium_champions_regma_v1', 'Pelipper Drizzle + Basculegion Adaptability Wave Crash + Archaludon Electro Shot rain core. Mega Meganium (Mega Sol) secondary. leoscerni LIGA DA COMUNIDADE #2 Rank #3.'),
+  ('trick_room_golurk', 'Trick Room — Mega Golurk', 'TRICK ROOM', 'opponent', 'champions_reg_m_doubles_bo3', 'builtin', 'trick_room_golurk_champions_regma_v1', 'Farigiraf Armor Tail + Trick Room setter, Mega Golurk Iron Fist Headlong Rush sweeper, Torkoal Eruption cleanup. pokefey Torneo Salida Rank #2.'),
+  ('sun_offense_charizard', 'Sun Offense — Mega Charizard Y', 'SUN', 'opponent', 'champions_reg_m_doubles_bo3', 'builtin', 'sun_offense_charizard_champions_regma_v1', 'Mega Charizard Y Drought + Torkoal Eruption + Hatterene/Farigiraf Trick Room hybrid. Jiang Jin-Hao Champions Arena Top 5.'),
+  ('z2r_feitosa_mega_floette', 'Z2R Feitosa — Mega Floette Balance', 'CHAMPIONS CUP', 'opponent', 'champions_reg_m_doubles_bo3', 'builtin', 'z2r_feitosa_champions_regma_v1', 'Mega Floette Fairy Aura Light of Ruin + Talonflame Gale Wings Tailwind + Basculegion/Kingambit dual wincon. Z2R Feitosa LIGA DA COMUNIDADE #2 Rank #2 15-0-0.'),
+  ('benny_v_mega_froslass', 'Benny V — Mega Froslass Wide League', 'WIDE LEAGUE', 'opponent', 'champions_reg_m_doubles_bo3', 'builtin', 'benny_v_champions_regma_v1', 'Mega Froslass Snow Cloak Blizzard + Basculegion Choice Scarf Last Respects + Kingambit closer. Benny V Wide League SNR #84 Rank #2 13-1-0.'),
+  ('lukasjoel1_sand_gengar', 'lukasjoel1 — Sand + Mega Gengar ZGG', 'ZGG CUP', 'opponent', 'champions_reg_m_doubles_bo3', 'builtin', 'lukasjoel1_champions_regma_v1', 'Tyranitar Sand Stream + Garchomp Sand Veil + Mega Gengar Shadow Tag trap core. lukasjoel1 ZGG #1 $200 Rank #2 13-2-0.'),
+  ('hiroto_imai_snow', 'Hiroto Imai — Snow + Mega Lopunny', 'CHAMPIONS CUP', 'opponent', 'champions_reg_m_doubles_bo3', 'builtin', 'hiroto_imai_snow_champions_regma_v1', 'Vanilluxe Snow Warning + Choice Scarf Blizzard spam, Mega Lopunny Fake Out disruption, Aegislash Stance Change. Hiroto Imai Champions Arena Rank #75.'),
+  ('fedecampovgc_aerodactyl_ariados', 'FedeCampoVGC — Aerodactyl Ariados', 'MAY META', 'opponent', 'champions_reg_m_doubles_bo3', 'builtin', 'fedecampovgc_aerodactyl_ariados_may2026_v1', 'Current May 2026 public meta-index roster built around Mega Aerodactyl + Mega Charizard Y pressure. Rental: AV7NTVGB10.'),
+  ('swirlingroses_meganium_vivillon', 'swirlingroses — Meganium Vivillon Balance', 'MAY REPLAY', 'opponent', 'champions_reg_m_doubles_bo3', 'builtin', 'swirlingroses_meganium_vivillon_may2026_v1', 'May 6, 2026 Champions replay-preview roster with Sneasler / Basculegion / Incineroar / Kingambit / Meganium / Vivillon-Continental.'),
+  ('prro_t_floette_aerodactyl', 'Prro-T — Floette Aerodactyl Pressure', 'MAY REPLAY', 'opponent', 'champions_reg_m_doubles_bo3', 'builtin', 'prro_t_floette_aerodactyl_may2026_v1', 'May 8, 2026 Champions Bo3 replay-preview roster with Floette-Eternal / Aerodactyl / Incineroar / Garchomp / Sneasler / Basculegion.'),
+  ('fabulous_sunroom', 'Fabulous Sunroom', 'SAMPLE TEAM', 'opponent', 'champions_reg_m_doubles_bo3', 'builtin', 'fabulous_sunroom_champions_regma_v1', 'Calibration sunroom built from public sample-team archetypes and shipped legal catalog sets.'),
+  ('sand_bulky_offense', 'Sand Bulky Offense', 'SAMPLE TEAM', 'opponent', 'champions_reg_m_doubles_bo3', 'builtin', 'sand_bulky_offense_champions_regma_v1', 'Calibration sand offense built from shipped legal catalog sets and public sample-team archetypes.'),
+  ('fire_ice_fullroom', 'Fire and Ice Fullroom', 'SAMPLE TEAM', 'opponent', 'champions_reg_m_doubles_bo3', 'builtin', 'fire_ice_fullroom_champions_regma_v1', 'Calibration room team built from shipped legal catalog sets and public sample-team archetypes.'),
+  ('zardx_snow_setup', 'ZardX Snow Setup', 'SAMPLE TEAM', 'opponent', 'champions_reg_m_doubles_bo3', 'builtin', 'zardx_snow_setup_champions_regma_v1', 'Calibration snow offense built from shipped legal catalog sets and public sample-team archetypes.')
+ON CONFLICT (team_id) DO UPDATE SET
+  name = EXCLUDED.name,
+  label = EXCLUDED.label,
+  mode = EXCLUDED.mode,
+  ruleset_id = EXCLUDED.ruleset_id,
+  source = EXCLUDED.source,
+  source_ref = EXCLUDED.source_ref,
+  description = EXCLUDED.description;
+
+-- Replace normalized members for shared canonical repo teams only.
 DELETE FROM team_members WHERE team_id IN (
   'player',
   'mega_altaria',
@@ -38,85 +92,6 @@ DELETE FROM team_members WHERE team_id IN (
   'fire_ice_fullroom',
   'zardx_snow_setup'
 );
-DELETE FROM teams WHERE team_id IN (
-  'player',
-  'mega_altaria',
-  'mega_dragonite',
-  'mega_houndoom',
-  'rin_sand',
-  'suica_sun',
-  'cofagrigus_tr',
-  'champions_arena_1st',
-  'champions_arena_2nd',
-  'champions_arena_3rd',
-  'chuppa_balance',
-  'aurora_veil_froslass',
-  'kingambit_sneasler',
-  'custom_1776995210260',
-  'perish_trap_gengar',
-  'rain_offense',
-  'trick_room_golurk',
-  'sun_offense_charizard',
-  'z2r_feitosa_mega_floette',
-  'benny_v_mega_froslass',
-  'lukasjoel1_sand_gengar',
-  'hiroto_imai_snow',
-  'fedecampovgc_aerodactyl_ariados',
-  'swirlingroses_meganium_vivillon',
-  'prro_t_floette_aerodactyl',
-  'fabulous_sunroom',
-  'sand_bulky_offense',
-  'fire_ice_fullroom',
-  'zardx_snow_setup'
-);
-DELETE FROM rulesets WHERE ruleset_id = 'champions_reg_m_doubles_bo3';
-
--- ============================================================
--- RULESET
--- ============================================================
-INSERT INTO rulesets (ruleset_id, format_group, engine_formatid, description, custom_rules)
-VALUES (
-  'champions_reg_m_doubles_bo3',
-  'Champion',
-  'gen9championsvgc2026regma',
-  'Champions 2026 Reg M A — Doubles, bring 6 pick 4, level 50, Bo3',
-  '{"bring":6,"choose":4,"gameMode":"doubles","levelCap":50}'::jsonb
-);
-
--- ============================================================
--- TEAMS (all 29)
--- ============================================================
-INSERT INTO teams (team_id, name, label, mode, ruleset_id, source, source_ref, description)
-VALUES
-  ('player', 'TR Counter Squad', 'YOUR TEAM', 'player', 'champions_reg_m_doubles_bo3', 'builtin', 'player_tr_counter_v1', 'Fast offensive pressure with Intimidate + Will-O-Wisp support. Built to break Trick Room before it starts.'),
-  ('mega_altaria', 'Mega Altaria', 'HYBRID RAINBOW', 'opponent', 'champions_reg_m_doubles_bo3', 'builtin', 'mega_altaria_champions_regma_v1', 'Sun-rain hybrid with Trick Room threat via Sinistcha. Prankster Whimsicott provides flexible speed control.'),
-  ('mega_dragonite', 'Mega Dragonite', 'HYBRID RAINBOW', 'opponent', 'champions_reg_m_doubles_bo3', 'builtin', 'mega_dragonite_champions_regma_v1', 'Rain team with Mega Dragonite as the primary sweeper. Basculegion Adaptability + Archaludon Electro Shot under rain.'),
-  ('mega_houndoom', 'Mega Houndoom', 'HYBRID RAINBOW', 'opponent', 'champions_reg_m_doubles_bo3', 'builtin', 'mega_houndoom_champions_regma_v1', 'Sun + Trick Room hybrid. Mega Houndoom Solar Power nukes under sun. Flexible TR setters in Sinistcha, Farigiraf, Whimsicott.'),
-  ('rin_sand', 'Rin Sand', 'RIN', 'opponent', 'champions_reg_m_doubles_bo3', 'builtin', 'rin_sand_champions_regma_v1', 'Sand offense with Tyranitar + Excadrill core. Sneasler Unburden for burst speed. Dragapult for speed and spread.'),
-  ('suica_sun', 'Suica Sun', 'SUICA', 'opponent', 'champions_reg_m_doubles_bo3', 'builtin', 'suica_sun_champions_regma_v1', 'Charizard Y sun offense. Sneasler + Basculegion revenge killers. Incineroar provides Intimidate support.'),
-  ('cofagrigus_tr', 'Cofagrigus TR', 'TRICK ROOM', 'opponent', 'champions_reg_m_doubles_bo3', 'builtin', 'cofagrigus_tr_champions_regma_v1', 'Classic Trick Room team. Cofagrigus + Sinistcha lead sets TR. Slow, powerful sweepers underneath.'),
-  ('champions_arena_1st', 'Hyungwoo Shin — Champions Arena', '1ST CHAMPIONS ARENA', 'champion_pack', 'champions_reg_m_doubles_bo3', 'builtin', 'champions_arena_1st_v1', 'Mega Charizard-Y Sun with Coil Milotic secret weapon. Champions Arena winner April 2026. Rental: SQMPYRW6BP'),
-  ('champions_arena_2nd', 'Jorge Tabuyo — Champions Arena Finalist', '2ND CHAMPIONS ARENA', 'champion_pack', 'champions_reg_m_doubles_bo3', 'builtin', 'champions_arena_2nd_v1', 'Double Mega Charizard-X + Tyranitar with Sinistcha TR fallback. Rental: P08QQ5NU9C'),
-  ('champions_arena_3rd', 'Juan Benítez — Champions Arena Top 3', '3RD CHAMPIONS ARENA', 'champion_pack', 'champions_reg_m_doubles_bo3', 'builtin', 'champions_arena_3rd_v1', 'Mega Charizard-Y + Max Speed Kingambit tech. Prankster Whimsicott + Scarf Garchomp. Rental: KN6SNLGUPA'),
-  ('chuppa_balance', 'Chuppa Cross IV — Pittsburgh Champion', 'REGIONAL WINNER', 'champion_pack', 'champions_reg_m_doubles_bo3', 'builtin', 'chuppa_balance_sv_v1', 'Adaptability Basculegion + Last Respects win-con. Pittsburgh Regional champion. Focus Sash + Maushold Follow Me.'),
-  ('aurora_veil_froslass', 'Mega Froslass — Aurora Veil', 'VEIL TEAM', 'opponent', 'champions_reg_m_doubles_bo3', 'builtin', 'aurora_veil_froslass_champions_regma_v1', 'Mega Froslass Snow Warning sets instant Aurora Veil. Dragonite + Kingambit behind veil. High win-condition team.'),
-  ('kingambit_sneasler', 'Kingambit + Sneasler Core', 'META CORE', 'opponent', 'champions_reg_m_doubles_bo3', 'builtin', 'kingambit_sneasler_sv_v1', 'The #1 ranked meta core in Reg M-A. 1,329 teams tracked. Defiant Kingambit punishes Intimidate; Unburden Sneasler cleans up.'),
-  ('custom_1776995210260', 'Froslass''s Team', 'CUSTOM', 'opponent', 'champions_reg_m_doubles_bo3', 'builtin', NULL, 'Imported via Showdown paste'),
-  ('perish_trap_gengar', 'Perish Trap — Mega Gengar', 'PERISH TRAP', 'opponent', 'champions_reg_m_doubles_bo3', 'builtin', 'perish_trap_gengar_champions_regma_v1', 'Mega Gengar Shadow Tag + Perish Song trap core. Sinistcha Rage Powder redirection stalls opponents through perish countdown. Francesco Rasini Champions Arena Top 12.'),
-  ('rain_offense', 'Rain Offense — Mega Meganium', 'RAIN', 'opponent', 'champions_reg_m_doubles_bo3', 'builtin', 'rain_offense_meganium_champions_regma_v1', 'Pelipper Drizzle + Basculegion Adaptability Wave Crash + Archaludon Electro Shot rain core. Mega Meganium (Mega Sol) secondary. leoscerni LIGA DA COMUNIDADE #2 Rank #3.'),
-  ('trick_room_golurk', 'Trick Room — Mega Golurk', 'TRICK ROOM', 'opponent', 'champions_reg_m_doubles_bo3', 'builtin', 'trick_room_golurk_champions_regma_v1', 'Farigiraf Armor Tail + Trick Room setter, Mega Golurk Iron Fist Headlong Rush sweeper, Torkoal Eruption cleanup. pokefey Torneo Salida Rank #2.'),
-  ('sun_offense_charizard', 'Sun Offense — Mega Charizard Y', 'SUN', 'opponent', 'champions_reg_m_doubles_bo3', 'builtin', 'sun_offense_charizard_champions_regma_v1', 'Mega Charizard Y Drought + Torkoal Eruption + Hatterene/Farigiraf Trick Room hybrid. Jiang Jin-Hao Champions Arena Top 5.'),
-  ('z2r_feitosa_mega_floette', 'Z2R Feitosa — Mega Floette Balance', 'CHAMPIONS CUP', 'opponent', 'champions_reg_m_doubles_bo3', 'builtin', 'z2r_feitosa_champions_regma_v1', 'Mega Floette Fairy Aura Light of Ruin + Talonflame Gale Wings Tailwind + Basculegion/Kingambit dual wincon. Z2R Feitosa LIGA DA COMUNIDADE #2 Rank #2 15-0-0.'),
-  ('benny_v_mega_froslass', 'Benny V — Mega Froslass Wide League', 'WIDE LEAGUE', 'opponent', 'champions_reg_m_doubles_bo3', 'builtin', 'benny_v_champions_regma_v1', 'Mega Froslass Snow Cloak Blizzard + Basculegion Choice Scarf Last Respects + Kingambit closer. Benny V Wide League SNR #84 Rank #2 13-1-0.'),
-  ('lukasjoel1_sand_gengar', 'lukasjoel1 — Sand + Mega Gengar ZGG', 'ZGG CUP', 'opponent', 'champions_reg_m_doubles_bo3', 'builtin', 'lukasjoel1_champions_regma_v1', 'Tyranitar Sand Stream + Garchomp Sand Veil + Mega Gengar Shadow Tag trap core. lukasjoel1 ZGG #1 $200 Rank #2 13-2-0.'),
-  ('hiroto_imai_snow', 'Hiroto Imai — Snow + Mega Lopunny', 'CHAMPIONS CUP', 'opponent', 'champions_reg_m_doubles_bo3', 'builtin', 'hiroto_imai_snow_champions_regma_v1', 'Vanilluxe Snow Warning + Choice Scarf Blizzard spam, Mega Lopunny Fake Out disruption, Aegislash Stance Change. Hiroto Imai Champions Arena Rank #75.'),
-  ('fedecampovgc_aerodactyl_ariados', 'FedeCampoVGC — Aerodactyl Ariados', 'MAY META', 'opponent', 'champions_reg_m_doubles_bo3', 'builtin', 'fedecampovgc_aerodactyl_ariados_may2026_v1', 'Current May 2026 public meta-index roster built around Mega Aerodactyl + Mega Charizard Y pressure. Rental: AV7NTVGB10.'),
-  ('swirlingroses_meganium_vivillon', 'swirlingroses — Meganium Vivillon Balance', 'MAY REPLAY', 'opponent', 'champions_reg_m_doubles_bo3', 'builtin', 'swirlingroses_meganium_vivillon_may2026_v1', 'May 6, 2026 Champions replay-preview roster with Sneasler / Basculegion / Incineroar / Kingambit / Meganium / Vivillon-Continental.'),
-  ('prro_t_floette_aerodactyl', 'Prro-T — Floette Aerodactyl Pressure', 'MAY REPLAY', 'opponent', 'champions_reg_m_doubles_bo3', 'builtin', 'prro_t_floette_aerodactyl_may2026_v1', 'May 8, 2026 Champions Bo3 replay-preview roster with Floette-Eternal / Aerodactyl / Incineroar / Garchomp / Sneasler / Basculegion.'),
-  ('fabulous_sunroom', 'Fabulous Sunroom', 'SAMPLE TEAM', 'opponent', 'champions_reg_m_doubles_bo3', 'builtin', 'fabulous_sunroom_champions_regma_v1', 'Calibration sunroom built from public sample-team archetypes and shipped legal catalog sets.'),
-  ('sand_bulky_offense', 'Sand Bulky Offense', 'SAMPLE TEAM', 'opponent', 'champions_reg_m_doubles_bo3', 'builtin', 'sand_bulky_offense_champions_regma_v1', 'Calibration sand offense built from shipped legal catalog sets and public sample-team archetypes.'),
-  ('fire_ice_fullroom', 'Fire and Ice Fullroom', 'SAMPLE TEAM', 'opponent', 'champions_reg_m_doubles_bo3', 'builtin', 'fire_ice_fullroom_champions_regma_v1', 'Calibration room team built from shipped legal catalog sets and public sample-team archetypes.'),
-  ('zardx_snow_setup', 'ZardX Snow Setup', 'SAMPLE TEAM', 'opponent', 'champions_reg_m_doubles_bo3', 'builtin', 'zardx_snow_setup_champions_regma_v1', 'Calibration snow offense built from shipped legal catalog sets and public sample-team archetypes.');
 
 -- ============================================================
 -- TEAM MEMBERS
@@ -382,3 +357,5 @@ INSERT INTO team_members (team_id, slot, species, item, ability, nature, level, 
   ('zardx_snow_setup', 4, 'Dragonite', 'Lum Berry', 'Multiscale', 'Adamant', 50, '{"atk":32,"def":0,"hp":2,"spa":0,"spd":0,"spe":32}'::jsonb, '["Extreme Speed","Dragon Dance","Fire Punch","Protect"]'::jsonb, NULL, 'Multiscale Setup Sweeper'),
   ('zardx_snow_setup', 5, 'Kingambit', 'Chople Berry', 'Supreme Overlord', 'Adamant', 50, '{"atk":32,"def":0,"hp":2,"spa":0,"spd":0,"spe":32}'::jsonb, '["Kowtow Cleave","Sucker Punch","Low Kick","Protect"]'::jsonb, NULL, 'Supreme Overlord Sweeper'),
   ('zardx_snow_setup', 6, 'Milotic', 'Life Orb', 'Competitive', 'Modest', 50, '{"atk":0,"def":0,"hp":2,"spa":32,"spd":32,"spe":0}'::jsonb, '["Blizzard","Scald","Weather Ball","Life Dew"]'::jsonb, NULL, 'Utility / Secret Weapon');
+
+COMMIT;

--- a/poke-sim/pokemon-champion-2026.html
+++ b/poke-sim/pokemon-champion-2026.html
@@ -3758,7 +3758,7 @@ const TEAMS = {
         "evs": {
           "hp": 2,
           "atk": 0,
-          "def": 0,
+          "def": 32,
           "spa": 32,
           "spd": 0,
           "spe": 32
@@ -3857,7 +3857,7 @@ const TEAMS = {
       },
       {
         "name": "Sinistcha",
-        "item": "Mental Herb",
+        "item": "Sitrus Berry",
         "ability": "Hospitality",
         "nature": "Bold",
         "evs": {
@@ -4132,7 +4132,7 @@ const TEAMS = {
       },
       {
         "name": "Farigiraf",
-        "item": "Sitrus Berry",
+        "item": "Mental Herb",
         "ability": "Armor Tail",
         "nature": "Relaxed",
         "evs": {
@@ -4153,7 +4153,7 @@ const TEAMS = {
       },
       {
         "name": "Sinistcha",
-        "item": "Mental Herb",
+        "item": "Sitrus Berry",
         "ability": "Hospitality",
         "nature": "Bold",
         "evs": {
@@ -4870,7 +4870,7 @@ const TEAMS = {
       },
       {
         "name": "Milotic",
-        "item": "Mystic Water",
+        "item": "Leftovers",
         "ability": "Competitive",
         "nature": "Calm",
         "evs": {
@@ -4891,7 +4891,7 @@ const TEAMS = {
       },
       {
         "name": "Sinistcha",
-        "item": "Mental Herb",
+        "item": "Sitrus Berry",
         "ability": "Hospitality",
         "nature": "Bold",
         "evs": {
@@ -5793,7 +5793,7 @@ const TEAMS = {
         "ability": "Defiant",
         "nature": "Adamant",
         "nature_source": "archetype_default",
-        "evs": {"hp": 4, "atk": 252, "def": 0, "spa": 0, "spd": 0, "spe": 252},
+        "evs": {"hp": 1, "atk": 32, "def": 0, "spa": 0, "spd": 0, "spe": 32},
         "ev_source": "archetype_default",
         "moves": ["Kowtow Cleave", "Sucker Punch", "Low Kick", "Protect"],
         "tera": "Dark",
@@ -5842,7 +5842,7 @@ const TEAMS = {
         "ability": "Unnerve",
         "nature": "Jolly",
         "nature_source": "archetype_default",
-        "evs": {"hp": 4, "atk": 252, "def": 0, "spa": 0, "spd": 0, "spe": 252},
+        "evs": {"hp": 1, "atk": 32, "def": 0, "spa": 0, "spd": 0, "spe": 32},
         "ev_source": "archetype_default",
         "moves": ["Tailwind", "Dual Wingbeat", "Rock Slide", "Protect"],
         "tera": "Flying",
@@ -5887,7 +5887,7 @@ const TEAMS = {
         "ability": "Mega Sol",
         "nature": "Modest",
         "nature_source": "archetype_default",
-        "evs": {"hp": 4, "atk": 0, "def": 0, "spa": 252, "spd": 0, "spe": 252},
+        "evs": {"hp": 1, "atk": 0, "def": 0, "spa": 32, "spd": 0, "spe": 32},
         "ev_source": "archetype_default",
         "moves": ["Solar Beam", "Weather Ball", "Dazzling Gleam", "Protect"],
         "tera": "Fairy",
@@ -5923,7 +5923,7 @@ const TEAMS = {
         "ability": "Adaptability",
         "nature": "Adamant",
         "nature_source": "archetype_default",
-        "evs": {"hp": 4, "atk": 252, "def": 0, "spa": 0, "spd": 0, "spe": 252},
+        "evs": {"hp": 1, "atk": 32, "def": 0, "spa": 0, "spd": 0, "spe": 32},
         "ev_source": "archetype_default",
         "moves": ["Wave Crash", "Flip Turn", "Aqua Jet", "Last Respects"],
         "tera": "Ghost",
@@ -5935,7 +5935,7 @@ const TEAMS = {
         "ability": "Drizzle",
         "nature": "Modest",
         "nature_source": "archetype_default",
-        "evs": {"hp": 252, "atk": 0, "def": 4, "spa": 252, "spd": 0, "spe": 0},
+        "evs": {"hp": 32, "atk": 0, "def": 1, "spa": 32, "spd": 0, "spe": 0},
         "ev_source": "archetype_default",
         "moves": ["Weather Ball", "Hurricane", "Tailwind", "Protect"],
         "tera": "Ghost",
@@ -5947,7 +5947,7 @@ const TEAMS = {
         "ability": "Unburden",
         "nature": "Jolly",
         "nature_source": "archetype_default",
-        "evs": {"hp": 4, "atk": 252, "def": 0, "spa": 0, "spd": 0, "spe": 252},
+        "evs": {"hp": 1, "atk": 32, "def": 0, "spa": 0, "spd": 0, "spe": 32},
         "ev_source": "archetype_default",
         "moves": ["Close Combat", "Dire Claw", "Fake Out", "Protect"],
         "tera": "Stellar",
@@ -6030,7 +6030,7 @@ const TEAMS = {
         "ability": "Unburden",
         "nature": "Jolly",
         "nature_source": "archetype_default",
-        "evs": {"hp": 4, "atk": 252, "def": 0, "spa": 0, "spd": 0, "spe": 252},
+        "evs": {"hp": 1, "atk": 32, "def": 0, "spa": 0, "spd": 0, "spe": 32},
         "ev_source": "archetype_default",
         "moves": ["Close Combat", "Dire Claw", "Fake Out", "Coaching"],
         "tera": "Fighting",
@@ -6150,7 +6150,7 @@ const TEAMS = {
         "ability": "Defiant",
         "nature": "Adamant",
         "nature_source": "archetype_default",
-        "evs": {"hp": 4, "atk": 252, "def": 0, "spa": 0, "spd": 0, "spe": 252},
+        "evs": {"hp": 1, "atk": 32, "def": 0, "spa": 0, "spd": 0, "spe": 32},
         "ev_source": "archetype_default",
         "moves": ["Kowtow Cleave", "Sucker Punch", "Iron Head", "Swords Dance"],
         "tera": "Dark",
@@ -6207,7 +6207,7 @@ const TEAMS = {
         "ability": "Gale Wings",
         "nature": "Jolly",
         "nature_source": "archetype_default",
-        "evs": {"hp": 4, "atk": 252, "def": 0, "spa": 0, "spd": 0, "spe": 252},
+        "evs": {"hp": 1, "atk": 32, "def": 0, "spa": 0, "spd": 0, "spe": 32},
         "ev_source": "archetype_default",
         "moves": ["Protect", "Dual Wingbeat", "Flare Blitz", "Tailwind"],
         "tera": "Flying",
@@ -6219,7 +6219,7 @@ const TEAMS = {
         "ability": "Rough Skin",
         "nature": "Jolly",
         "nature_source": "archetype_default",
-        "evs": {"hp": 4, "atk": 252, "def": 0, "spa": 0, "spd": 0, "spe": 252},
+        "evs": {"hp": 1, "atk": 32, "def": 0, "spa": 0, "spd": 0, "spe": 32},
         "ev_source": "archetype_default",
         "moves": ["Protect", "Rock Slide", "Earthquake", "Dragon Claw"],
         "tera": "Steel",
@@ -6267,7 +6267,7 @@ const TEAMS = {
         "ability": "Fairy Aura",
         "nature": "Timid",
         "nature_source": "archetype_default",
-        "evs": {"hp": 4, "atk": 0, "def": 0, "spa": 252, "spd": 0, "spe": 252},
+        "evs": {"hp": 1, "atk": 0, "def": 0, "spa": 32, "spd": 0, "spe": 32},
         "ev_source": "archetype_default",
         "moves": ["Protect", "Light of Ruin", "Dazzling Gleam", "Moonblast"],
         "tera": "Fairy",
@@ -6312,7 +6312,7 @@ const TEAMS = {
         "ability": "Adaptability",
         "nature": "Adamant",
         "nature_source": "archetype_default",
-        "evs": {"hp": 4, "atk": 252, "def": 0, "spa": 0, "spd": 0, "spe": 252},
+        "evs": {"hp": 1, "atk": 32, "def": 0, "spa": 0, "spd": 0, "spe": 32},
         "ev_source": "archetype_default",
         "moves": ["Wave Crash", "Last Respects", "Icy Wind", "Flip Turn"],
         "tera": "Water",
@@ -6534,7 +6534,7 @@ const TEAMS = {
         "ability": "Stance Change",
         "nature": "Brave",
         "nature_source": "archetype_default",
-        "evs": {"hp": 252, "atk": 0, "def": 4, "spa": 252, "spd": 0, "spe": 0},
+        "evs": {"hp": 32, "atk": 0, "def": 1, "spa": 32, "spd": 0, "spe": 0},
         "ev_source": "archetype_default",
         "ivs": { "hp":31, "atk":31, "def":31, "spa":31, "spd":31, "spe":0 },
         "moves": ["Poltergeist", "Close Combat", "Shadow Sneak", "King's Shield"],
@@ -6559,7 +6559,7 @@ const TEAMS = {
         "ability": "Rough Skin",
         "nature": "Jolly",
         "nature_source": "archetype_default",
-        "evs": {"hp": 4, "atk": 252, "def": 0, "spa": 0, "spd": 0, "spe": 252},
+        "evs": {"hp": 1, "atk": 32, "def": 0, "spa": 0, "spd": 0, "spe": 32},
         "ev_source": "archetype_default",
         "moves": ["Dragon Claw", "Earthquake", "Rock Slide", "Protect"],
         "tera": "Ground",
@@ -6571,7 +6571,7 @@ const TEAMS = {
         "ability": "Defiant",
         "nature": "Adamant",
         "nature_source": "archetype_default",
-        "evs": {"hp": 4, "atk": 252, "def": 0, "spa": 0, "spd": 0, "spe": 252},
+        "evs": {"hp": 1, "atk": 32, "def": 0, "spa": 0, "spd": 0, "spe": 32},
         "ev_source": "archetype_default",
         "moves": ["Kowtow Cleave", "Sucker Punch", "Low Kick", "Protect"],
         "tera": "Dark",
@@ -6583,11 +6583,326 @@ const TEAMS = {
         "ability": "Adaptability",
         "nature": "Adamant",
         "nature_source": "archetype_default",
-        "evs": {"hp": 4, "atk": 252, "def": 0, "spa": 0, "spd": 0, "spe": 252},
+        "evs": {"hp": 1, "atk": 32, "def": 0, "spa": 0, "spd": 0, "spe": 32},
         "ev_source": "archetype_default",
         "moves": ["Wave Crash", "Last Respects", "Aqua Jet", "Protect"],
         "tera": "Water",
         "role": "Revenge Killer"
+      }
+    ]
+  },
+  "fedecampovgc_aerodactyl_ariados": {
+    "name": "FedeCampoVGC — Aerodactyl Ariados",
+    "label": "MAY META",
+    "style": "speed_sun_pressure",
+    "description": "Current May 2026 public meta-index roster built around Mega Aerodactyl + Mega Charizard Y pressure. Rental: AV7NTVGB10.",
+    "champion_pack_id": "fedecampovgc_aerodactyl_ariados_may2026_v1",
+    "format": "champions",
+    "formatid": "champions-vgc-2026-regma",
+    "gametype": "doubles",
+    "ruleset": ["Species Clause", "Item Clause", "Bring 6 Pick 4", "Level 50"],
+    "source": "preloaded",
+    "origin": {
+      "url": "https://pokemonchampionsmeta.net/",
+      "player": "Federico Camporesi",
+      "event": "Public meta index (May 1, 2026) · rental AV7NTVGB10"
+    },
+    "provenance": {
+      "roster_source": "pokemon_champions_meta_index",
+      "spread_source": "archetype_default",
+      "author": "Federico Camporesi",
+      "url": "https://pokemonchampionsmeta.net/",
+      "status": "species-forms-verified-sets-inferred"
+    },
+    "legality_status": "legal_inferred",
+    "legality_notes": "Species/forms verified from the current public Champions meta index. Full sets are inferred because the index does not expose a raw export in-repo.",
+    "assumption_register": [
+      "Species/forms verified from the public May 1, 2026 Champions meta index entry.",
+      "Items, abilities, moves, EVs, natures, and Tera types were inferred from current Reg M-A archetypes.",
+      "Team carries two Mega-capable species; actual per-game Mega choice remains player-selected in battle."
+    ],
+    "members": [
+      {
+        "name": "Ariados",
+        "item": "Focus Sash",
+        "ability": "Insomnia",
+        "nature": "Adamant",
+        "nature_source": "archetype_default",
+        "evs": {"hp": 1, "atk": 32, "def": 0, "spa": 0, "spd": 0, "spe": 32},
+        "ev_source": "archetype_default",
+        "moves": ["Lunge", "Poison Jab", "Sucker Punch", "Protect"],
+        "tera": "Poison",
+        "role": "Utility Pressure"
+      },
+      {
+        "name": "Aerodactyl-Mega",
+        "item": "Aerodactylite",
+        "ability": "Tough Claws",
+        "nature": "Jolly",
+        "nature_source": "archetype_default",
+        "evs": {"hp": 1, "atk": 32, "def": 0, "spa": 0, "spd": 0, "spe": 32},
+        "ev_source": "archetype_default",
+        "moves": ["Tailwind", "Dual Wingbeat", "Rock Slide", "Protect"],
+        "tera": "Flying",
+        "role": "Mega Speed Control"
+      },
+      {
+        "name": "Charizard-Mega-Y",
+        "item": "Charizardite Y",
+        "ability": "Drought",
+        "nature": "Timid",
+        "nature_source": "archetype_default",
+        "evs": {"hp": 1, "atk": 0, "def": 0, "spa": 32, "spd": 0, "spe": 32},
+        "ev_source": "archetype_default",
+        "moves": ["Heat Wave", "Solar Beam", "Overheat", "Protect"],
+        "tera": "Fire",
+        "role": "Sun Breaker"
+      },
+      {
+        "name": "Basculegion",
+        "item": "Choice Scarf",
+        "ability": "Adaptability",
+        "nature": "Adamant",
+        "nature_source": "archetype_default",
+        "evs": {"hp": 1, "atk": 32, "def": 0, "spa": 0, "spd": 0, "spe": 32},
+        "ev_source": "archetype_default",
+        "moves": ["Wave Crash", "Last Respects", "Aqua Jet", "Flip Turn"],
+        "tera": "Ghost",
+        "role": "Scarf Cleaner"
+      },
+      {
+        "name": "Sylveon",
+        "item": "Leftovers",
+        "ability": "Pixilate",
+        "nature": "Modest",
+        "nature_source": "archetype_default",
+        "evs": {"hp": 32, "atk": 0, "def": 1, "spa": 32, "spd": 0, "spe": 0},
+        "ev_source": "archetype_default",
+        "moves": ["Hyper Voice", "Moonblast", "Helping Hand", "Protect"],
+        "tera": "Fairy",
+        "role": "Fairy Support"
+      },
+      {
+        "name": "Sneasler",
+        "item": "White Herb",
+        "ability": "Unburden",
+        "nature": "Jolly",
+        "nature_source": "archetype_default",
+        "evs": {"hp": 1, "atk": 32, "def": 0, "spa": 0, "spd": 0, "spe": 32},
+        "ev_source": "archetype_default",
+        "moves": ["Close Combat", "Dire Claw", "Fake Out", "Protect"],
+        "tera": "Fighting",
+        "role": "Unburden Sweeper"
+      }
+    ]
+  },
+  "swirlingroses_meganium_vivillon": {
+    "name": "swirlingroses — Meganium Vivillon Balance",
+    "label": "MAY REPLAY",
+    "style": "balance_speed",
+    "description": "May 6, 2026 Champions replay-preview roster with Sneasler / Basculegion / Incineroar / Kingambit / Meganium / Vivillon-Continental.",
+    "champion_pack_id": "swirlingroses_meganium_vivillon_may2026_v1",
+    "format": "champions",
+    "formatid": "champions-vgc-2026-regma",
+    "gametype": "doubles",
+    "ruleset": ["Species Clause", "Item Clause", "Bring 6 Pick 4", "Level 50"],
+    "source": "preloaded",
+    "origin": {
+      "url": "https://replay.pokemonshowdown.com/gen9championsvgc2026regma-2603247306",
+      "player": "swirlingroses",
+      "event": "Pokémon Showdown replay preview (Tournament battle, May 6, 2026)"
+    },
+    "provenance": {
+      "roster_source": "pokemon_showdown_replay_preview",
+      "spread_source": "archetype_default",
+      "author": "swirlingroses",
+      "url": "https://replay.pokemonshowdown.com/gen9championsvgc2026regma-2603247306",
+      "status": "species-verified-sets-inferred"
+    },
+    "legality_status": "legal_inferred",
+    "legality_notes": "Six species verified from the replay preview team line. Full sets are inferred because replay preview does not expose items, moves, or spreads.",
+    "assumption_register": [
+      "Only the six species were verified from the replay preview.",
+      "Items, abilities, moves, EVs, natures, and Tera types were inferred from current Reg M-A archetypes.",
+      "Vivillon-Continental uses Vivillon's canonical statline and typing; regional wing pattern is cosmetic for sim purposes."
+    ],
+    "members": [
+      {
+        "name": "Sneasler",
+        "item": "White Herb",
+        "ability": "Unburden",
+        "nature": "Jolly",
+        "nature_source": "archetype_default",
+        "evs": {"hp": 1, "atk": 32, "def": 0, "spa": 0, "spd": 0, "spe": 32},
+        "ev_source": "archetype_default",
+        "moves": ["Close Combat", "Dire Claw", "Fake Out", "Protect"],
+        "tera": "Fighting",
+        "role": "Unburden Sweeper"
+      },
+      {
+        "name": "Basculegion",
+        "item": "Mystic Water",
+        "ability": "Adaptability",
+        "nature": "Adamant",
+        "nature_source": "archetype_default",
+        "evs": {"hp": 1, "atk": 32, "def": 0, "spa": 0, "spd": 0, "spe": 32},
+        "ev_source": "archetype_default",
+        "moves": ["Wave Crash", "Last Respects", "Aqua Jet", "Protect"],
+        "tera": "Water",
+        "role": "Physical Cleaner"
+      },
+      {
+        "name": "Incineroar",
+        "item": "Sitrus Berry",
+        "ability": "Intimidate",
+        "nature": "Careful",
+        "nature_source": "archetype_default",
+        "evs": {"hp": 32, "atk": 1, "def": 0, "spa": 0, "spd": 32, "spe": 0},
+        "ev_source": "archetype_default",
+        "moves": ["Fake Out", "Parting Shot", "Flare Blitz", "Knock Off"],
+        "tera": "Ghost",
+        "role": "Pivot"
+      },
+      {
+        "name": "Kingambit",
+        "item": "Black Glasses",
+        "ability": "Defiant",
+        "nature": "Adamant",
+        "nature_source": "archetype_default",
+        "evs": {"hp": 1, "atk": 32, "def": 0, "spa": 0, "spd": 0, "spe": 32},
+        "ev_source": "archetype_default",
+        "moves": ["Kowtow Cleave", "Sucker Punch", "Low Kick", "Protect"],
+        "tera": "Dark",
+        "role": "Late-Game Cleaner"
+      },
+      {
+        "name": "Meganium",
+        "item": "Leftovers",
+        "ability": "Overgrow",
+        "nature": "Calm",
+        "nature_source": "archetype_default",
+        "evs": {"hp": 32, "atk": 0, "def": 1, "spa": 0, "spd": 32, "spe": 0},
+        "ev_source": "archetype_default",
+        "moves": ["Giga Drain", "Dazzling Gleam", "Leech Seed", "Protect"],
+        "tera": "Fairy",
+        "role": "Bulky Support"
+      },
+      {
+        "name": "Vivillon-Continental",
+        "item": "Focus Sash",
+        "ability": "Compound Eyes",
+        "nature": "Timid",
+        "nature_source": "archetype_default",
+        "evs": {"hp": 1, "atk": 0, "def": 0, "spa": 32, "spd": 0, "spe": 32},
+        "ev_source": "archetype_default",
+        "moves": ["Sleep Powder", "Hurricane", "Tailwind", "Protect"],
+        "tera": "Flying",
+        "role": "Fast Utility"
+      }
+    ]
+  },
+  "prro_t_floette_aerodactyl": {
+    "name": "Prro-T — Floette Aerodactyl Pressure",
+    "label": "MAY REPLAY",
+    "style": "fast_pressure",
+    "description": "May 8, 2026 Champions Bo3 replay-preview roster with Floette-Eternal / Aerodactyl / Incineroar / Garchomp / Sneasler / Basculegion.",
+    "champion_pack_id": "prro_t_floette_aerodactyl_may2026_v1",
+    "format": "champions",
+    "formatid": "champions-vgc-2026-regma",
+    "gametype": "doubles",
+    "ruleset": ["Species Clause", "Item Clause", "Bring 6 Pick 4", "Level 50"],
+    "source": "preloaded",
+    "origin": {
+      "url": "https://replay.pokemonshowdown.com/gen9championsvgc2026regma-2604413910",
+      "player": "Prro-T",
+      "event": "Pokémon Showdown replay preview (Bo3 Game 2, May 8, 2026)"
+    },
+    "provenance": {
+      "roster_source": "pokemon_showdown_replay_preview",
+      "spread_source": "archetype_default",
+      "author": "Prro-T",
+      "url": "https://replay.pokemonshowdown.com/gen9championsvgc2026regma-2604413910",
+      "status": "species-verified-sets-inferred"
+    },
+    "legality_status": "legal_inferred",
+    "legality_notes": "Six species verified from the replay preview team line. Full sets are inferred because replay preview does not expose items, moves, or spreads.",
+    "assumption_register": [
+      "Only the six species were verified from the replay preview.",
+      "Repo canonical naming normalizes replay-preview Floette-Eternal to Floette (Eternal Flower).",
+      "Items, abilities, moves, EVs, natures, and Tera types were inferred from current Reg M-A archetypes."
+    ],
+    "members": [
+      {
+        "name": "Floette (Eternal Flower)",
+        "item": "Fairy Feather",
+        "ability": "Flower Veil",
+        "nature": "Timid",
+        "nature_source": "archetype_default",
+        "evs": {"hp": 1, "atk": 0, "def": 0, "spa": 32, "spd": 0, "spe": 32},
+        "ev_source": "archetype_default",
+        "moves": ["Light of Ruin", "Dazzling Gleam", "Moonblast", "Protect"],
+        "tera": "Fairy",
+        "role": "Fairy Breaker"
+      },
+      {
+        "name": "Aerodactyl",
+        "item": "Focus Sash",
+        "ability": "Unnerve",
+        "nature": "Jolly",
+        "nature_source": "archetype_default",
+        "evs": {"hp": 1, "atk": 32, "def": 0, "spa": 0, "spd": 0, "spe": 32},
+        "ev_source": "archetype_default",
+        "moves": ["Tailwind", "Dual Wingbeat", "Rock Slide", "Protect"],
+        "tera": "Flying",
+        "role": "Speed Control"
+      },
+      {
+        "name": "Incineroar",
+        "item": "Chople Berry",
+        "ability": "Intimidate",
+        "nature": "Careful",
+        "nature_source": "archetype_default",
+        "evs": {"hp": 32, "atk": 1, "def": 0, "spa": 0, "spd": 32, "spe": 0},
+        "ev_source": "archetype_default",
+        "moves": ["Fake Out", "Parting Shot", "Flare Blitz", "Darkest Lariat"],
+        "tera": "Ghost",
+        "role": "Pivot"
+      },
+      {
+        "name": "Garchomp",
+        "item": "Soft Sand",
+        "ability": "Rough Skin",
+        "nature": "Jolly",
+        "nature_source": "archetype_default",
+        "evs": {"hp": 1, "atk": 32, "def": 0, "spa": 0, "spd": 0, "spe": 32},
+        "ev_source": "archetype_default",
+        "moves": ["Earthquake", "Dragon Claw", "Rock Slide", "Protect"],
+        "tera": "Ground",
+        "role": "Physical Pressure"
+      },
+      {
+        "name": "Sneasler",
+        "item": "White Herb",
+        "ability": "Unburden",
+        "nature": "Jolly",
+        "nature_source": "archetype_default",
+        "evs": {"hp": 1, "atk": 32, "def": 0, "spa": 0, "spd": 0, "spe": 32},
+        "ev_source": "archetype_default",
+        "moves": ["Close Combat", "Dire Claw", "Fake Out", "Protect"],
+        "tera": "Fighting",
+        "role": "Unburden Sweeper"
+      },
+      {
+        "name": "Basculegion",
+        "item": "Choice Scarf",
+        "ability": "Adaptability",
+        "nature": "Adamant",
+        "nature_source": "archetype_default",
+        "evs": {"hp": 1, "atk": 32, "def": 0, "spa": 0, "spd": 0, "spe": 32},
+        "ev_source": "archetype_default",
+        "moves": ["Wave Crash", "Last Respects", "Aqua Jet", "Flip Turn"],
+        "tera": "Ghost",
+        "role": "Scarf Cleaner"
       }
     ]
   },

--- a/poke-sim/sw.js
+++ b/poke-sim/sw.js
@@ -18,7 +18,7 @@
 // v8-supabase-live [2026-04-27] — Supabase DB fully wired (real URL + anon key in supabase_adapter.js)
 // v7-phase4c2      — previous
 
-const CACHE_NAME = 'champions-sim-v34-mobile-shell-layout';
+const CACHE_NAME = 'champions-sim-v35-shared-29-team-catalog';
 const SPRITE_CACHE = 'champions-sprites-v1';
 
 const APP_ASSETS = [

--- a/poke-sim/tests/db_m2_seed_tests.js
+++ b/poke-sim/tests/db_m2_seed_tests.js
@@ -27,6 +27,19 @@ function readSeed() {
   return fs.readFileSync(seedPath, 'utf8');
 }
 
+function dataTeamIds() {
+  var dataContent = fs.readFileSync(dataPath, 'utf8');
+  var start = dataContent.indexOf('const TEAMS = {') + 'const TEAMS = '.length;
+  var depth = 0; var end = start;
+  for (var i = start; i < dataContent.length; i++) {
+    var c = dataContent[i];
+    if (c === '{') depth++;
+    else if (c === '}') { depth--; if (depth === 0) { end = i + 1; break; } }
+  }
+  var teamsObj = JSON.parse(dataContent.substring(start, end));
+  return Object.keys(teamsObj);
+}
+
 // Extract every team_id used as the first column of an INSERT INTO teams (...) VALUES ('id', ...).
 // We anchor on the row pattern emitted by the generator (two-space indent + '(' + id-quote)
 // because SQL string literals can contain ';' which breaks naive [\s\S]*?; matchers.
@@ -70,16 +83,7 @@ describe('Module 2 \u2014 Seed suite (14 cases)', function() {
     var seedContent = readSeed();
     var ids = teamIdsInSeed(seedContent);
     var distinct = Array.from(new Set(ids));
-    var dataContent = fs.readFileSync(dataPath, 'utf8');
-    var start = dataContent.indexOf('const TEAMS = {') + 'const TEAMS = '.length;
-    var depth = 0; var end = start;
-    for (var i = start; i < dataContent.length; i++) {
-      var c = dataContent[i];
-      if (c === '{') depth++;
-      else if (c === '}') { depth--; if (depth === 0) { end = i + 1; break; } }
-    }
-    var teamsObj = JSON.parse(dataContent.substring(start, end));
-    eq(distinct.length, Object.keys(teamsObj).length, 'seed team count matches data.js TEAMS literal');
+    eq(distinct.length, dataTeamIds().length, 'seed team count matches data.js team count');
   });
 
   T('T-seed-3', function() {
@@ -92,19 +96,10 @@ describe('Module 2 \u2014 Seed suite (14 cases)', function() {
 
   T('T-seed-4', function() {
     // Every team_id from data.js TEAMS literal has a matching INSERT INTO teams row
-    var dataContent = fs.readFileSync(dataPath, 'utf8');
-    var start = dataContent.indexOf('const TEAMS = {') + 'const TEAMS = '.length;
-    var depth = 0; var end = start;
-    for (var i = start; i < dataContent.length; i++) {
-      var c = dataContent[i];
-      if (c === '{') depth++;
-      else if (c === '}') { depth--; if (depth === 0) { end = i + 1; break; } }
-    }
-    var teamsObj = JSON.parse(dataContent.substring(start, end));
-    var dataTeamIds = Object.keys(teamsObj);
+    var idsFromData = dataTeamIds();
     var seedContent = readSeed();
     var seedIds = new Set(teamIdsInSeed(seedContent));
-    dataTeamIds.forEach(function(id) {
+    idsFromData.forEach(function(id) {
       eq(seedIds.has(id), true, 'team_id ' + id + ' from data.js has matching INSERT in seed SQL');
     });
   });
@@ -246,10 +241,18 @@ describe('Module 2 \u2014 Seed suite (14 cases)', function() {
         req.end();
       });
     }
-    return get('/rest/v1/teams?select=team_id').then(function(r) {
+    return get('/rest/v1/teams?select=team_id&order=team_id').then(function(r) {
       truthy(r.status === 200, 'GET /teams returned 200, got ' + r.status);
       var arr = JSON.parse(r.body);
-      truthy(arr.length === 22, 'live DB has 22 teams, got ' + arr.length);
+      var liveIds = Array.from(new Set(arr.map(function(row) { return row.team_id; }))).sort();
+      var expectedIds = Array.from(new Set(teamIdsInSeed(readSeed()))).sort();
+      var missing = expectedIds.filter(function(id) { return liveIds.indexOf(id) === -1; });
+      var extra = liveIds.filter(function(id) { return expectedIds.indexOf(id) === -1; });
+      truthy(missing.length === 0 && extra.length === 0,
+        'live DB team_ids match seed; expected ' + expectedIds.length +
+        ', got ' + liveIds.length +
+        ', missing=' + JSON.stringify(missing) +
+        ', extra=' + JSON.stringify(extra));
     });
   });
 

--- a/poke-sim/tools/README.md
+++ b/poke-sim/tools/README.md
@@ -51,7 +51,7 @@ Pokemon-Champions-Sim-Planner/
 ├── poke-sim/
 │   ├── index.html                   ← app shell (SINGLE SOURCE OF TRUTH)
 │   ├── style.css
-│   ├── data.js                      ← BASE_STATS, POKEMON_TYPES_DB, TEAMS (13 teams)
+│   ├── data.js                      ← BASE_STATS, POKEMON_TYPES_DB, TEAMS (29 teams)
 │   ├── engine.js                    ← battle engine, damage formula
 │   ├── ui.js                        ← all UI logic
 │   ├── storage_adapter.js           ← localStorage wrapper
@@ -60,7 +60,8 @@ Pokemon-Champions-Sim-Planner/
 │   ├── pokemon-champion-2026.html   ← REBUILT BUNDLE (never edit directly)
 │   ├── db/
 │   │   ├── schema_v1.sql
-│   │   ├── seed_teams_v1.sql
+│   │   ├── seed_teams_v2.sql
+│   │   ├── migrations/
 │   │   └── rls_policies_v1.sql
 │   └── tools/
 │       ├── build-bundle.py          ← canonical bundle builder (always use this)
@@ -215,14 +216,15 @@ git push --force origin main
 | Key | Value |
 |---|---|
 | Project URL | `https://ymlahqnshgiarpbgxehp.supabase.co` |
-| Status | ✅ Live — schema + 13 teams seeded |
+| Status | ✅ Live — schema active; 29-team seed target pending shared catalog migration |
 | Auth | anon key (read-only for teams/pokemon; open write for analyses) |
 
 ### Initial setup (already done — for reference)
 ```sql
 -- Run in order in Supabase SQL Editor:
 -- 1. poke-sim/db/schema_v1.sql
--- 2. poke-sim/db/seed_teams_v1.sql
+-- 2. poke-sim/db/seed_teams_v2.sql for fresh DBs only
+--    Use poke-sim/db/migrations/2026_05_24_align_shared_29_team_catalog.sql for existing DBs with analyses history.
 -- 3. poke-sim/db/rls_policies_v1.sql
 ```
 

--- a/poke-sim/tools/generate_seed_from_data.py
+++ b/poke-sim/tools/generate_seed_from_data.py
@@ -34,6 +34,7 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parent.parent
 DATA_JS = ROOT / "data.js"
 OUT_SQL = ROOT / "db" / "seed_teams_v2.sql"
+MIGRATION_SQL = ROOT / "db" / "migrations" / "2026_04_28_seed_teams_v2.sql"
 
 CANONICAL_RULESET_ID = "champions_reg_m_doubles_bo3"
 RULESET_ROW = {
@@ -246,11 +247,22 @@ def main(argv=None):
         sys.stdout.write(sql)
         return 0
 
-    OUT_SQL.parent.mkdir(parents=True, exist_ok=True)
-    # Write with explicit UTF-8 + \n line endings for stable diff across platforms
-    with open(OUT_SQL, "w", encoding="utf-8", newline="\n") as f:
-        f.write(sql)
-    print("wrote " + str(OUT_SQL.relative_to(ROOT.parent)) + " (" + str(len(sql)) + " bytes, " + str(len(teams)) + " teams)")
+    for out_path in (OUT_SQL, MIGRATION_SQL):
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        # Write with explicit UTF-8 + \n line endings for stable diff across platforms
+        with open(out_path, "w", encoding="utf-8", newline="\n") as f:
+            f.write(sql)
+    print(
+        "wrote "
+        + str(OUT_SQL.relative_to(ROOT.parent))
+        + " and "
+        + str(MIGRATION_SQL.relative_to(ROOT.parent))
+        + " ("
+        + str(len(sql))
+        + " bytes, "
+        + str(len(teams))
+        + " teams)"
+    )
     return 0
 
 


### PR DESCRIPTION
## Summary

Aligns Alfredo repo to the shared 29-team catalog used across Y Factor, Alfredo, and the live Supabase seed target.

## What changed

- Adds the Y Factor May teams to Alfredo's shipped catalog.
- Preserves Alfredo-only sample teams.
- Aligns shared team definitions to the Y Factor canonical definitions.
- Regenerates seed_teams_v2.sql and 2026_04_28_seed_teams_v2.sql from data.js.
- Updates generate_seed_from_data.py so future regeneration writes both seed files.
- Adds non-destructive live DB migration: poke-sim/db/migrations/2026_05_24_align_shared_29_team_catalog.sql.
- Updates DB/tool docs to remove stale 13-team and old M2 guidance.
- Rebuilds pokemon-champion-2026.html and bumps sw.js cache.

## Database handling

No live DB write was performed in this PR.
No schema change.
No secrets or .env inspection.
After merge and approval, run the Supabase DB Migration workflow with:
2026_05_24_align_shared_29_team_catalog.sql

## Verification

- node --check poke-sim/data.js
- node --check poke-sim/engine.js
- node --check poke-sim/ui.js
- node --check poke-sim/supabase_adapter.js
- node poke-sim/tests/db_m2_seed_tests.js
- bash poke-sim/tools/check-bundle.sh
- npm run test:fast
- node tests/audit.js from poke-sim: completed 5,780 battles with 0 JS errors
- git diff --check

## Cross-repo alignment

The TEAMS JSON, seed_teams_v2.sql, 2026_04_28_seed_teams_v2.sql, and 2026_05_24_align_shared_29_team_catalog.sql match the Y Factor alignment branch.

## Merge rule

Do not merge without Alfredo/Kevin approval.