### PR TITLE
Sync ability damage parity from Y fork

### DIFF
--- a/poke-sim/engine.js
+++ b/poke-sim/engine.js
@@ -700,6 +700,18 @@ function _moveRecoilRule(move) {
 // Hook signatures:
 //   onModifyMove({move, attacker, field}) -> {move?, bpMult?, typeOverride?}
 //     Fires at the top of calcDamage so type/STAB/type-chart all see the change.
+//   onBasePower({move, moveType, basePower, attacker, defender, field}) -> {bpMod}
+//     Fires after dynamic BP resolution and before terrain/helping-hand BP mods.
+//     bpMod uses Showdown's 4096 fixed-point modifier scale.
+//   onSourceModifyAtk({move, moveType, attacker, defender, field}) -> {statMod}
+//     Fires from the defender before base damage is computed. statMod uses
+//     Showdown's 4096 fixed-point scale against the attack/sp-atk value.
+//   onModifyDamage({move, moveType, attacker, defender, typeEffectiveness, field}) -> {finalMod}
+//   onSourceModifyDamage({move, moveType, attacker, defender, typeEffectiveness, field}) -> {finalMod}
+//     Fires during final-mod construction. finalMod uses Showdown's 4096 scale.
+//   onTryHit({move, moveType, attacker, defender, field}) -> {immune, healFraction}
+//     Fires before damage calculation in battle execution and as a zero-damage
+//     guard in calcDamage previews.
 //   onProtectResolve({attacker, defender, move, moveType, isContact}) -> {damageMult}
 //     Fires when a target's Protect flag is up; default is 0 (full block). A
 //     positive damageMult lets the attacker deal dmg * mult through Protect.
@@ -809,8 +821,98 @@ var ABILITIES = {
       return null;
     }
   },
+  'Iron Fist': {
+    // Punch moves gain 20% power.
+    // Cite: https://github.com/smogon/pokemon-showdown/blob/master/data/abilities.ts
+    onBasePower: function(ctx) {
+      if (_moveHasFlag(ctx.move, 'punch')) return { bpMod: 4915 };
+      return null;
+    }
+  },
+  'Technician': {
+    // Moves with 60 or lower current BP gain 50% power.
+    // Cite: https://github.com/smogon/pokemon-showdown/blob/master/data/abilities.ts
+    onBasePower: function(ctx) {
+      if (ctx.basePower <= 60) return { bpMod: 6144 };
+      return null;
+    }
+  },
+  'Sand Force': {
+    // Rock/Ground/Steel moves gain 30% power during sand.
+    // Cite: https://github.com/smogon/pokemon-showdown/blob/master/data/abilities.ts
+    onBasePower: function(ctx) {
+      if (_effectiveFieldWeather(ctx.field) === 'sand' &&
+          (ctx.moveType === 'Rock' || ctx.moveType === 'Ground' || ctx.moveType === 'Steel')) {
+        return { bpMod: 5325 };
+      }
+      return null;
+    }
+  },
+  'Thick Fat': {
+    // Incoming Fire/Ice moves use half the attacker's relevant attacking stat.
+    // Cite: https://github.com/smogon/pokemon-showdown/blob/master/data/abilities.ts
+    onSourceModifyAtk: function(ctx) {
+      if (ctx.moveType === 'Fire' || ctx.moveType === 'Ice') return { statMod: 2048 };
+      return null;
+    }
+  },
+  'Filter': {
+    // Super-effective hits against the holder deal 0.75x damage.
+    // Cite: https://github.com/smogon/pokemon-showdown/blob/master/data/abilities.ts
+    onSourceModifyDamage: function(ctx) {
+      if (ctx.typeEffectiveness > 1) return { finalMod: 3072 };
+      return null;
+    }
+  },
+  'Tinted Lens': {
+    // Not-very-effective hits from the holder deal 2x damage.
+    // Cite: https://github.com/smogon/pokemon-showdown/blob/master/data/abilities.ts
+    onModifyDamage: function(ctx) {
+      if (ctx.typeEffectiveness < 1) return { finalMod: 8192 };
+      return null;
+    }
+  },
+  'Earth Eater': {
+    // Ground moves targeting another Pokemon are absorbed; holder heals 1/4 max HP.
+    // Cite: https://github.com/smogon/pokemon-showdown/blob/master/data/abilities.ts
+    onTryHit: function(ctx) {
+      if (ctx.defender !== ctx.attacker && ctx.moveType === 'Ground') {
+        return { immune: true, healFraction: 0.25 };
+      }
+      return null;
+    }
+  },
+  'Rough Skin': {
+    // Contact attackers lose 1/8 of their own max HP on a damaging hit.
+    // Mirrors Pokemon Showdown's onDamagingHit hook.
+    // Cite: https://github.com/smogon/pokemon-showdown/blob/master/data/abilities.ts
+    onDamagingHit: function(ctx) {
+      var attacker = ctx.attacker, defender = ctx.defender;
+      if (!attacker || !attacker.alive || !defender) return;
+      if (!ctx.damage || ctx.damage <= 0) return;
+      if (!_isContactMove(ctx.move)) return;
+      var chip = Math.max(1, Math.floor(attacker.maxHp / 8));
+      attacker.hp = Math.max(0, attacker.hp - chip);
+      if (ctx.log) ctx.log.push(attacker.name + " was hurt by " + defender.name + "'s Rough Skin! [" + chip + " dmg]");
+      if (attacker.hp === 0) {
+        attacker.alive = false;
+        if (ctx.log) ctx.log.push(attacker.name + ' fainted!');
+        if (typeof ctx.recordKO === 'function') {
+          ctx.recordKO(attacker, { move: ctx.move, attacker: defender, reason: 'Rough Skin' });
+        }
+      }
+    }
+  },
   // Inline in executeAction/setStanceForm: Aegislash swaps between Shield and Blade.
   'Stance Change': {},
+  // Inline in getStat: Attack is doubled after stat-stage resolution.
+  'Huge Power': {},
+  // Inline in getStat: Attack is doubled after stat-stage resolution.
+  'Pure Power': {},
+  // Inline in calcDamage: low-HP Fire moves get a 1.5x attacking-stat boost.
+  'Blaze': {},
+  // Inline in calcDamage: low-HP Grass moves get a 1.5x attacking-stat boost.
+  'Overgrow': {},
   'Solar Power': {},
   // Inline in applyDamage: survive lethal direct damage from full HP at 1 HP.
   'Sturdy': {},
