### PR TITLE
Implement priority and status-targeting abilities

### DIFF
--- a/poke-sim/engine.js
+++ b/poke-sim/engine.js
@@ -1866,6 +1866,18 @@ function simulateBattle(playerTeam, oppTeam, opts = {}) {
         log.push(`${attacker.name} used ${move}! But it failed because of Substitute!`);
         return;
       }
+      if (target && target.alive && shouldPranksterFailOnTarget(attacker, move, target)) {
+        log.push(`${target.name} is immune to Prankster-boosted ${move}!`);
+        return;
+      }
+      if (target && target.alive && isBlockedByGoodAsGold(target, move)) {
+        log.push(`${target.name}'s Good as Gold blocked ${move}!`);
+        return;
+      }
+      if (target && target.alive && shouldReflectByMagicBounce(attacker, target, move)) {
+        log.push(`${target.name}'s Magic Bounce reflected ${move}!`);
+        target = attacker;
+      }
       if (move === 'Trick Room') {
         if (field.trickRoom) {
           field.trickRoom = false;
@@ -2048,7 +2060,7 @@ function simulateBattle(playerTeam, oppTeam, opts = {}) {
         return;
       }
       if (move === 'Taunt' && target && target.alive) {
-        const targetAllies = enemies;
+        const targetAllies = (target.side && attacker.side && target.side === attacker.side) ? allies : enemies;
         const aromaVeilOnSide = targetAllies.some(m => m.alive && m.ability === 'Aroma Veil');
         if (target.ability === 'Oblivious' || target.ability === 'Aroma Veil' || aromaVeilOnSide) {
           log.push(`${target.name} is immune to Taunt!`);
@@ -2068,7 +2080,7 @@ function simulateBattle(playerTeam, oppTeam, opts = {}) {
         return;
       }
       if (move === 'Encore' && target && target.alive) {
-        const targetAllies = enemies;
+        const targetAllies = (target.side && attacker.side && target.side === attacker.side) ? allies : enemies;
         const aromaVeilOnSide = targetAllies.some(m => m.alive && m.ability === 'Aroma Veil');
         if (target.ability === 'Oblivious' || target.ability === 'Aroma Veil' || aromaVeilOnSide) {
           log.push(`${target.name} is immune to Encore!`);
@@ -2452,12 +2464,17 @@ function simulateBattle(playerTeam, oppTeam, opts = {}) {
       if (targets.length === 0) return;
     }
 
-    const movePriority = getPriority(move);
+    const movePriority = getPriority(move, attacker);
     if (movePriority > 0) {
       targets = targets.filter(t => {
         if (!t.side || !attacker.side || t.side === attacker.side) return true;
         if (t.side.quickGuard && move !== 'Feint') {
           log.push(`Quick Guard blocked ${move} on ${t.name}!`);
+          return false;
+        }
+        const defenders = (t.side === field.playerSide) ? playerActive : oppActive;
+        if (defenders.some(m => m.alive && m.ability === 'Armor Tail')) {
+          log.push(`Armor Tail blocked ${move} on ${t.name}!`);
           return false;
         }
         return true;
@@ -2771,7 +2788,7 @@ function simulateBattle(playerTeam, oppTeam, opts = {}) {
         target,
         targetIndex: (target && oppActive.indexOf(target) >= 0) ? oppActive.indexOf(target) : null,
         side: 'player',
-        priority: getPriority(move)
+        priority: getPriority(move, mon)
       };
       mon._chosenMove = move;
       _recordAction(_act);
@@ -2785,7 +2802,7 @@ function simulateBattle(playerTeam, oppTeam, opts = {}) {
         target,
         targetIndex: (target && playerActive.indexOf(target) >= 0) ? playerActive.indexOf(target) : null,
         side: 'opp',
-        priority: getPriority(move)
+        priority: getPriority(move, mon)
       };
       mon._chosenMove = move;
       _recordAction(_act);
@@ -3158,7 +3175,25 @@ function simulateBattle(playerTeam, oppTeam, opts = {}) {
 // ============================================================
 // PRIORITY LOOKUP
 // ============================================================
-function getPriority(move) {
+var STATUS_MOVE_NAMES = new Set([
+  'Will-O-Wisp','Thunder Wave','Taunt','Sleep Powder','Tailwind','Sunny Day',
+  'Trick Room','Life Dew','Rage Powder','Roost','Parting Shot','Shed Tail',
+  'Quick Guard','Endure','Wide Guard','Follow Me','Protect','Detect',
+  "King's Shield",'Spiky Shield','Baneful Bunker','Obstruct','Light Screen',
+  'Reflect','Aurora Veil','Encore','Haze','Defog','Recover','Shore Up','Rest',
+  'Sleep Talk','Substitute','Imprison','Ally Switch','Toxic','Poison Powder'
+]);
+
+var TARGETED_STATUS_MOVES = new Set([
+  'Will-O-Wisp','Thunder Wave','Taunt','Sleep Powder','Toxic',
+  'Poison Powder','Encore','Parting Shot'
+]);
+
+function isStatusMoveName(move) {
+  return !!(move && (STATUS_MOVE_NAMES.has(move) || MOVE_CATEGORY[move] === 'status'));
+}
+
+function getPriority(move, attacker) {
   // T9j.2 — Champions 2026 priority table (Refs CHAMPIONS_MECHANICS_SPEC §4).
   // Rage Powder and Follow Me are +2 in Champions (ORACLE-DIVERGENCE-3 vs SV +3).
   const P = {
@@ -3171,7 +3206,40 @@ function getPriority(move) {
     'Follow Me':2, 'Rage Powder':2,
     'Trick Room':-7, 'Roost':0
   };
-  return P[move] || 0;
+  let priority = P[move] || 0;
+  if (attacker && attacker.ability === 'Prankster' && isStatusMoveName(move)) priority += 1;
+  return priority;
+}
+
+function shouldPranksterFailOnTarget(attacker, move, target) {
+  return !!(attacker
+    && attacker.ability === 'Prankster'
+    && target
+    && target.alive
+    && target.side
+    && attacker.side
+    && target.side !== attacker.side
+    && TARGETED_STATUS_MOVES.has(move)
+    && Array.isArray(target.types)
+    && target.types.indexOf('Dark') !== -1);
+}
+
+function isBlockedByGoodAsGold(target, move) {
+  return !!(target
+    && target.alive
+    && target.ability === 'Good as Gold'
+    && TARGETED_STATUS_MOVES.has(move));
+}
+
+function shouldReflectByMagicBounce(attacker, target, move) {
+  return !!(attacker
+    && target
+    && target.alive
+    && target.ability === 'Magic Bounce'
+    && attacker.side
+    && target.side
+    && attacker.side !== target.side
+    && TARGETED_STATUS_MOVES.has(move));
 }
 
 // ============================================================

--- a/poke-sim/reports/ability_coverage_audit.md
+++ b/poke-sim/reports/ability_coverage_audit.md
@@ -1,0 +1,72 @@
+# Ability Coverage Audit
+
+Date: 2026-05-24
+
+Scope:
+- curated shipped teams in `data.js` excluding `player` and `custom_*`
+- `CHAMPIONS_MEGAS` ability catalog
+- current battle engine ability hooks and inline checks in `engine.js`
+
+Summary:
+- unique curated-team + mega abilities audited: 82
+- already modeled by the engine: 23
+- still unmodeled and classified: 59
+
+Why this exists:
+- Issue #125 showed repeated review friction around ability gaps being noticed ad hoc.
+- This audit turns that into a maintained inventory with a guard test so new gaps cannot quietly pile up.
+
+Classification buckets:
+- `passive_or_noop_for_current_sim`
+- `missing_low_impact`
+- `missing_battle_result_impacting`
+
+Highest-priority shipped-team gaps:
+- `Adaptability`: affects Basculegion damage across multiple shipped teams.
+- `Clear Body`, `Competitive`, `Defiant`: all change Intimidate-heavy matchups.
+- `Cloud Nine`: changes weather suppression, damage, and speed.
+- `Shadow Tag`: changes switch options and perish-style endgames.
+- `Solar Power`, `Tough Claws`, `Pixilate`, `Supreme Overlord`: direct damage modifiers.
+- `Stance Change`, `Sturdy`, `Unaware`: major battle-result mechanics, not flavor.
+
+Implemented after this audit:
+- `Prankster`: real battle priority for status moves, with Dark-type immunity on targeted opposing status.
+- `Armor Tail`: side-wide blocking for opposing priority moves.
+- `Good as Gold`: targeted status immunity.
+- `Magic Bounce`: targeted status reflection back to the user.
+
+Lower-priority or no-op examples:
+- `Frisk`: item reveal is effectively already visible in the sim.
+- `Pressure`: PP drain is not modeled, so it has no current battle-math path.
+- `Healer`, `Shell Armor`, `Trace`, `Limber`, `Insomnia`: real mechanics, but narrower current user impact than the top gaps.
+
+Recommended implementation order:
+1. Priority and targeting control
+   - `Shadow Tag`
+2. Damage modifiers with broad shipped-team exposure
+   - `Adaptability`
+   - `Tough Claws`
+   - `Pixilate`
+   - `Solar Power`
+   - `Supreme Overlord`
+3. Stat-reaction and anti-Intimidate slice
+   - `Clear Body`
+   - `Competitive`
+   - `Defiant`
+   - `Unaware`
+4. Defensive and board-state mechanics
+   - `Cloud Nine`
+   - `Earth Eater`
+   - `Sturdy`
+   - `Stance Change`
+   - `Friend Guard`
+
+Guardrail:
+- `tests/ability_coverage_audit_tests.js` compares the current unmodeled ability inventory against `tests/fixtures/ability_gap_classification.json`.
+- If a new shipped-team or mega ability is unmodeled and unclassified, the test fails immediately.
+
+Out of scope for this pass:
+- implementing the missing mechanics
+- Supabase changes
+- bundle or deployment changes
+- broad engine rewrite

--- a/poke-sim/reports/ability_coverage_audit.md
+++ b/poke-sim/reports/ability_coverage_audit.md
@@ -8,9 +8,9 @@ Scope:
 - current battle engine ability hooks and inline checks in `engine.js`
 
 Summary:
-- unique curated-team + mega abilities audited: 82
+- unique curated-team + mega abilities audited: 79
 - already modeled by the engine: 23
-- still unmodeled and classified: 59
+- still unmodeled and classified: 56
 
 Why this exists:
 - Issue #125 showed repeated review friction around ability gaps being noticed ad hoc.

--- a/poke-sim/tests/README.md
+++ b/poke-sim/tests/README.md
@@ -23,6 +23,8 @@ node tests/phase4c_detectors.js # Phase 4c — detectors + confidence badges (5 
 node tests/phase4d_threat_response_tests.js # Phase 4d — threat response solver + line classifier — 7 cases
 node tests/phase4e_policy_regression.js # Phase 4e — policy audit / T5 static-advice gate — 16 cases
 node tests/mechanics_audit.js      # Mechanics audit — move-rule checks used by smoke test
+node tests/ability_coverage_audit_tests.js # Ability coverage inventory + classification guard
+node tests/ability_priority_targeting_tests.js # Prankster, Armor Tail, Good as Gold, Magic Bounce
 node tests/t159_mobile_roster_layout_tests.js # Mobile roster layout safeguards
 node tests/t160_distinct_battle_team_tests.js # Battle team selection must stay distinct
 node tests/t161_team_member_uniqueness_tests.js # Catalog teams must not repeat members

--- a/poke-sim/tests/ability_coverage_audit_tests.js
+++ b/poke-sim/tests/ability_coverage_audit_tests.js
@@ -1,0 +1,183 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+const ROOT = path.resolve(__dirname, '..');
+const dataSource = fs.readFileSync(path.join(ROOT, 'data.js'), 'utf8');
+const engineSource = fs.readFileSync(path.join(ROOT, 'engine.js'), 'utf8');
+const classification = JSON.parse(
+  fs.readFileSync(path.join(ROOT, 'tests/fixtures/ability_gap_classification.json'), 'utf8')
+);
+
+const ctx = {
+  console,
+  module: {},
+  exports: {},
+  Math,
+  Object,
+  Array,
+  Set,
+  JSON,
+  RegExp,
+  String
+};
+vm.createContext(ctx);
+vm.runInContext(dataSource + '\nthis.TEAMS=TEAMS; this.CHAMPIONS_MEGAS=CHAMPIONS_MEGAS;', ctx, { filename: 'data.js' });
+vm.runInContext(engineSource + '\nthis.ABILITIES=ABILITIES;', ctx, { filename: 'engine.js' });
+
+const CURATED_TEAMS = Object.fromEntries(
+  Object.entries(ctx.TEAMS || {}).filter(function(entry) {
+    return entry[0] !== 'player' && entry[0].indexOf('custom_') !== 0;
+  })
+);
+
+function getCuratedTeamAbilities() {
+  return Object.values(CURATED_TEAMS).flatMap(function(team) {
+    return (team.members || []).map(function(member) {
+      return member.ability;
+    }).filter(Boolean);
+  });
+}
+
+function getMegaAbilities() {
+  return Object.values(ctx.CHAMPIONS_MEGAS || {}).map(function(mega) {
+    return mega.ability;
+  }).filter(Boolean);
+}
+
+function getModeledAbilities() {
+  return new Set([
+    'Aroma Veil',
+    'Chlorophyll',
+    'Comatose',
+    'Dragonize',
+    'Drizzle',
+    'Drought',
+    'Hospitality',
+    'Inner Focus',
+    'Intimidate',
+    'Levitate',
+    'Magic Bounce',
+    'Magma Armor',
+    'Mega Sol',
+    'Multiscale',
+    'Oblivious',
+    'Overcoat',
+    'Own Tempo',
+    'Parental Bond',
+    'Piercing Drill',
+    'Prankster',
+    'Armor Tail',
+    'Good as Gold',
+    'Sand Rush',
+    'Sand Stream',
+    'Slush Rush',
+    'Snow Warning',
+    'Spicy Spray',
+    'Sweet Veil',
+    'Swift Swim',
+    'Unburden',
+    'Unseen Fist',
+    'Water Veil'
+  ]);
+}
+
+function uniqSorted(list) {
+  return Array.from(new Set(list)).sort();
+}
+
+const modeled = getModeledAbilities();
+const abilityUnion = uniqSorted(getCuratedTeamAbilities().concat(getMegaAbilities()));
+const unmodeled = abilityUnion.filter(function(ability) {
+  return !modeled.has(ability);
+});
+const catalog = classification.classifications || {};
+
+let pass = 0;
+let fail = 0;
+
+function T(name, fn) {
+  try {
+    fn();
+    console.log('  PASS', name);
+    pass++;
+  } catch (err) {
+    console.log('  FAIL', name, '-', err.message);
+    fail++;
+  }
+}
+
+function eq(a, b, msg) {
+  if (a !== b) throw new Error((msg || 'eq failed') + ' expected ' + JSON.stringify(b) + ', got ' + JSON.stringify(a));
+}
+
+function truthy(v, msg) {
+  if (!v) throw new Error(msg || 'expected truthy');
+}
+
+console.log('\n=== ability coverage audit tests ===\n');
+
+T('1. every unmodeled curated-team or mega ability has a classification entry', function() {
+  const missing = unmodeled.filter(function(ability) {
+    return !catalog[ability];
+  });
+  eq(missing.length, 0, missing.join(', '));
+});
+
+T('2. classification catalog does not contain stale abilities that are no longer unmodeled', function() {
+  const stale = Object.keys(catalog).filter(function(ability) {
+    return unmodeled.indexOf(ability) === -1;
+  });
+  eq(stale.length, 0, stale.join(', '));
+});
+
+T('3. every classification uses an allowed category and a non-empty rationale', function() {
+  const allowed = new Set(classification._meta.categories);
+  Object.keys(catalog).forEach(function(ability) {
+    truthy(allowed.has(catalog[ability].category), ability + ' category must be allowed');
+    truthy(typeof catalog[ability].why === 'string' && catalog[ability].why.length > 0, ability + ' rationale required');
+  });
+});
+
+T('4. known high-impact shipped ability gaps stay marked battle-result-impacting', function() {
+  [
+    'Adaptability',
+    'Clear Body',
+    'Cloud Nine',
+    'Competitive',
+    'Defiant',
+    'Pixilate',
+    'Shadow Tag',
+    'Solar Power',
+    'Stance Change',
+    'Sturdy',
+    'Supreme Overlord',
+    'Tough Claws',
+    'Unaware'
+  ].forEach(function(ability) {
+    const entry = catalog[ability];
+    truthy(entry, ability + ' should be cataloged');
+    eq(entry.category, 'missing_battle_result_impacting', ability + ' should stay high priority');
+  });
+});
+
+T('5. Pressure and Frisk stay explicitly marked as non-battle-math gaps', function() {
+  eq(catalog.Pressure.category, 'passive_or_noop_for_current_sim', 'Pressure');
+  eq(catalog.Frisk.category, 'passive_or_noop_for_current_sim', 'Frisk');
+});
+
+const categoryCounts = Object.keys(catalog).reduce(function(acc, ability) {
+  const category = catalog[ability].category;
+  acc[category] = (acc[category] || 0) + 1;
+  return acc;
+}, {});
+
+console.log('Curated+mega ability inventory:', abilityUnion.length);
+console.log('Modeled by engine:', abilityUnion.length - unmodeled.length);
+console.log('Still unmodeled:', unmodeled.length);
+console.log('Category counts:', JSON.stringify(categoryCounts));
+
+console.log('\nability coverage audit:', pass + ' pass, ' + fail + ' fail\n');
+process.exit(fail ? 1 : 0);

--- a/poke-sim/tests/ability_priority_targeting_tests.js
+++ b/poke-sim/tests/ability_priority_targeting_tests.js
@@ -1,0 +1,198 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+const ROOT = path.resolve(__dirname, '..');
+const ctx = {
+  console, require, module: {}, exports: {}, Math, Object, Array, Set, JSON,
+  Promise, setTimeout, clearTimeout, Date, String, Number, Boolean, RegExp,
+  parseInt, parseFloat
+};
+vm.createContext(ctx);
+
+function load(file) {
+  vm.runInContext(fs.readFileSync(path.join(ROOT, file), 'utf8'), ctx, { filename: file });
+}
+
+load('data.js');
+load('engine.js');
+vm.runInContext('this.simulateBattle = simulateBattle;', ctx);
+
+let pass = 0;
+let fail = 0;
+
+function T(name, fn) {
+  try {
+    fn();
+    console.log('  PASS', name);
+    pass++;
+  } catch (err) {
+    console.log('  FAIL', name, '-', err.message);
+    fail++;
+  }
+}
+
+function truthy(v, msg) {
+  if (!v) throw new Error(msg || 'expected truthy');
+}
+
+function falsy(v, msg) {
+  if (v) throw new Error(msg || 'expected falsy');
+}
+
+function team(members) {
+  return { name: 'Test', format: 'champions', legality_status: 'legal', members };
+}
+
+console.log('\n=== ability priority / targeting tests ===\n');
+
+T('1. Prankster gives Taunt priority over a faster foe', function() {
+  const playerTeam = team([{
+    name: 'Sableye',
+    item: '',
+    ability: 'Prankster',
+    nature: 'Calm',
+    level: 50,
+    moves: ['Taunt'],
+    evs: { hp: 32, atk: 0, def: 0, spa: 0, spd: 32, spe: 0 }
+  }]);
+  const oppTeam = team([{
+    name: 'Whimsicott',
+    item: '',
+    ability: 'Infiltrator',
+    nature: 'Timid',
+    level: 50,
+    moves: ['Haze'],
+    evs: { hp: 0, atk: 0, def: 0, spa: 0, spd: 0, spe: 32 }
+  }]);
+  const battle = ctx.simulateBattle(playerTeam, oppTeam, { format: 'doubles', seed: [1, 2, 3, 4], maxTurns: 1 });
+  const tauntIdx = battle.log.findIndex(line => String(line).includes('Whimsicott fell for the Taunt!'));
+  const failIdx = battle.log.findIndex(line => String(line).includes('used Haze! But it failed because of Taunt!'));
+  truthy(tauntIdx >= 0, 'Taunt should land');
+  truthy(failIdx > tauntIdx, 'faster foe should still be taunted before acting');
+});
+
+T('2. Dark-type foes are immune to Prankster-boosted status moves', function() {
+  const playerTeam = team([{
+    name: 'Whimsicott',
+    item: '',
+    ability: 'Prankster',
+    nature: 'Timid',
+    level: 50,
+    moves: ['Taunt'],
+    evs: { hp: 0, atk: 0, def: 0, spa: 0, spd: 0, spe: 32 }
+  }]);
+  const oppTeam = team([{
+    name: 'Incineroar',
+    item: '',
+    ability: 'Intimidate',
+    nature: 'Careful',
+    level: 50,
+    moves: ['Tackle'],
+    evs: { hp: 32, atk: 0, def: 0, spa: 0, spd: 32, spe: 4 }
+  }]);
+  const battle = ctx.simulateBattle(playerTeam, oppTeam, { format: 'doubles', seed: [5, 6, 7, 8], maxTurns: 1 });
+  truthy(battle.log.some(line => String(line).includes('Incineroar is immune to Prankster-boosted Taunt!')),
+    'Dark-type immunity log missing');
+  falsy(battle.log.some(line => String(line).includes('fell for the Taunt!')),
+    'Dark-type target should not be taunted');
+});
+
+T('3. Armor Tail blocks opposing priority moves for the side', function() {
+  const playerTeam = team([{
+    name: 'Farigiraf',
+    item: '',
+    ability: 'Armor Tail',
+    nature: 'Calm',
+    level: 50,
+    moves: ['Tackle'],
+    evs: { hp: 32, atk: 0, def: 0, spa: 0, spd: 32, spe: 4 }
+  }, {
+    name: 'Incineroar',
+    item: '',
+    ability: 'Intimidate',
+    nature: 'Careful',
+    level: 50,
+    moves: ['Tackle'],
+    evs: { hp: 32, atk: 0, def: 0, spa: 0, spd: 32, spe: 4 }
+  }]);
+  const oppTeam = team([{
+    name: 'Incineroar',
+    item: '',
+    ability: 'Intimidate',
+    nature: 'Adamant',
+    level: 50,
+    moves: ['Fake Out'],
+    evs: { hp: 32, atk: 32, def: 0, spa: 0, spd: 0, spe: 4 }
+  }, {
+    name: 'Smeargle',
+    item: '',
+    ability: 'Own Tempo',
+    nature: 'Serious',
+    level: 50,
+    moves: ['Protect'],
+    evs: { hp: 0, atk: 0, def: 0, spa: 0, spd: 0, spe: 0 }
+  }]);
+  const battle = ctx.simulateBattle(playerTeam, oppTeam, { format: 'doubles', seed: [9, 10, 11, 12], maxTurns: 1 });
+  truthy(battle.log.some(line => String(line).includes('Armor Tail blocked Fake Out')),
+    'Armor Tail should block Fake Out');
+});
+
+T('4. Good as Gold blocks targeted status moves', function() {
+  const playerTeam = team([{
+    name: 'Gholdengo',
+    item: '',
+    ability: 'Good as Gold',
+    nature: 'Modest',
+    level: 50,
+    moves: ['Protect'],
+    evs: { hp: 4, atk: 0, def: 0, spa: 32, spd: 0, spe: 32 }
+  }]);
+  const oppTeam = team([{
+    name: 'Whimsicott',
+    item: '',
+    ability: 'Prankster',
+    nature: 'Timid',
+    level: 50,
+    moves: ['Taunt'],
+    evs: { hp: 0, atk: 0, def: 0, spa: 0, spd: 0, spe: 32 }
+  }]);
+  const battle = ctx.simulateBattle(playerTeam, oppTeam, { format: 'doubles', seed: [13, 14, 15, 16], maxTurns: 1 });
+  truthy(battle.log.some(line => String(line).includes("Gholdengo's Good as Gold blocked Taunt!")),
+    'Good as Gold should block Taunt');
+  falsy(battle.log.some(line => String(line).includes('Gholdengo fell for the Taunt!')),
+    'Good as Gold target should not be taunted');
+});
+
+T('5. Magic Bounce reflects targeted status moves back to the user', function() {
+  const playerTeam = team([{
+    name: 'Hatterene',
+    item: '',
+    ability: 'Magic Bounce',
+    nature: 'Quiet',
+    level: 50,
+    moves: ['Protect'],
+    evs: { hp: 32, atk: 0, def: 0, spa: 32, spd: 4, spe: 0 }
+  }]);
+  const oppTeam = team([{
+    name: 'Whimsicott',
+    item: '',
+    ability: 'Prankster',
+    nature: 'Timid',
+    level: 50,
+    moves: ['Taunt'],
+    evs: { hp: 0, atk: 0, def: 0, spa: 0, spd: 0, spe: 32 }
+  }]);
+  const battle = ctx.simulateBattle(playerTeam, oppTeam, { format: 'doubles', seed: [17, 18, 19, 20], maxTurns: 1 });
+  truthy(battle.log.some(line => String(line).includes("Hatterene's Magic Bounce reflected Taunt!")),
+    'Magic Bounce reflection log missing');
+  truthy(battle.log.some(line => String(line).includes('Whimsicott fell for the Taunt!')),
+    'attacker should be taunted by reflection');
+  falsy(battle.log.some(line => String(line).includes('Hatterene fell for the Taunt!')),
+    'Magic Bounce holder should not be taunted');
+});
+
+console.log('\nability priority / targeting:', pass + ' pass, ' + fail + ' fail\n');
+process.exit(fail ? 1 : 0);

--- a/poke-sim/tests/fixtures/ability_gap_classification.json
+++ b/poke-sim/tests/fixtures/ability_gap_classification.json
@@ -1,0 +1,250 @@
+{
+  "_meta": {
+    "issue": 125,
+    "date": "2026-05-24",
+    "scope": "Unmodeled abilities present in curated shipped teams or the Champions mega registry.",
+    "categories": [
+      "passive_or_noop_for_current_sim",
+      "missing_low_impact",
+      "missing_battle_result_impacting"
+    ]
+  },
+  "classifications": {
+    "Adaptability": {
+      "category": "missing_battle_result_impacting",
+      "why": "1.5x STAB materially shifts Basculegion and Mega Lucario/Glimmora damage ranges."
+    },
+    "Aerilate": {
+      "category": "missing_battle_result_impacting",
+      "why": "Type conversion plus damage boost changes Mega Pinsir damage and STAB coverage."
+    },
+    "Berserk": {
+      "category": "missing_battle_result_impacting",
+      "why": "Special Attack boost on HP threshold changes Mega Drampa snowball turns."
+    },
+    "Blaze": {
+      "category": "missing_battle_result_impacting",
+      "why": "Low-HP Fire boost changes Charizard damage in close endgames."
+    },
+    "Bulletproof": {
+      "category": "missing_low_impact",
+      "why": "Projectile immunities are real but Mega Chesnaught is not in current shipped teams."
+    },
+    "Clear Body": {
+      "category": "missing_battle_result_impacting",
+      "why": "Blocks Intimidate and stat drops on Dragapult, changing lead pressure and damage."
+    },
+    "Cloud Nine": {
+      "category": "missing_battle_result_impacting",
+      "why": "Suppresses weather effects, changing speed tiers and sun/rain damage math."
+    },
+    "Competitive": {
+      "category": "missing_battle_result_impacting",
+      "why": "Turns Intimidate and other drops into Milotic Special Attack boosts."
+    },
+    "Compound Eyes": {
+      "category": "missing_battle_result_impacting",
+      "why": "Accuracy boost changes hit rates for status and utility lines."
+    },
+    "Defiant": {
+      "category": "missing_battle_result_impacting",
+      "why": "Turns Intimidate and stat drops into Kingambit Attack boosts."
+    },
+    "Earth Eater": {
+      "category": "missing_battle_result_impacting",
+      "why": "Ground immunity plus healing changes partner Earthquake interactions."
+    },
+    "Fairy Aura": {
+      "category": "missing_battle_result_impacting",
+      "why": "Field-wide Fairy damage boost changes Mega Floette and partner damage."
+    },
+    "Filter": {
+      "category": "missing_low_impact",
+      "why": "Super-effective damage reduction matters, but only on mega-only catalog rows today."
+    },
+    "Flower Veil": {
+      "category": "missing_battle_result_impacting",
+      "why": "Protects allied Grass types from stat drops and status in supported lines."
+    },
+    "Friend Guard": {
+      "category": "missing_battle_result_impacting",
+      "why": "Passive ally damage reduction changes KO thresholds in Maushold boards."
+    },
+    "Frisk": {
+      "category": "passive_or_noop_for_current_sim",
+      "why": "Item reveal is already effectively visible in the sim and does not alter battle math."
+    },
+    "Gale Wings": {
+      "category": "missing_battle_result_impacting",
+      "why": "Priority Flying moves change Talonflame turn order and lead pressure."
+    },
+    "Healer": {
+      "category": "missing_low_impact",
+      "why": "End-turn ally status cure can matter, but it is mega-only and relatively narrow."
+    },
+    "Huge Power": {
+      "category": "missing_battle_result_impacting",
+      "why": "Attack doubling is a major damage multiplier on Mega Starmie."
+    },
+    "Infiltrator": {
+      "category": "missing_battle_result_impacting",
+      "why": "Bypasses Substitute and screens, changing damage and status delivery."
+    },
+    "Innards Out": {
+      "category": "missing_battle_result_impacting",
+      "why": "Punishes KOs with reflected HP loss and can swing trades."
+    },
+    "Insomnia": {
+      "category": "missing_low_impact",
+      "why": "Sleep immunity matters on Ariados, but it is narrower than the top coverage gaps."
+    },
+    "Iron Fist": {
+      "category": "missing_battle_result_impacting",
+      "why": "Punching move boost changes Mega Golurk and Mega Crabominable damage."
+    },
+    "Limber": {
+      "category": "missing_low_impact",
+      "why": "Paralysis immunity matters, but current exposure is one Mega Lopunny team."
+    },
+    "Mega Launcher": {
+      "category": "missing_battle_result_impacting",
+      "why": "Pulse move boost materially changes Mega Blastoise damage."
+    },
+    "Mind's Eye": {
+      "category": "missing_battle_result_impacting",
+      "why": "Ghost immunity bypass and accuracy behavior affect Ursaluna-Bloodmoon lines."
+    },
+    "Mold Breaker": {
+      "category": "missing_battle_result_impacting",
+      "why": "Ignores defensive abilities and changes interaction outcomes for multiple Megas."
+    },
+    "Mummy": {
+      "category": "missing_low_impact",
+      "why": "Ability overwrite on contact is real, but it is less common than the top-tier gaps."
+    },
+    "No Guard": {
+      "category": "missing_battle_result_impacting",
+      "why": "Perfect accuracy changes both move reliability and opposing hit rates."
+    },
+    "Overgrow": {
+      "category": "missing_battle_result_impacting",
+      "why": "Low-HP Grass boost changes Meganium damage in close games."
+    },
+    "Pixilate": {
+      "category": "missing_battle_result_impacting",
+      "why": "Type conversion plus damage boost changes Sylveon and Mega Altaria outputs."
+    },
+    "Poison Touch": {
+      "category": "missing_battle_result_impacting",
+      "why": "Contact poison chance changes Sneasler chip and status pressure."
+    },
+    "Pressure": {
+      "category": "passive_or_noop_for_current_sim",
+      "why": "PP drain is not modeled, so Pressure has no active mechanical path today."
+    },
+    "Protean": {
+      "category": "missing_battle_result_impacting",
+      "why": "Type-changing on move use radically changes STAB and defensive matchups."
+    },
+    "Pure Power": {
+      "category": "missing_battle_result_impacting",
+      "why": "Attack doubling is a major damage multiplier on Mega Medicham."
+    },
+    "Refrigerate": {
+      "category": "missing_battle_result_impacting",
+      "why": "Type conversion plus damage boost changes Mega Glalie damage and coverage."
+    },
+    "Regenerator": {
+      "category": "missing_battle_result_impacting",
+      "why": "Switch healing changes Amoonguss cycling and board longevity."
+    },
+    "Rough Skin": {
+      "category": "missing_battle_result_impacting",
+      "why": "Contact chip affects many Garchomp trades and KO ranges."
+    },
+    "Sand Force": {
+      "category": "missing_battle_result_impacting",
+      "why": "Sand-boosted Rock, Ground, and Steel damage matters on Mega Steelix/Garchomp."
+    },
+    "Sand Veil": {
+      "category": "missing_low_impact",
+      "why": "Weather evasion can matter, but it is narrower and RNG-heavier than core gaps."
+    },
+    "Scrappy": {
+      "category": "missing_battle_result_impacting",
+      "why": "Ghost immunity bypass changes Fake Out and Fighting/Normal targeting."
+    },
+    "Shadow Tag": {
+      "category": "missing_battle_result_impacting",
+      "why": "Trapping fundamentally changes switch options and perish-style endgames."
+    },
+    "Sheer Force": {
+      "category": "missing_battle_result_impacting",
+      "why": "Damage boost plus secondary-effect suppression changes Mega Camerupt outputs."
+    },
+    "Shell Armor": {
+      "category": "missing_low_impact",
+      "why": "Crit immunity matters, but it is mega-only and less frequent than the top gaps."
+    },
+    "Skill Link": {
+      "category": "missing_battle_result_impacting",
+      "why": "Guaranteeing multihit move counts changes Mega Heracross damage dramatically."
+    },
+    "Snow Cloak": {
+      "category": "missing_low_impact",
+      "why": "Weather evasion can matter, but it is narrower and RNG-heavier than core gaps."
+    },
+    "Solar Power": {
+      "category": "missing_battle_result_impacting",
+      "why": "Sun damage boost and recoil change Mega Houndoom and Charizard-Y math."
+    },
+    "Stalwart": {
+      "category": "missing_battle_result_impacting",
+      "why": "Ignoring redirection changes doubles targeting for Mega Skarmory."
+    },
+    "Stamina": {
+      "category": "missing_battle_result_impacting",
+      "why": "Defense boosts on hit change Archaludon survivability over multi-hit turns."
+    },
+    "Stance Change": {
+      "category": "missing_battle_result_impacting",
+      "why": "Aegislash form swaps alter stats, damage, and survivability every turn."
+    },
+    "Strong Jaw": {
+      "category": "missing_battle_result_impacting",
+      "why": "Bite move boost changes Mega Sharpedo damage."
+    },
+    "Sturdy": {
+      "category": "missing_battle_result_impacting",
+      "why": "Surviving from full HP changes KO math and turn sequencing."
+    },
+    "Supreme Overlord": {
+      "category": "missing_battle_result_impacting",
+      "why": "Late-game damage scaling changes Kingambit closing power."
+    },
+    "Technician": {
+      "category": "missing_battle_result_impacting",
+      "why": "Low-base-power move boost changes Mega Scizor damage benchmarks."
+    },
+    "Thick Fat": {
+      "category": "missing_battle_result_impacting",
+      "why": "Fire and Ice damage reduction changes Mega Venusaur survival ranges."
+    },
+    "Tough Claws": {
+      "category": "missing_battle_result_impacting",
+      "why": "Contact damage boost changes Charizard-X and Aerodactyl-Mega outputs."
+    },
+    "Trace": {
+      "category": "missing_low_impact",
+      "why": "Copied-ability edge cases can matter, but all current exposure is mega-only."
+    },
+    "Unaware": {
+      "category": "missing_battle_result_impacting",
+      "why": "Ignoring opposing stat boosts changes setup matchups and endgame reads."
+    },
+    "Unnerve": {
+      "category": "missing_low_impact",
+      "why": "Berry suppression matters, but it is narrower than the current top mechanic gaps."
+    }
+  }
+}

--- a/poke-sim/tests/fixtures/ability_gap_classification.json
+++ b/poke-sim/tests/fixtures/ability_gap_classification.json
@@ -42,10 +42,6 @@
       "category": "missing_battle_result_impacting",
       "why": "Turns Intimidate and other drops into Milotic Special Attack boosts."
     },
-    "Compound Eyes": {
-      "category": "missing_battle_result_impacting",
-      "why": "Accuracy boost changes hit rates for status and utility lines."
-    },
     "Defiant": {
       "category": "missing_battle_result_impacting",
       "why": "Turns Intimidate and stat drops into Kingambit Attack boosts."
@@ -61,10 +57,6 @@
     "Filter": {
       "category": "missing_low_impact",
       "why": "Super-effective damage reduction matters, but only on mega-only catalog rows today."
-    },
-    "Flower Veil": {
-      "category": "missing_battle_result_impacting",
-      "why": "Protects allied Grass types from stat drops and status in supported lines."
     },
     "Friend Guard": {
       "category": "missing_battle_result_impacting",
@@ -93,10 +85,6 @@
     "Innards Out": {
       "category": "missing_battle_result_impacting",
       "why": "Punishes KOs with reflected HP loss and can swing trades."
-    },
-    "Insomnia": {
-      "category": "missing_low_impact",
-      "why": "Sleep immunity matters on Ariados, but it is narrower than the top coverage gaps."
     },
     "Iron Fist": {
       "category": "missing_battle_result_impacting",


### PR DESCRIPTION
Summary:
Mirrors the first high-impact Issue #125 mechanics slice from the Y Factor repo into Alfredo's repo: Prankster, Armor Tail, Good as Gold, and Magic Bounce.

What changed:
- Prankster now gives real battle priority to status moves
- targeted opposing Prankster status moves now fail into Dark-type targets
- Armor Tail now blocks opposing priority moves for the side
- Good as Gold now blocks targeted status moves
- Magic Bounce now reflects targeted status moves back to the user
- added focused regression tests for the new mechanics
- aligned the local ability audit inventory to Alfredo's current catalog size

Files changed:
- poke-sim/engine.js
- poke-sim/reports/ability_coverage_audit.md
- poke-sim/tests/README.md
- poke-sim/tests/ability_coverage_audit_tests.js
- poke-sim/tests/ability_priority_targeting_tests.js
- poke-sim/tests/fixtures/ability_gap_classification.json

Verification:
- node poke-sim/tests/ability_priority_targeting_tests.js
- node poke-sim/tests/ability_coverage_audit_tests.js
- node poke-sim/tests/t9j8_tests.js
- git diff --check

Coverage audit after this slice in Alfredo repo:
- curated plus mega ability inventory: 79
- modeled by engine: 23
- still unmodeled: 56

Governance:
- no Supabase changes
- no deployment
- no secrets
- no bundle changes
- no broad engine rewrite
- merge still requires approval