@@ -1314,6 +1416,7 @@ class Pokemon {
     // Unburden doubles speed after item consumed
     if (stat === 'spe' && this.ability === 'Unburden' && this.itemConsumed) val *= 2;
     // Intimidate already applied to statBoosts.atk
+    if (stat === 'atk' && (this.ability === 'Huge Power' || this.ability === 'Pure Power')) val *= 2;
     // Standard baseline: Rock-types gain 1.5x Special Defense in sand.
     if (stat === 'spd' && effectiveWeather === 'sand' && Array.isArray(this.types) && this.types.includes('Rock')) val *= 1.5;
     // Eviolite for Dusclops
@@ -1412,6 +1515,14 @@ class Pokemon {
       : field.terrain === 'psychic' ? 'Psychic'
       : 'Normal';
     }
+    const _tryHitPreview = callAbilityHook(target, 'onTryHit', {
+      move: move,
+      moveType: moveType,
+      attacker: this,
+      defender: target,
+      field: field
+    });
+    if (_tryHitPreview && _tryHitPreview.immune) return 0;
 
     // T9j.8 (Refs #30) Mega Sol: personal sun when field weather is 'none'.
     let _effWeather = _effectiveMoveWeather(this, field, moveType);
@@ -1464,6 +1575,24 @@ class Pokemon {
     }
     if (!isPhysical && this.ability === 'Solar Power' && _fieldWeather === 'sun') {
       atk = _applyStatMod(atk, 6144);
+    }
+    if (this.hp <= this.maxHp / 3) {
+      if (this.ability === 'Blaze' && moveType === 'Fire') {
+        atk = _applyStatMod(atk, 6144);
+      }
+      if (this.ability === 'Overgrow' && moveType === 'Grass') {
+        atk = _applyStatMod(atk, 6144);
+      }
+    }
+    const _sourceAtkRes = callAbilityHook(target, 'onSourceModifyAtk', {
+      move: move,
+      moveType: moveType,
+      attacker: this,
+      defender: target,
+      field: field
+    });
+    if (_sourceAtkRes && _sourceAtkRes.statMod) {
+      atk = _applyStatMod(atk, _sourceAtkRes.statMod);
     }
 
     // Base power
@@ -1541,6 +1670,15 @@ class Pokemon {
     // Showdown / mainline terrain and Helping Hand modify base power, not the
     // late final-damage stage. Use fixed-point chaining so ranges stay aligned.
     const bpMods = [];
+    const _abilityBpRes = callAbilityHook(this, 'onBasePower', {
+      move: move,
+      moveType: moveType,
+      basePower: bp,
+      attacker: this,
+      defender: target,
+      field: field
+    });
+    if (_abilityBpRes && _abilityBpRes.bpMod) bpMods.push(_abilityBpRes.bpMod);
     if (this.helpingHand) bpMods.push(6144);
     if (_isGrounded(this)) {
       if (field.terrain === 'electric' && moveType === 'Electric') bpMods.push(5325);
@@ -1628,6 +1766,22 @@ class Pokemon {
     const supremeOverlordMod = this.ability === 'Supreme Overlord'
       ? SUPREME_OVERLORD_MODS[Math.min(this.side?.fainted || 0, 5)]
       : 4096;
+    const _attackerDamageRes = callAbilityHook(this, 'onModifyDamage', {
+      move: move,
+      moveType: moveType,
+      attacker: this,
+      defender: target,
+      typeEffectiveness: typeEff,
+      field: field
+    });
+    const _defenderDamageRes = callAbilityHook(target, 'onSourceModifyDamage', {
+      move: move,
+      moveType: moveType,
+      attacker: this,
+      defender: target,
+      typeEffectiveness: typeEff,
+      field: field
+    });
 
     // Choice Specs/Band handled in getStat
     // Burn handled in getStat
@@ -1635,7 +1789,6 @@ class Pokemon {
     // Base damage formula (Gen 9)
     const raw = Math.floor(Math.floor(Math.floor(2 * this.level / 5 + 2) * bp * atk / def) / 50) + 2;
     const roll = _sampleDamageRoll(this, field, rng);
-    const finalMod = _chain4096Mods([screenMod, loMod, supremeOverlordMod]);
     const applyStatusPenalty =
       (isPhysical && this.status === 'burn' && this.ability !== 'Guts' && move !== 'Facade') ||
       (!isPhysical && this.status === 'frostbite');
@@ -1646,7 +1799,10 @@ class Pokemon {
     baseDamage = _applyBaseDamageMod(baseDamage, spreadMod);
     baseDamage = _applyBaseDamageMod(baseDamage, weatherMod);
     if (_isCrit) baseDamage = Math.floor(_of32(baseDamage * 1.5));
-    return _finalizeDamage(baseDamage, roll, typeEff, applyStatusPenalty, stabMod, finalMod);
+    const finalMods = [screenMod, loMod, supremeOverlordMod];
+    if (_attackerDamageRes && _attackerDamageRes.finalMod) finalMods.push(_attackerDamageRes.finalMod);
+    if (_defenderDamageRes && _defenderDamageRes.finalMod) finalMods.push(_defenderDamageRes.finalMod);
+    return _finalizeDamage(baseDamage, roll, typeEff, applyStatusPenalty, stabMod, _chain4096Mods(finalMods));
   }
 
   applyItem(trigger, field) {
@@ -3943,6 +4099,28 @@ function simulateBattle(playerTeam, oppTeam, opts = {}) {
         if (t.side) t.side.quickGuard = false;
         log.push(`${attacker.name}'s Feint broke through ${t.name}'s protection!`);
       }
+      const _tryHitRes = callAbilityHook(t, 'onTryHit', {
+        attacker: attacker,
+        defender: t,
+        move: move,
+        moveType: _moveType(move),
+        field: field,
+        log: log
+      });
+      if (_tryHitRes && _tryHitRes.immune) {
+        const healFraction = Number(_tryHitRes.healFraction) || 0;
+        const healAmount = healFraction > 0 ? Math.max(1, Math.floor(t.maxHp * healFraction)) : 0;
+        const healed = healAmount > 0 && _canReceiveHealing(t)
+          ? Math.max(0, Math.min(t.maxHp, t.hp + healAmount) - t.hp)
+          : 0;
+        if (healed > 0) {
+          t.hp += healed;
+          log.push(`${t.name}'s ${t.ability} restored HP! [+${healed} HP]`);
+        } else {
+          log.push(`${t.name} is immune to ${move} because of ${t.ability}!`);
+        }
+        continue;
+      }
       // Set spread context for calcDamage
       field._ctx.isSpread = applySpreadMod;
       field._ctx.lastWasCrit = false;
@@ -4083,6 +4261,12 @@ function simulateBattle(playerTeam, oppTeam, opts = {}) {
         }
       }
     }
+    callAbilityHook(target, 'onDamagingHit', {
+      attacker: attacker, defender: target, move: move,
+      moveType: _moveType(move),
+      damage: finalDmg, field: field, log: log,
+      recordKO: _recordKO
+    });
     // Recoil
     const recoilRule = _moveRecoilRule(move);
     if (recoilRule && attacker && attacker.alive) {

--- a/poke-sim/pokemon-champion-2026.html
+++ b/poke-sim/pokemon-champion-2026.html
@@ -8928,6 +8928,18 @@ function _moveRecoilRule(move) {
 // Hook signatures:
 //   onModifyMove({move, attacker, field}) -> {move?, bpMult?, typeOverride?}
 //     Fires at the top of calcDamage so type/STAB/type-chart all see the change.
+//   onBasePower({move, moveType, basePower, attacker, defender, field}) -> {bpMod}
+//     Fires after dynamic BP resolution and before terrain/helping-hand BP mods.
+//     bpMod uses Showdown's 4096 fixed-point modifier scale.
+//   onSourceModifyAtk({move, moveType, attacker, defender, field}) -> {statMod}
+//     Fires from the defender before base damage is computed. statMod uses
+//     Showdown's 4096 fixed-point scale against the attack/sp-atk value.
+//   onModifyDamage({move, moveType, attacker, defender, typeEffectiveness, field}) -> {finalMod}
+//   onSourceModifyDamage({move, moveType, attacker, defender, typeEffectiveness, field}) -> {finalMod}
+//     Fires during final-mod construction. finalMod uses Showdown's 4096 scale.
+//   onTryHit({move, moveType, attacker, defender, field}) -> {immune, healFraction}
+//     Fires before damage calculation in battle execution and as a zero-damage
+//     guard in calcDamage previews.
 //   onProtectResolve({attacker, defender, move, moveType, isContact}) -> {damageMult}
 //     Fires when a target's Protect flag is up; default is 0 (full block). A
 //     positive damageMult lets the attacker deal dmg * mult through Protect.
@@ -9037,8 +9049,98 @@ var ABILITIES = {
       return null;
     }
   },
+  'Iron Fist': {
+    // Punch moves gain 20% power.
+    // Cite: https://github.com/smogon/pokemon-showdown/blob/master/data/abilities.ts
+    onBasePower: function(ctx) {
+      if (_moveHasFlag(ctx.move, 'punch')) return { bpMod: 4915 };
+      return null;
+    }
+  },
+  'Technician': {
+    // Moves with 60 or lower current BP gain 50% power.
+    // Cite: https://github.com/smogon/pokemon-showdown/blob/master/data/abilities.ts
+    onBasePower: function(ctx) {
+      if (ctx.basePower <= 60) return { bpMod: 6144 };
+      return null;
+    }
+  },
+  'Sand Force': {
+    // Rock/Ground/Steel moves gain 30% power during sand.
+    // Cite: https://github.com/smogon/pokemon-showdown/blob/master/data/abilities.ts
+    onBasePower: function(ctx) {
+      if (_effectiveFieldWeather(ctx.field) === 'sand' &&
+          (ctx.moveType === 'Rock' || ctx.moveType === 'Ground' || ctx.moveType === 'Steel')) {
+        return { bpMod: 5325 };
+      }
+      return null;
+    }
+  },
+  'Thick Fat': {
+    // Incoming Fire/Ice moves use half the attacker's relevant attacking stat.
+    // Cite: https://github.com/smogon/pokemon-showdown/blob/master/data/abilities.ts
+    onSourceModifyAtk: function(ctx) {
+      if (ctx.moveType === 'Fire' || ctx.moveType === 'Ice') return { statMod: 2048 };
+      return null;
+    }
+  },
+  'Filter': {
+    // Super-effective hits against the holder deal 0.75x damage.
+    // Cite: https://github.com/smogon/pokemon-showdown/blob/master/data/abilities.ts
+    onSourceModifyDamage: function(ctx) {
+      if (ctx.typeEffectiveness > 1) return { finalMod: 3072 };
+      return null;
+    }
+  },
+  'Tinted Lens': {
+    // Not-very-effective hits from the holder deal 2x damage.
+    // Cite: https://github.com/smogon/pokemon-showdown/blob/master/data/abilities.ts
+    onModifyDamage: function(ctx) {
+      if (ctx.typeEffectiveness < 1) return { finalMod: 8192 };
+      return null;
+    }
+  },
+  'Earth Eater': {
+    // Ground moves targeting another Pokemon are absorbed; holder heals 1/4 max HP.
+    // Cite: https://github.com/smogon/pokemon-showdown/blob/master/data/abilities.ts
+    onTryHit: function(ctx) {
+      if (ctx.defender !== ctx.attacker && ctx.moveType === 'Ground') {
+        return { immune: true, healFraction: 0.25 };
+      }
+      return null;
+    }
+  },
+  'Rough Skin': {
+    // Contact attackers lose 1/8 of their own max HP on a damaging hit.
+    // Mirrors Pokemon Showdown's onDamagingHit hook.
+    // Cite: https://github.com/smogon/pokemon-showdown/blob/master/data/abilities.ts
+    onDamagingHit: function(ctx) {
+      var attacker = ctx.attacker, defender = ctx.defender;
+      if (!attacker || !attacker.alive || !defender) return;
+      if (!ctx.damage || ctx.damage <= 0) return;
+      if (!_isContactMove(ctx.move)) return;
+      var chip = Math.max(1, Math.floor(attacker.maxHp / 8));
+      attacker.hp = Math.max(0, attacker.hp - chip);
+      if (ctx.log) ctx.log.push(attacker.name + " was hurt by " + defender.name + "'s Rough Skin! [" + chip + " dmg]");
+      if (attacker.hp === 0) {
+        attacker.alive = false;
+        if (ctx.log) ctx.log.push(attacker.name + ' fainted!');
+        if (typeof ctx.recordKO === 'function') {
+          ctx.recordKO(attacker, { move: ctx.move, attacker: defender, reason: 'Rough Skin' });
+        }
+      }
+    }
+  },
   // Inline in executeAction/setStanceForm: Aegislash swaps between Shield and Blade.
   'Stance Change': {},
+  // Inline in getStat: Attack is doubled after stat-stage resolution.
+  'Huge Power': {},
+  // Inline in getStat: Attack is doubled after stat-stage resolution.
+  'Pure Power': {},
+  // Inline in calcDamage: low-HP Fire moves get a 1.5x attacking-stat boost.
+  'Blaze': {},
+  // Inline in calcDamage: low-HP Grass moves get a 1.5x attacking-stat boost.
+  'Overgrow': {},
   'Solar Power': {},
   // Inline in applyDamage: survive lethal direct damage from full HP at 1 HP.
   'Sturdy': {},
@@ -9542,6 +9644,7 @@ class Pokemon {
     // Unburden doubles speed after item consumed
     if (stat === 'spe' && this.ability === 'Unburden' && this.itemConsumed) val *= 2;
     // Intimidate already applied to statBoosts.atk
+    if (stat === 'atk' && (this.ability === 'Huge Power' || this.ability === 'Pure Power')) val *= 2;
     // Standard baseline: Rock-types gain 1.5x Special Defense in sand.
     if (stat === 'spd' && effectiveWeather === 'sand' && Array.isArray(this.types) && this.types.includes('Rock')) val *= 1.5;
     // Eviolite for Dusclops
@@ -9640,6 +9743,14 @@ class Pokemon {
       : field.terrain === 'psychic' ? 'Psychic'
       : 'Normal';
     }
+    const _tryHitPreview = callAbilityHook(target, 'onTryHit', {
+      move: move,
+      moveType: moveType,
+      attacker: this,
+      defender: target,
+      field: field
+    });
+    if (_tryHitPreview && _tryHitPreview.immune) return 0;
 
     // T9j.8 (Refs #30) Mega Sol: personal sun when field weather is 'none'.
     let _effWeather = _effectiveMoveWeather(this, field, moveType);
@@ -9692,6 +9803,24 @@ class Pokemon {
     }
     if (!isPhysical && this.ability === 'Solar Power' && _fieldWeather === 'sun') {
       atk = _applyStatMod(atk, 6144);
+    }
+    if (this.hp <= this.maxHp / 3) {
+      if (this.ability === 'Blaze' && moveType === 'Fire') {
+        atk = _applyStatMod(atk, 6144);
+      }
+      if (this.ability === 'Overgrow' && moveType === 'Grass') {
+        atk = _applyStatMod(atk, 6144);
+      }
+    }
+    const _sourceAtkRes = callAbilityHook(target, 'onSourceModifyAtk', {
+      move: move,
+      moveType: moveType,
+      attacker: this,
+      defender: target,
+      field: field
+    });
+    if (_sourceAtkRes && _sourceAtkRes.statMod) {
+      atk = _applyStatMod(atk, _sourceAtkRes.statMod);
     }
 
     // Base power
@@ -9769,6 +9898,15 @@ class Pokemon {
     // Showdown / mainline terrain and Helping Hand modify base power, not the
     // late final-damage stage. Use fixed-point chaining so ranges stay aligned.
     const bpMods = [];
+    const _abilityBpRes = callAbilityHook(this, 'onBasePower', {
+      move: move,
+      moveType: moveType,
+      basePower: bp,
+      attacker: this,
+      defender: target,
+      field: field
+    });
+    if (_abilityBpRes && _abilityBpRes.bpMod) bpMods.push(_abilityBpRes.bpMod);
     if (this.helpingHand) bpMods.push(6144);
     if (_isGrounded(this)) {
       if (field.terrain === 'electric' && moveType === 'Electric') bpMods.push(5325);
@@ -9856,6 +9994,22 @@ class Pokemon {
     const supremeOverlordMod = this.ability === 'Supreme Overlord'
       ? SUPREME_OVERLORD_MODS[Math.min(this.side?.fainted || 0, 5)]
       : 4096;
+    const _attackerDamageRes = callAbilityHook(this, 'onModifyDamage', {
+      move: move,
+      moveType: moveType,
+      attacker: this,
+      defender: target,
+      typeEffectiveness: typeEff,
+      field: field
+    });
+    const _defenderDamageRes = callAbilityHook(target, 'onSourceModifyDamage', {
+      move: move,
+      moveType: moveType,
+      attacker: this,
+      defender: target,
+      typeEffectiveness: typeEff,
+      field: field
+    });
 
     // Choice Specs/Band handled in getStat
     // Burn handled in getStat
@@ -9863,7 +10017,6 @@ class Pokemon {
     // Base damage formula (Gen 9)
     const raw = Math.floor(Math.floor(Math.floor(2 * this.level / 5 + 2) * bp * atk / def) / 50) + 2;
     const roll = _sampleDamageRoll(this, field, rng);
-    const finalMod = _chain4096Mods([screenMod, loMod, supremeOverlordMod]);
     const applyStatusPenalty =
       (isPhysical && this.status === 'burn' && this.ability !== 'Guts' && move !== 'Facade') ||
       (!isPhysical && this.status === 'frostbite');
@@ -9874,7 +10027,10 @@ class Pokemon {
     baseDamage = _applyBaseDamageMod(baseDamage, spreadMod);
     baseDamage = _applyBaseDamageMod(baseDamage, weatherMod);
     if (_isCrit) baseDamage = Math.floor(_of32(baseDamage * 1.5));
-    return _finalizeDamage(baseDamage, roll, typeEff, applyStatusPenalty, stabMod, finalMod);
+    const finalMods = [screenMod, loMod, supremeOverlordMod];
+    if (_attackerDamageRes && _attackerDamageRes.finalMod) finalMods.push(_attackerDamageRes.finalMod);
+    if (_defenderDamageRes && _defenderDamageRes.finalMod) finalMods.push(_defenderDamageRes.finalMod);
+    return _finalizeDamage(baseDamage, roll, typeEff, applyStatusPenalty, stabMod, _chain4096Mods(finalMods));
   }
 
   applyItem(trigger, field) {
@@ -12171,6 +12327,28 @@ function simulateBattle(playerTeam, oppTeam, opts = {}) {
         if (t.side) t.side.quickGuard = false;
         log.push(`${attacker.name}'s Feint broke through ${t.name}'s protection!`);
       }
+      const _tryHitRes = callAbilityHook(t, 'onTryHit', {
+        attacker: attacker,
+        defender: t,
+        move: move,
+        moveType: _moveType(move),
+        field: field,
+        log: log
+      });
+      if (_tryHitRes && _tryHitRes.immune) {
+        const healFraction = Number(_tryHitRes.healFraction) || 0;
+        const healAmount = healFraction > 0 ? Math.max(1, Math.floor(t.maxHp * healFraction)) : 0;
+        const healed = healAmount > 0 && _canReceiveHealing(t)
+          ? Math.max(0, Math.min(t.maxHp, t.hp + healAmount) - t.hp)
+          : 0;
+        if (healed > 0) {
+          t.hp += healed;
+          log.push(`${t.name}'s ${t.ability} restored HP! [+${healed} HP]`);
+        } else {
+          log.push(`${t.name} is immune to ${move} because of ${t.ability}!`);
+        }
+        continue;
+      }
       // Set spread context for calcDamage
       field._ctx.isSpread = applySpreadMod;
       field._ctx.lastWasCrit = false;
@@ -12311,6 +12489,12 @@ function simulateBattle(playerTeam, oppTeam, opts = {}) {
         }
       }
     }
+    callAbilityHook(target, 'onDamagingHit', {
+      attacker: attacker, defender: target, move: move,
+      moveType: _moveType(move),
+      damage: finalDmg, field: field, log: log,
+      recordKO: _recordKO
+    });
     // Recoil
     const recoilRule = _moveRecoilRule(move);
     if (recoilRule && attacker && attacker.alive) {

--- a/poke-sim/reports/ability_coverage_audit.md
+++ b/poke-sim/reports/ability_coverage_audit.md
@@ -9,8 +9,8 @@ Scope:
 
 Summary:
 - unique curated-team + mega abilities audited: 80
-- already modeled by the engine: 34
-- still unmodeled and classified: 46
+- already modeled by the engine: 50
+- still unmodeled and classified: 30
 
 Why this exists:
 - Issue #125 showed repeated review friction around ability gaps being noticed ad hoc.
@@ -23,9 +23,8 @@ Classification buckets:
 
 Highest-priority shipped-team gaps:
 - `Shadow Tag`: changes switch options and perish-style endgames.
-- `Stance Change`, `Sturdy`, `Unaware`: major battle-result mechanics, not flavor.
-- `Strong Jaw` and `Mega Launcher`: direct damage modifiers with real mega exposure.
-- `Earth Eater` and `Rough Skin`: common contact and spread interaction swing points.
+- `Sheer Force`, `Fairy Aura`: direct damage modifiers with real KO-range impact.
+- `Infiltrator`, `Mold Breaker`, `Scrappy`, `Stalwart`: targeting, immunity, or defensive-bypass mechanics that can flip matchups.
 
 Implemented after this audit:
 - `Prankster`: real battle priority for status moves, with Dark-type immunity on targeted opposing status.
@@ -39,6 +38,23 @@ Implemented after this audit:
 - `Solar Power`: Showdown-aligned sun damage boost, plus end-of-turn recoil under active sun.
 - `Supreme Overlord`: Showdown-aligned late-game damage scaling from allied faint count.
 - `Tough Claws`: Showdown-aligned contact damage boost.
+- `Strong Jaw`: Showdown-aligned bite move damage boost.
+- `Mega Launcher`: Showdown-aligned pulse move damage boost.
+- `Stance Change`: Aegislash form swap changes battle stats across attacking/protecting lines.
+- `Sturdy`: Showdown-aligned full-HP lethal hit survival.
+- `Unaware`: Showdown-aligned stat-stage ignoring for attacker/defender comparisons.
+- `Rough Skin`: Showdown-aligned contact chip for damaging contact hits, including KO trades.
+- `Blaze`: Showdown-aligned low-HP Fire damage boost.
+- `Overgrow`: Showdown-aligned low-HP Grass damage boost.
+- `Iron Fist`: Showdown-aligned punch move damage boost.
+- `Technician`: Showdown-aligned low-BP move damage boost.
+- `Huge Power`: Showdown-aligned Attack doubling.
+- `Pure Power`: Showdown-aligned Attack doubling.
+- `Sand Force`: Showdown-aligned sand Rock/Ground/Steel damage boost.
+- `Thick Fat`: Showdown-aligned incoming Fire/Ice damage reduction.
+- `Filter`: Showdown-aligned super-effective damage reduction.
+- `Tinted Lens`: Showdown-aligned resisted-hit damage boost.
+- `Earth Eater`: Showdown-aligned Ground immunity and one-quarter max HP recovery on absorbed hits.
 
 Lower-priority or no-op examples:
 - `Frisk`: item reveal is effectively already visible in the sim.
@@ -49,15 +65,15 @@ Recommended implementation order:
 1. Priority and targeting control
    - `Shadow Tag`
 2. Damage modifiers with broad shipped-team exposure
-   - `Strong Jaw`
-   - `Mega Launcher`
+   - `Sheer Force`
+   - `Fairy Aura`
 3. Defensive and board-state mechanics
-   - `Earth Eater`
-   - `Sturdy`
-   - `Stance Change`
-   - `Unaware`
+   - `Infiltrator`
+   - `Mold Breaker`
+   - `Scrappy`
 4. Support and mitigation mechanics
-   - `Friend Guard`
+   - `Flower Veil`
+   - `Stalwart`
 
 Guardrail:
 - `tests/ability_coverage_audit_tests.js` compares the current unmodeled ability inventory against `tests/fixtures/ability_gap_classification.json`.

--- a/poke-sim/sw.js
+++ b/poke-sim/sw.js
@@ -45,7 +45,7 @@
 // restoring holders that were reduced to 0 HP before faint cleanup.
 // v55-champion-item-sp-gate [2026-06-21] - Positive Champions item allowlist,
 // SP import/export gate, and stale DB-team rejection before selector rebuild.
-const CACHE_NAME = 'champions-sim-v55-champion-item-sp-gate';
+const CACHE_NAME = 'champions-sim-v56-ability-damage-parity';
 const SPRITE_CACHE = 'champions-sprites-v1';
 
 const APP_ASSETS = [

--- a/poke-sim/tests/ability_damage_parity_tests.js
+++ b/poke-sim/tests/ability_damage_parity_tests.js
@@ -77,7 +77,7 @@ T('1. Sturdy survives a lethal hit from full HP', function() {
   const battle = ctx.simulateBattle(
     team([member('Magnemite', { ability: 'Sturdy', hp: probe.maxHp })]),
     team([member('Garchomp', {
-      ability: 'Rough Skin',
+      ability: '',
       nature: 'Adamant',
       moves: ['Earthquake'],
       evs: { hp: 0, atk: 32, def: 0, spa: 0, spd: 0, spe: 32 }
@@ -94,7 +94,7 @@ T('2. Sturdy does not trigger once the holder is chipped below full HP', functio
   const battle = ctx.simulateBattle(
     team([member('Magnemite', { ability: 'Sturdy', hp: probe.maxHp - 1 })]),
     team([member('Garchomp', {
-      ability: 'Rough Skin',
+      ability: '',
       nature: 'Adamant',
       moves: ['Earthquake'],
       evs: { hp: 0, atk: 32, def: 0, spa: 0, spd: 0, spe: 32 }
@@ -104,6 +104,90 @@ T('2. Sturdy does not trigger once the holder is chipped below full HP', functio
   falsy(battle.log.some(line => String(line).includes('Magnemite hung on with Sturdy!')),
     'Sturdy should not trigger after prior chip damage');
   eq(battle.playerSurvivors, 0, 'Chipped Sturdy holder should faint to the lethal hit');
+});
+
+T('3. Rough Skin damages a contact attacker by one eighth max HP', function() {
+  const attackerProbe = new ctx.Pokemon(member('Ninjask', { moves: ['Tackle'] }), '', 'champions');
+  const expectedChip = Math.max(1, Math.floor(attackerProbe.maxHp / 8));
+  const battle = ctx.simulateBattle(
+    team([member('Ninjask', {
+      moves: ['Tackle'],
+      evs: { hp: 0, atk: 32, def: 0, spa: 0, spd: 0, spe: 32 }
+    })]),
+    team([member('Garchomp', {
+      ability: 'Rough Skin',
+      moves: ['Splash'],
+      evs: { hp: 32, atk: 0, def: 32, spa: 0, spd: 0, spe: 0 }
+    })]),
+    { format: 'singles', seed: [1, 2, 3, 4], maxTurns: 1 }
+  );
+  truthy(battle.log.some(line => String(line).includes("Ninjask was hurt by Garchomp's Rough Skin! [" + expectedChip + ' dmg]')),
+    'Rough Skin contact chip log missing');
+});
+
+T('4. Rough Skin does not damage non-contact attackers', function() {
+  const battle = ctx.simulateBattle(
+    team([member('Garchomp', {
+      moves: ['Earthquake'],
+      evs: { hp: 0, atk: 32, def: 0, spa: 0, spd: 0, spe: 32 }
+    })]),
+    team([member('Garchomp', {
+      ability: 'Rough Skin',
+      moves: ['Splash'],
+      evs: { hp: 32, atk: 0, def: 32, spa: 0, spd: 0, spe: 0 }
+    })]),
+    { format: 'singles', seed: [1, 2, 3, 4], maxTurns: 1 }
+  );
+  falsy(battle.log.some(line => String(line).includes('Rough Skin')),
+    'Rough Skin should not trigger on Earthquake');
+});
+
+T('5. Rough Skin can KO a weakened contact attacker after damage is dealt', function() {
+  const battle = ctx.simulateBattle(
+    team([member('Ninjask', {
+      hp: 1,
+      moves: ['Tackle'],
+      evs: { hp: 0, atk: 32, def: 0, spa: 0, spd: 0, spe: 32 }
+    })]),
+    team([member('Garchomp', {
+      ability: 'Rough Skin',
+      moves: ['Splash'],
+      evs: { hp: 32, atk: 0, def: 32, spa: 0, spd: 0, spe: 0 }
+    })]),
+    { format: 'singles', seed: [1, 2, 3, 4], maxTurns: 1 }
+  );
+  truthy(battle.log.some(line => String(line).includes("Ninjask was hurt by Garchomp's Rough Skin!")),
+    'Rough Skin KO chip log missing');
+  truthy(battle.log.some(line => String(line).includes('Ninjask fainted!')),
+    'Rough Skin should faint the weakened attacker');
+  eq(battle.playerSurvivors, 0, 'Rough Skin should leave no player survivors when it KOs the only attacker');
+});
+
+T('6. Earth Eater blocks Ground damage and heals the target', function() {
+  const orthwormEvs = { hp: 31, atk: 1, def: 1, spa: 0, spd: 32, spe: 1 };
+  const probe = new ctx.Pokemon(member('Orthworm', { ability: 'Earth Eater', evs: orthwormEvs }), '', 'champions');
+  const expectedHeal = Math.max(1, Math.floor(probe.maxHp / 4));
+  const startingHp = probe.maxHp - expectedHeal;
+  const battle = ctx.simulateBattle(
+    team([member('Orthworm', {
+      ability: 'Earth Eater',
+      hp: startingHp,
+      moves: ['Splash'],
+      evs: orthwormEvs
+    })]),
+    team([member('Garchomp', {
+      ability: '',
+      nature: 'Adamant',
+      moves: ['Earthquake'],
+      evs: { hp: 0, atk: 32, def: 0, spa: 0, spd: 0, spe: 32 }
+    })]),
+    { format: 'singles', seed: [1, 2, 3, 4], maxTurns: 1 }
+  );
+  truthy(battle.log.some(line => String(line).includes("Orthworm's Earth Eater restored HP! [+" + expectedHeal + ' HP]')),
+    'Earth Eater heal log missing');
+  falsy(battle.log.some(line => String(line).includes('Garchomp used Earthquake!') && String(line).includes('Orthworm')),
+    'Earth Eater should block normal Earthquake damage application');
+  eq(battle.playerSurvivors, 1, 'Earth Eater holder should survive the Ground hit');
 });
 
 console.log('\nability damage parity:', pass + ' pass, ' + fail + ' fail\n');

--- a/poke-sim/tests/fixtures/ability_gap_classification.json
+++ b/poke-sim/tests/fixtures/ability_gap_classification.json
@@ -14,10 +14,6 @@
       "category": "missing_battle_result_impacting",
       "why": "Special Attack boost on HP threshold changes Mega Drampa snowball turns."
     },
-    "Blaze": {
-      "category": "missing_battle_result_impacting",
-      "why": "Low-HP Fire boost changes Charizard damage in close endgames."
-    },
     "Bulletproof": {
       "category": "missing_low_impact",
       "why": "Projectile immunities are real but Mega Chesnaught is not in current shipped teams."
@@ -26,17 +22,9 @@
       "category": "missing_battle_result_impacting",
       "why": "Accuracy boost changes hit rates for status and utility lines."
     },
-    "Earth Eater": {
-      "category": "missing_battle_result_impacting",
-      "why": "Ground immunity plus healing changes partner Earthquake interactions."
-    },
     "Fairy Aura": {
       "category": "missing_battle_result_impacting",
       "why": "Field-wide Fairy damage boost changes Mega Floette and partner damage."
-    },
-    "Filter": {
-      "category": "missing_low_impact",
-      "why": "Super-effective damage reduction matters, but only on mega-only catalog rows today."
     },
     "Flower Veil": {
       "category": "missing_battle_result_impacting",
@@ -54,10 +42,6 @@
       "category": "missing_low_impact",
       "why": "End-turn ally status cure can matter, but it is mega-only and relatively narrow."
     },
-    "Huge Power": {
-      "category": "missing_battle_result_impacting",
-      "why": "Attack doubling is a major damage multiplier on Mega Starmie."
-    },
     "Infiltrator": {
       "category": "missing_battle_result_impacting",
       "why": "Bypasses Substitute and screens, changing damage and status delivery."
@@ -69,10 +53,6 @@
     "Insomnia": {
       "category": "missing_low_impact",
       "why": "Sleep immunity matters on Ariados, but it is narrower than the top coverage gaps."
-    },
-    "Iron Fist": {
-      "category": "missing_battle_result_impacting",
-      "why": "Punching move boost changes Mega Golurk and Mega Crabominable damage."
     },
     "Limber": {
       "category": "missing_low_impact",
@@ -94,10 +74,6 @@
       "category": "missing_battle_result_impacting",
       "why": "Perfect accuracy changes both move reliability and opposing hit rates."
     },
-    "Overgrow": {
-      "category": "missing_battle_result_impacting",
-      "why": "Low-HP Grass boost changes Meganium damage in close games."
-    },
     "Poison Touch": {
       "category": "missing_battle_result_impacting",
       "why": "Contact poison chance changes Sneasler chip and status pressure."
@@ -109,18 +85,6 @@
     "Protean": {
       "category": "missing_battle_result_impacting",
       "why": "Type-changing on move use radically changes STAB and defensive matchups."
-    },
-    "Pure Power": {
-      "category": "missing_battle_result_impacting",
-      "why": "Attack doubling is a major damage multiplier on Mega Medicham."
-    },
-    "Rough Skin": {
-      "category": "missing_battle_result_impacting",
-      "why": "Contact chip affects many Garchomp trades and KO ranges."
-    },
-    "Sand Force": {
-      "category": "missing_battle_result_impacting",
-      "why": "Sand-boosted Rock, Ground, and Steel damage matters on Mega Steelix/Garchomp."
     },
     "Sand Veil": {
       "category": "missing_low_impact",
@@ -157,14 +121,6 @@
     "Stamina": {
       "category": "missing_battle_result_impacting",
       "why": "Defense boosts on hit change Archaludon survivability over multi-hit turns."
-    },
-    "Technician": {
-      "category": "missing_battle_result_impacting",
-      "why": "Low-base-power move boost changes Mega Scizor damage benchmarks."
-    },
-    "Thick Fat": {
-      "category": "missing_battle_result_impacting",
-      "why": "Fire and Ice damage reduction changes Mega Venusaur survival ranges."
     },
     "Trace": {
       "category": "missing_low_impact",

--- a/poke-sim/tests/showdown_damage_oracle_tests.js
+++ b/poke-sim/tests/showdown_damage_oracle_tests.js
@@ -541,5 +541,189 @@ T('28. Strong Jaw bite boost matches Showdown exactly', () => {
   eqRange(sim, oracle, 'strong jaw');
 });
 
+T('29. Blaze low-HP Fire boost matches Showdown exactly', () => {
+  const simAttacker = simMon('Charizard', { nature: 'Modest', moves: ['Flamethrower'], evs: { spa: 252 }, ability: 'Blaze' });
+  const oracleBase = calcMon('Charizard', { nature: 'Modest', moves: ['Flamethrower'], evs: { spa: 252 }, ability: 'Blaze' });
+  const lowHp = Math.floor(simAttacker.maxHp / 3);
+  simAttacker.hp = lowHp;
+  const sim = simRange(
+    simAttacker,
+    simMon('Incineroar'),
+    'Flamethrower',
+    new Field({ format: 'doubles' })
+  );
+  const oracle = oracleRange(
+    calcMon('Charizard', { nature: 'Modest', moves: ['Flamethrower'], evs: { spa: 252 }, ability: 'Blaze', curHP: Math.floor(oracleBase.maxHP() / 3) }),
+    calcMon('Incineroar'),
+    'Flamethrower',
+    new calc.Field({ gameType: 'Doubles' })
+  );
+  eqRange(sim, oracle, 'blaze');
+});
+
+T('30. Overgrow low-HP Grass boost matches Showdown exactly', () => {
+  const simAttacker = simMon('Venusaur', { nature: 'Modest', moves: ['Energy Ball'], evs: { spa: 252 }, ability: 'Overgrow' });
+  const oracleBase = calcMon('Venusaur', { nature: 'Modest', moves: ['Energy Ball'], evs: { spa: 252 }, ability: 'Overgrow' });
+  const lowHp = Math.floor(simAttacker.maxHp / 3);
+  simAttacker.hp = lowHp;
+  const sim = simRange(
+    simAttacker,
+    simMon('Pelipper'),
+    'Energy Ball',
+    new Field({ format: 'doubles' })
+  );
+  const oracle = oracleRange(
+    calcMon('Venusaur', { nature: 'Modest', moves: ['Energy Ball'], evs: { spa: 252 }, ability: 'Overgrow', curHP: Math.floor(oracleBase.maxHP() / 3) }),
+    calcMon('Pelipper'),
+    'Energy Ball',
+    new calc.Field({ gameType: 'Doubles' })
+  );
+  eqRange(sim, oracle, 'overgrow');
+});
+
+T('31. Iron Fist punch boost matches Showdown exactly', () => {
+  const sim = simRange(
+    simMon('Golurk', { nature: 'Adamant', moves: ['Ice Punch'], evs: { atk: 252 }, ability: 'Iron Fist' }),
+    simMon('Garchomp'),
+    'Ice Punch',
+    new Field({ format: 'doubles' })
+  );
+  const oracle = oracleRange(
+    calcMon('Golurk', { nature: 'Adamant', moves: ['Ice Punch'], evs: { atk: 252 }, ability: 'Iron Fist' }),
+    calcMon('Garchomp'),
+    'Ice Punch',
+    new calc.Field({ gameType: 'Doubles' })
+  );
+  eqRange(sim, oracle, 'iron fist');
+});
+
+T('32. Technician low-BP boost matches Showdown exactly', () => {
+  const sim = simRange(
+    simMon('Scizor-Mega', { nature: 'Adamant', moves: ['Bullet Punch'], evs: { atk: 252 }, ability: 'Technician' }),
+    simMon('Tyranitar'),
+    'Bullet Punch',
+    new Field({ format: 'doubles' })
+  );
+  const oracle = oracleRange(
+    calcMon('Scizor-Mega', { nature: 'Adamant', moves: ['Bullet Punch'], evs: { atk: 252 }, ability: 'Technician' }),
+    calcMon('Tyranitar'),
+    'Bullet Punch',
+    new calc.Field({ gameType: 'Doubles' })
+  );
+  eqRange(sim, oracle, 'technician');
+});
+
+T('33. Huge Power Attack boost matches Showdown exactly', () => {
+  const sim = simRange(
+    simMon('Azumarill', { nature: 'Adamant', moves: ['Liquidation'], evs: { atk: 252 }, ability: 'Huge Power' }),
+    simMon('Incineroar'),
+    'Liquidation',
+    new Field({ format: 'doubles' })
+  );
+  const oracle = oracleRange(
+    calcMon('Azumarill', { nature: 'Adamant', moves: ['Liquidation'], evs: { atk: 252 }, ability: 'Huge Power' }),
+    calcMon('Incineroar'),
+    'Liquidation',
+    new calc.Field({ gameType: 'Doubles' })
+  );
+  eqRange(sim, oracle, 'huge power');
+});
+
+T('34. Pure Power Attack boost matches Showdown exactly', () => {
+  const sim = simRange(
+    simMon('Medicham-Mega', { nature: 'Adamant', moves: ['Drain Punch'], evs: { atk: 252 }, ability: 'Pure Power' }),
+    simMon('Incineroar'),
+    'Drain Punch',
+    new Field({ format: 'doubles' })
+  );
+  const oracle = oracleRange(
+    calcMon('Medicham-Mega', { nature: 'Adamant', moves: ['Drain Punch'], evs: { atk: 252 }, ability: 'Pure Power' }),
+    calcMon('Incineroar'),
+    'Drain Punch',
+    new calc.Field({ gameType: 'Doubles' })
+  );
+  eqRange(sim, oracle, 'pure power');
+});
+
+T('35. Sand Force sand boost matches Showdown exactly', () => {
+  const sim = simRange(
+    simMon('Steelix-Mega', { nature: 'Adamant', moves: ['Iron Head'], evs: { atk: 252 }, ability: 'Sand Force' }),
+    simMon('Pelipper'),
+    'Iron Head',
+    new Field({ format: 'doubles', weather: 'sand' })
+  );
+  const oracle = oracleRange(
+    calcMon('Steelix-Mega', { nature: 'Adamant', moves: ['Iron Head'], evs: { atk: 252 }, ability: 'Sand Force' }),
+    calcMon('Pelipper'),
+    'Iron Head',
+    new calc.Field({ gameType: 'Doubles', weather: 'Sand' })
+  );
+  eqRange(sim, oracle, 'sand force');
+});
+
+T('36. Thick Fat Fire reduction matches Showdown exactly', () => {
+  const sim = simRange(
+    simMon('Charizard', { nature: 'Modest', moves: ['Flamethrower'], evs: { spa: 252 } }),
+    simMon('Venusaur-Mega', { ability: 'Thick Fat' }),
+    'Flamethrower',
+    new Field({ format: 'doubles' })
+  );
+  const oracle = oracleRange(
+    calcMon('Charizard', { nature: 'Modest', moves: ['Flamethrower'], evs: { spa: 252 } }),
+    calcMon('Venusaur-Mega', { ability: 'Thick Fat' }),
+    'Flamethrower',
+    new calc.Field({ gameType: 'Doubles' })
+  );
+  eqRange(sim, oracle, 'thick fat');
+});
+
+T('37. Filter super-effective reduction matches Showdown exactly', () => {
+  const sim = simRange(
+    simMon('Infernape', { nature: 'Adamant', moves: ['Close Combat'], evs: { atk: 252 } }),
+    simMon('Aggron-Mega', { ability: 'Filter' }),
+    'Close Combat',
+    new Field({ format: 'doubles' })
+  );
+  const oracle = oracleRange(
+    calcMon('Infernape', { nature: 'Adamant', moves: ['Close Combat'], evs: { atk: 252 } }),
+    calcMon('Aggron-Mega', { ability: 'Filter' }),
+    'Close Combat',
+    new calc.Field({ gameType: 'Doubles' })
+  );
+  eqRange(sim, oracle, 'filter');
+});
+
+T('38. Tinted Lens resisted-hit boost matches Showdown exactly', () => {
+  const sim = simRange(
+    simMon('Yanmega', { nature: 'Modest', moves: ['Bug Buzz'], evs: { spa: 252 }, ability: 'Tinted Lens' }),
+    simMon('Charizard'),
+    'Bug Buzz',
+    new Field({ format: 'doubles' })
+  );
+  const oracle = oracleRange(
+    calcMon('Yanmega', { nature: 'Modest', moves: ['Bug Buzz'], evs: { spa: 252 }, ability: 'Tinted Lens' }),
+    calcMon('Charizard'),
+    'Bug Buzz',
+    new calc.Field({ gameType: 'Doubles' })
+  );
+  eqRange(sim, oracle, 'tinted lens');
+});
+
+T('39. Earth Eater Ground immunity matches Showdown zero damage', () => {
+  const sim = simRange(
+    simMon('Garchomp', { nature: 'Adamant', moves: ['Earthquake'], evs: { atk: 252 } }),
+    simMon('Orthworm', { ability: 'Earth Eater' }),
+    'Earthquake',
+    new Field({ format: 'doubles' })
+  );
+  const oracle = oracleRange(
+    calcMon('Garchomp', { nature: 'Adamant', moves: ['Earthquake'], evs: { atk: 252 } }),
+    calcMon('Orthworm', { ability: 'Earth Eater' }),
+    'Earthquake',
+    new calc.Field({ gameType: 'Doubles' })
+  );
+  eqRange(sim, oracle, 'earth eater');
+});
+
 console.log('\nshowdown damage oracle:', pass + ' pass, ' + fail + ' fail\n');
 process.exit(fail ? 1 : 0);

--- a/poke-sim/tests/sw_local_credentials_tests.js
+++ b/poke-sim/tests/sw_local_credentials_tests.js
@@ -40,7 +40,7 @@ T('3. missing local-credentials.js returns empty JavaScript instead of cached ap
 });
 
 T('4. service worker cache is bumped for stale app-shell release fix', () => {
-  truthy(sw.includes('champions-sim-v55-champion-item-sp-gate'), 'CACHE_NAME should be v55 champion item/SP gate');
+  truthy(sw.includes('champions-sim-v56-ability-damage-parity'), 'CACHE_NAME should be v56 ability damage parity');
 });
 
 T('5. app shell includes pokemon-champion bundle in network-first detection', () => {


### PR DESCRIPTION
## Summary
- Syncs the latest Y fork Champion sim parity batch into Alfredo main.
- Adds Showdown-aligned ability hooks for Rough Skin, Blaze, Overgrow, Iron Fist, Technician, Huge Power, Pure Power, Sand Force, Thick Fat, Filter, Tinted Lens, and Earth Eater.
- Rebuilds the Pages HTML bundle and updates the ability coverage audit snapshot to 50 modeled / 30 open current abilities.

## Validation
- Local full no-DB suite: 90 non-DB test files passed, 14 DB files skipped.
- Local Showdown damage oracle: 39 pass / 0 fail.
- Local bundle freshness/load-order/UI smoke passed.
- Y fork CI passed, including 5,070-battle audit.
- Y fork Pages deploy passed for 36d1635.