### PR TITLE
Sync ability mechanics parity from Y fork

### DIFF
--- a/poke-sim/engine.js
+++ b/poke-sim/engine.js
@@ -266,6 +266,19 @@ var FLINCH_MOVES = {
   'Stomp':        { chance: 0.30 }
 };
 
+var SHEER_FORCE_MOVES = new Set([
+  'Air Slash','Ancient Power','Bite','Blizzard','Body Slam','Bug Buzz',
+  'Charge Beam','Crunch','Dark Pulse','Discharge','Dragon Rush','Earth Power',
+  'Energy Ball','Extrasensory','Fire Blast','Fire Fang','Flamethrower',
+  'Flash Cannon','Focus Blast','Heat Wave','Hurricane','Hyper Fang',
+  'Ice Beam','Ice Fang','Icicle Crash','Icy Wind','Iron Head','Lava Plume',
+  'Lunge','Meteor Mash','Moonblast','Muddy Water','Needle Arm','Poison Jab',
+  'Psychic','Psychic Noise','Rock Slide','Rock Tomb','Scald','Scorching Sands',
+  'Seed Flare','Shadow Ball','Sludge Bomb','Sludge Wave','Snarl','Thunder',
+  'Thunder Fang','Thunderbolt','Tri Attack','Twister','Waterfall','Zen Headbutt',
+  'Dire Claw','Matcha Gotcha'
+]);
+
 // Contact moves — Champions/Gen 9 contact list used by Piercing Drill,
 // Unseen Fist, and future contact-triggered hooks (Rough Skin, Iron Barbs).
 // Cite: https://bulbapedia.bulbagarden.net/wiki/Contact
@@ -607,6 +620,24 @@ function _applyTargetStageMap(source, target, deltas, log) {
   return applied;
 }
 
+function _attackerIgnoresTargetAbility(attacker, target) {
+  return !!(
+    attacker &&
+    target &&
+    attacker !== target &&
+    attacker.ability === 'Mold Breaker' &&
+    target.item !== 'Ability Shield'
+  );
+}
+
+function _targetAbilityActive(target, attacker, ability) {
+  return !!(
+    target &&
+    target.ability === ability &&
+    !_attackerIgnoresTargetAbility(attacker, target)
+  );
+}
+
 function _isGrounded(mon) {
   return !!mon && !mon.flying;
 }
@@ -821,6 +852,24 @@ var ABILITIES = {
       return null;
     }
   },
+  'Sheer Force': {
+    // Moves with eligible secondary effects gain 30% power and those effects
+    // are suppressed after damage. Uses the current engine's secondary-effect
+    // surface plus common Showdown secondary moves used by shipped teams.
+    // Cite: https://github.com/smogon/pokemon-showdown/blob/master/data/abilities.ts
+    onBasePower: function(ctx) {
+      if (SHEER_FORCE_MOVES.has(ctx.move)) return { bpMod: 5325 };
+      return null;
+    }
+  },
+  'Fairy Aura': {
+    // Fairy moves gain Showdown's aura modifier, 0x1548 / 0x1000.
+    // Cite: https://github.com/smogon/pokemon-showdown/blob/master/data/abilities.ts
+    onBasePower: function(ctx) {
+      if (ctx.moveType === 'Fairy') return { bpMod: 5448 };
+      return null;
+    }
+  },
   'Iron Fist': {
     // Punch moves gain 20% power.
     // Cite: https://github.com/smogon/pokemon-showdown/blob/master/data/abilities.ts
@@ -872,6 +921,18 @@ var ABILITIES = {
       return null;
     }
   },
+  'Levitate': {
+    // Ground immunity for grounded non-Thousand Arrows attacks. Flying-type
+    // immunity is still handled by the type chart; this covers non-Flying
+    // Levitate users such as Cresselia/Rotom/Chimecho.
+    // Cite: https://github.com/smogon/pokemon-showdown/blob/master/data/abilities.ts
+    onTryHit: function(ctx) {
+      if (ctx.defender !== ctx.attacker && ctx.moveType === 'Ground' && ctx.move !== 'Thousand Arrows') {
+        return { immune: true };
+      }
+      return null;
+    }
+  },
   'Earth Eater': {
     // Ground moves targeting another Pokemon are absorbed; holder heals 1/4 max HP.
     // Cite: https://github.com/smogon/pokemon-showdown/blob/master/data/abilities.ts
@@ -903,6 +964,14 @@ var ABILITIES = {
       }
     }
   },
+  // Inline in calcDamage/applyDamage: ignores modeled target defensive hooks,
+  // defender Unaware, Sturdy, Levitate/Earth Eater immunity, and reductions.
+  'Mold Breaker': {},
+  // Inline in calcDamage/applyEntryAbility: Normal/Fighting hit Ghosts and
+  // Intimidate-style Attack drops are ignored.
+  'Scrappy': {},
+  // Inline in calcDamage/status/applyDamage: bypasses screens and Substitute.
+  'Infiltrator': {},
   // Inline in executeAction/setStanceForm: Aegislash swaps between Shield and Blade.
   'Stance Change': {},
   // Inline in getStat: Attack is doubled after stat-stage resolution.
@@ -1012,6 +1081,8 @@ function applyWeatherAbility(mon, field, log) {
 // no matching hook. Invoked from engine trigger points.
 function callAbilityHook(mon, hookName, ctx) {
   if (!mon || !mon.ability) return null;
+  if ((hookName === 'onTryHit' || hookName === 'onSourceModifyAtk' || hookName === 'onSourceModifyDamage') &&
+      ctx && _attackerIgnoresTargetAbility(ctx.attacker, mon)) return null;
   var ability = ABILITIES[mon.ability];
   if (!ability || typeof ability[hookName] !== 'function') return null;
   try {
@@ -1547,7 +1618,7 @@ class Pokemon {
     const dBoost = target.statBoosts[dStatKey] || 0;
     let aOverride = aBoost;
     let dOverride = dBoost;
-    if (target.ability === 'Unaware') aOverride = 0;
+    if (_targetAbilityActive(target, this, 'Unaware')) aOverride = 0;
     if (this.ability === 'Unaware') dOverride = 0;
     if (_isCrit) {
       if (aOverride < 0) aOverride = 0;
@@ -1724,6 +1795,8 @@ class Pokemon {
       let eff = (chart[t] !== undefined ? chart[t] : 1);
       // Freeze-Dry replaces Ice's normal Water matchup with super effective.
       if (move === 'Freeze-Dry' && t === 'Water') eff = 2;
+      if (eff === 0 && t === 'Ghost' && this.ability === 'Scrappy' &&
+          (moveType === 'Normal' || moveType === 'Fighting')) eff = 1;
       typeEff *= eff;
     }
     if (typeEff === 0) return 0;
@@ -1750,7 +1823,7 @@ class Pokemon {
     const _screenBase = (_fmt === 'doubles') ? 2732 : 2048;
     let screenMod = 4096;
     const _tSide = target.side;
-    if (_tSide && !_isCrit) {
+    if (_tSide && !_isCrit && this.ability !== 'Infiltrator') {
       if (_tSide.auroraVeil) {
         screenMod = _screenBase;
       } else if (isPhysical && _tSide.reflect) {
@@ -2590,7 +2663,7 @@ function simulateBattle(playerTeam, oppTeam, opts = {}) {
       log.push(`${mon.name}'s Intimidate activated!`);
       for (const t of targets) {
         if (!t.alive) continue;
-        if (t.ability === 'Inner Focus' || t.ability === 'Own Tempo' || t.ability === 'Oblivious') {
+        if (t.ability === 'Inner Focus' || t.ability === 'Own Tempo' || t.ability === 'Oblivious' || t.ability === 'Scrappy') {
           log.push(`${t.name} ignored Intimidate!`);
           continue;
         }
@@ -3021,7 +3094,7 @@ function simulateBattle(playerTeam, oppTeam, opts = {}) {
         'Parting Shot',
         'Trick'
       ]);
-      if (target && target.alive && target.substituteHp > 0 && blockedBySubstitute.has(move)) {
+      if (target && target.alive && target.substituteHp > 0 && attacker.ability !== 'Infiltrator' && blockedBySubstitute.has(move)) {
         log.push(`${attacker.name} used ${move}! But it failed because of Substitute!`);
         return;
       }
@@ -4033,7 +4106,7 @@ function simulateBattle(playerTeam, oppTeam, opts = {}) {
 
     for (const t of ordered) {
       if (!t.alive) continue;
-      const _hadSubstitute = t.substituteHp > 0;
+      const _hadSubstitute = t.substituteHp > 0 && attacker.ability !== 'Infiltrator';
       if (t.concealedByMove && move !== 'Phantom Force') {
         log.push(`${t.name} avoided the attack while concealed!`);
         continue;
@@ -4136,23 +4209,24 @@ function simulateBattle(playerTeam, oppTeam, opts = {}) {
         if (_wasCrit) log.push(`A critical hit!`);
         applyDamage(attacker, move, t, dmg, field, log, rng);
         resolution.didDamage = true;
-        if (SPEED_DROP_MOVES.has(move)) {
+        const _suppressSecondary = attacker.ability === 'Sheer Force' && SHEER_FORCE_MOVES.has(move);
+        if (!_suppressSecondary && SPEED_DROP_MOVES.has(move)) {
           _applyTargetStageMap(attacker, t, { spe: -1 }, log);
         }
-        if (move === 'Snarl' && t.alive && !_hadSubstitute) _applyTargetStageMap(attacker, t, { spa: -1 }, log);
-        if (move === 'Lunge' && t.alive && !_hadSubstitute) _applyTargetStageMap(attacker, t, { atk: -1 }, log);
-        if (move === 'Psychic Noise' && t.alive) {
+        if (!_suppressSecondary && move === 'Snarl' && t.alive && !_hadSubstitute) _applyTargetStageMap(attacker, t, { spa: -1 }, log);
+        if (!_suppressSecondary && move === 'Lunge' && t.alive && !_hadSubstitute) _applyTargetStageMap(attacker, t, { atk: -1 }, log);
+        if (!_suppressSecondary && move === 'Psychic Noise' && t.alive) {
           t.healBlockedTurns = Math.max(t.healBlockedTurns || 0, 2);
           log.push(`${t.name} can no longer recover HP because of Psychic Noise!`);
         }
-        if (move === 'Muddy Water' && rng() < 0.30) {
+        if (!_suppressSecondary && move === 'Muddy Water' && rng() < 0.30) {
           _applyTargetStageMap(attacker, t, { acc: -1 }, log);
         }
         // T9j.8 (Refs #19) Flinch roll: after damage applied, target alive,
         // target hasn't acted yet. Fang moves roll flinch + status independently.
         if (t.alive) {
           const _flinch = FLINCH_MOVES[move];
-          if (_flinch && !t.hasActed && rng() < _flinch.chance) {
+          if (!_suppressSecondary && _flinch && !t.hasActed && rng() < _flinch.chance) {
             t._flinched = true;
             log.push(`${t.name} flinched and couldn't move!`);
           }
@@ -4185,7 +4259,7 @@ function simulateBattle(playerTeam, oppTeam, opts = {}) {
     let finalDmg = dmg;
     const DRAIN_MOVES = new Set(['Giga Drain', 'Matcha Gotcha']);
     // Substitute absorb
-    if (target.substituteHp > 0) {
+    if (target.substituteHp > 0 && !(attacker && attacker.ability === 'Infiltrator')) {
       target.substituteHp -= finalDmg;
       if (target.substituteHp <= 0) { target.substituteHp = 0; log.push(`${target.name}'s Substitute was destroyed!`); }
       else log.push(`${attacker.name} used ${move}! (Substitute absorbed ${finalDmg} dmg)`);
@@ -4210,7 +4284,7 @@ function simulateBattle(playerTeam, oppTeam, opts = {}) {
     target.hp = Math.max(0, target.hp - finalDmg);
     // T9j.6 (#8) — Focus Sash survives a KO from full HP; consumed.
     let sturdySaved = false;
-    if (target.hp === 0 && target.ability === 'Sturdy' && wasFullHp) {
+    if (target.hp === 0 && _targetAbilityActive(target, attacker, 'Sturdy') && wasFullHp) {
       target.hp = 1;
       sturdySaved = true;
     }
@@ -4239,13 +4313,14 @@ function simulateBattle(playerTeam, oppTeam, opts = {}) {
       target.frozenTurns = 0;
       log.push(`${target.name} was thawed out by ${attacker.name}'s ${move}!`);
     }
+    const suppressSecondary = attacker && attacker.ability === 'Sheer Force' && SHEER_FORCE_MOVES.has(move);
     if (move === 'Matcha Gotcha' && target.alive) {
-      if (!target.status && canInflictStatus(target, 'burn', field) && rng() < 0.2) {
+      if (!suppressSecondary && !target.status && canInflictStatus(target, 'burn', field) && rng() < 0.2) {
         target.status = 'burn';
         log.push(`${target.name} was burned by ${attacker.name}'s Matcha Gotcha!`);
       }
     }
-    if (move === 'Dire Claw' && target.alive && !target.status) {
+    if (!suppressSecondary && move === 'Dire Claw' && target.alive && !target.status) {
       if (rng() < 0.5) {
         const options = ['poison', 'paralysis', 'sleep'].filter((status) => canInflictStatus(target, status, field));
         if (options.length) {

--- a/poke-sim/pokemon-champion-2026.html
+++ b/poke-sim/pokemon-champion-2026.html
@@ -8494,6 +8494,19 @@ var FLINCH_MOVES = {
   'Stomp':        { chance: 0.30 }
 };
 
+var SHEER_FORCE_MOVES = new Set([
+  'Air Slash','Ancient Power','Bite','Blizzard','Body Slam','Bug Buzz',
+  'Charge Beam','Crunch','Dark Pulse','Discharge','Dragon Rush','Earth Power',
+  'Energy Ball','Extrasensory','Fire Blast','Fire Fang','Flamethrower',
+  'Flash Cannon','Focus Blast','Heat Wave','Hurricane','Hyper Fang',
+  'Ice Beam','Ice Fang','Icicle Crash','Icy Wind','Iron Head','Lava Plume',
+  'Lunge','Meteor Mash','Moonblast','Muddy Water','Needle Arm','Poison Jab',
+  'Psychic','Psychic Noise','Rock Slide','Rock Tomb','Scald','Scorching Sands',
+  'Seed Flare','Shadow Ball','Sludge Bomb','Sludge Wave','Snarl','Thunder',
+  'Thunder Fang','Thunderbolt','Tri Attack','Twister','Waterfall','Zen Headbutt',
+  'Dire Claw','Matcha Gotcha'
+]);
+
 // Contact moves — Champions/Gen 9 contact list used by Piercing Drill,
 // Unseen Fist, and future contact-triggered hooks (Rough Skin, Iron Barbs).
 // Cite: https://bulbapedia.bulbagarden.net/wiki/Contact
@@ -8835,6 +8848,24 @@ function _applyTargetStageMap(source, target, deltas, log) {
   return applied;
 }
 
+function _attackerIgnoresTargetAbility(attacker, target) {
+  return !!(
+    attacker &&
+    target &&
+    attacker !== target &&
+    attacker.ability === 'Mold Breaker' &&
+    target.item !== 'Ability Shield'
+  );
+}
+
+function _targetAbilityActive(target, attacker, ability) {
+  return !!(
+    target &&
+    target.ability === ability &&
+    !_attackerIgnoresTargetAbility(attacker, target)
+  );
+}
+
 function _isGrounded(mon) {
   return !!mon && !mon.flying;
 }
@@ -9049,6 +9080,24 @@ var ABILITIES = {
       return null;
     }
   },
+  'Sheer Force': {
+    // Moves with eligible secondary effects gain 30% power and those effects
+    // are suppressed after damage. Uses the current engine's secondary-effect
+    // surface plus common Showdown secondary moves used by shipped teams.
+    // Cite: https://github.com/smogon/pokemon-showdown/blob/master/data/abilities.ts
+    onBasePower: function(ctx) {
+      if (SHEER_FORCE_MOVES.has(ctx.move)) return { bpMod: 5325 };
+      return null;
+    }
+  },
+  'Fairy Aura': {
+    // Fairy moves gain Showdown's aura modifier, 0x1548 / 0x1000.
+    // Cite: https://github.com/smogon/pokemon-showdown/blob/master/data/abilities.ts
+    onBasePower: function(ctx) {
+      if (ctx.moveType === 'Fairy') return { bpMod: 5448 };
+      return null;
+    }
+  },
   'Iron Fist': {
     // Punch moves gain 20% power.
     // Cite: https://github.com/smogon/pokemon-showdown/blob/master/data/abilities.ts
@@ -9100,6 +9149,18 @@ var ABILITIES = {
       return null;
     }
   },
+  'Levitate': {
+    // Ground immunity for grounded non-Thousand Arrows attacks. Flying-type
+    // immunity is still handled by the type chart; this covers non-Flying
+    // Levitate users such as Cresselia/Rotom/Chimecho.
+    // Cite: https://github.com/smogon/pokemon-showdown/blob/master/data/abilities.ts
+    onTryHit: function(ctx) {
+      if (ctx.defender !== ctx.attacker && ctx.moveType === 'Ground' && ctx.move !== 'Thousand Arrows') {
+        return { immune: true };
+      }
+      return null;
+    }
+  },
   'Earth Eater': {
     // Ground moves targeting another Pokemon are absorbed; holder heals 1/4 max HP.
     // Cite: https://github.com/smogon/pokemon-showdown/blob/master/data/abilities.ts
@@ -9131,6 +9192,14 @@ var ABILITIES = {
       }
     }
   },
+  // Inline in calcDamage/applyDamage: ignores modeled target defensive hooks,
+  // defender Unaware, Sturdy, Levitate/Earth Eater immunity, and reductions.
+  'Mold Breaker': {},
+  // Inline in calcDamage/applyEntryAbility: Normal/Fighting hit Ghosts and
+  // Intimidate-style Attack drops are ignored.
+  'Scrappy': {},
+  // Inline in calcDamage/status/applyDamage: bypasses screens and Substitute.
+  'Infiltrator': {},
   // Inline in executeAction/setStanceForm: Aegislash swaps between Shield and Blade.
   'Stance Change': {},
   // Inline in getStat: Attack is doubled after stat-stage resolution.
@@ -9240,6 +9309,8 @@ function applyWeatherAbility(mon, field, log) {
 // no matching hook. Invoked from engine trigger points.
 function callAbilityHook(mon, hookName, ctx) {
   if (!mon || !mon.ability) return null;
+  if ((hookName === 'onTryHit' || hookName === 'onSourceModifyAtk' || hookName === 'onSourceModifyDamage') &&
+      ctx && _attackerIgnoresTargetAbility(ctx.attacker, mon)) return null;
   var ability = ABILITIES[mon.ability];
   if (!ability || typeof ability[hookName] !== 'function') return null;
   try {
@@ -9775,7 +9846,7 @@ class Pokemon {
     const dBoost = target.statBoosts[dStatKey] || 0;
     let aOverride = aBoost;
     let dOverride = dBoost;
-    if (target.ability === 'Unaware') aOverride = 0;
+    if (_targetAbilityActive(target, this, 'Unaware')) aOverride = 0;
     if (this.ability === 'Unaware') dOverride = 0;
     if (_isCrit) {
       if (aOverride < 0) aOverride = 0;
@@ -9952,6 +10023,8 @@ class Pokemon {
       let eff = (chart[t] !== undefined ? chart[t] : 1);
       // Freeze-Dry replaces Ice's normal Water matchup with super effective.
       if (move === 'Freeze-Dry' && t === 'Water') eff = 2;
+      if (eff === 0 && t === 'Ghost' && this.ability === 'Scrappy' &&
+          (moveType === 'Normal' || moveType === 'Fighting')) eff = 1;
       typeEff *= eff;
     }
     if (typeEff === 0) return 0;
@@ -9978,7 +10051,7 @@ class Pokemon {
     const _screenBase = (_fmt === 'doubles') ? 2732 : 2048;
     let screenMod = 4096;
     const _tSide = target.side;
-    if (_tSide && !_isCrit) {
+    if (_tSide && !_isCrit && this.ability !== 'Infiltrator') {
       if (_tSide.auroraVeil) {
         screenMod = _screenBase;
       } else if (isPhysical && _tSide.reflect) {
@@ -10818,7 +10891,7 @@ function simulateBattle(playerTeam, oppTeam, opts = {}) {
       log.push(`${mon.name}'s Intimidate activated!`);
       for (const t of targets) {
         if (!t.alive) continue;
-        if (t.ability === 'Inner Focus' || t.ability === 'Own Tempo' || t.ability === 'Oblivious') {
+        if (t.ability === 'Inner Focus' || t.ability === 'Own Tempo' || t.ability === 'Oblivious' || t.ability === 'Scrappy') {
           log.push(`${t.name} ignored Intimidate!`);
           continue;
         }
@@ -11249,7 +11322,7 @@ function simulateBattle(playerTeam, oppTeam, opts = {}) {
         'Parting Shot',
         'Trick'
       ]);
-      if (target && target.alive && target.substituteHp > 0 && blockedBySubstitute.has(move)) {
+      if (target && target.alive && target.substituteHp > 0 && attacker.ability !== 'Infiltrator' && blockedBySubstitute.has(move)) {
         log.push(`${attacker.name} used ${move}! But it failed because of Substitute!`);
         return;
       }
@@ -12261,7 +12334,7 @@ function simulateBattle(playerTeam, oppTeam, opts = {}) {
 
     for (const t of ordered) {
       if (!t.alive) continue;
-      const _hadSubstitute = t.substituteHp > 0;
+      const _hadSubstitute = t.substituteHp > 0 && attacker.ability !== 'Infiltrator';
       if (t.concealedByMove && move !== 'Phantom Force') {
         log.push(`${t.name} avoided the attack while concealed!`);
         continue;
@@ -12364,23 +12437,24 @@ function simulateBattle(playerTeam, oppTeam, opts = {}) {
         if (_wasCrit) log.push(`A critical hit!`);
         applyDamage(attacker, move, t, dmg, field, log, rng);
         resolution.didDamage = true;
-        if (SPEED_DROP_MOVES.has(move)) {
+        const _suppressSecondary = attacker.ability === 'Sheer Force' && SHEER_FORCE_MOVES.has(move);
+        if (!_suppressSecondary && SPEED_DROP_MOVES.has(move)) {
           _applyTargetStageMap(attacker, t, { spe: -1 }, log);
         }
-        if (move === 'Snarl' && t.alive && !_hadSubstitute) _applyTargetStageMap(attacker, t, { spa: -1 }, log);
-        if (move === 'Lunge' && t.alive && !_hadSubstitute) _applyTargetStageMap(attacker, t, { atk: -1 }, log);
-        if (move === 'Psychic Noise' && t.alive) {
+        if (!_suppressSecondary && move === 'Snarl' && t.alive && !_hadSubstitute) _applyTargetStageMap(attacker, t, { spa: -1 }, log);
+        if (!_suppressSecondary && move === 'Lunge' && t.alive && !_hadSubstitute) _applyTargetStageMap(attacker, t, { atk: -1 }, log);
+        if (!_suppressSecondary && move === 'Psychic Noise' && t.alive) {
           t.healBlockedTurns = Math.max(t.healBlockedTurns || 0, 2);
           log.push(`${t.name} can no longer recover HP because of Psychic Noise!`);
         }
-        if (move === 'Muddy Water' && rng() < 0.30) {
+        if (!_suppressSecondary && move === 'Muddy Water' && rng() < 0.30) {
           _applyTargetStageMap(attacker, t, { acc: -1 }, log);
         }
         // T9j.8 (Refs #19) Flinch roll: after damage applied, target alive,
         // target hasn't acted yet. Fang moves roll flinch + status independently.
         if (t.alive) {
           const _flinch = FLINCH_MOVES[move];
-          if (_flinch && !t.hasActed && rng() < _flinch.chance) {
+          if (!_suppressSecondary && _flinch && !t.hasActed && rng() < _flinch.chance) {
             t._flinched = true;
             log.push(`${t.name} flinched and couldn't move!`);
           }
@@ -12413,7 +12487,7 @@ function simulateBattle(playerTeam, oppTeam, opts = {}) {
     let finalDmg = dmg;
     const DRAIN_MOVES = new Set(['Giga Drain', 'Matcha Gotcha']);
     // Substitute absorb
-    if (target.substituteHp > 0) {
+    if (target.substituteHp > 0 && !(attacker && attacker.ability === 'Infiltrator')) {
       target.substituteHp -= finalDmg;
       if (target.substituteHp <= 0) { target.substituteHp = 0; log.push(`${target.name}'s Substitute was destroyed!`); }
       else log.push(`${attacker.name} used ${move}! (Substitute absorbed ${finalDmg} dmg)`);
@@ -12438,7 +12512,7 @@ function simulateBattle(playerTeam, oppTeam, opts = {}) {
     target.hp = Math.max(0, target.hp - finalDmg);
     // T9j.6 (#8) — Focus Sash survives a KO from full HP; consumed.
     let sturdySaved = false;
-    if (target.hp === 0 && target.ability === 'Sturdy' && wasFullHp) {
+    if (target.hp === 0 && _targetAbilityActive(target, attacker, 'Sturdy') && wasFullHp) {
       target.hp = 1;
       sturdySaved = true;
     }
@@ -12467,13 +12541,14 @@ function simulateBattle(playerTeam, oppTeam, opts = {}) {
       target.frozenTurns = 0;
       log.push(`${target.name} was thawed out by ${attacker.name}'s ${move}!`);
     }
+    const suppressSecondary = attacker && attacker.ability === 'Sheer Force' && SHEER_FORCE_MOVES.has(move);
     if (move === 'Matcha Gotcha' && target.alive) {
-      if (!target.status && canInflictStatus(target, 'burn', field) && rng() < 0.2) {
+      if (!suppressSecondary && !target.status && canInflictStatus(target, 'burn', field) && rng() < 0.2) {
         target.status = 'burn';
         log.push(`${target.name} was burned by ${attacker.name}'s Matcha Gotcha!`);
       }
     }
-    if (move === 'Dire Claw' && target.alive && !target.status) {
+    if (!suppressSecondary && move === 'Dire Claw' && target.alive && !target.status) {
       if (rng() < 0.5) {
         const options = ['poison', 'paralysis', 'sleep'].filter((status) => canInflictStatus(target, status, field));
         if (options.length) {

--- a/poke-sim/reports/ability_coverage_audit.md
+++ b/poke-sim/reports/ability_coverage_audit.md
@@ -9,8 +9,8 @@ Scope:
 
 Summary:
 - unique curated-team + mega abilities audited: 80
-- already modeled by the engine: 50
-- still unmodeled and classified: 30
+- already modeled by the engine: 55
+- still unmodeled and classified: 25
 
 Why this exists:
 - Issue #125 showed repeated review friction around ability gaps being noticed ad hoc.
@@ -23,8 +23,8 @@ Classification buckets:
 
 Highest-priority shipped-team gaps:
 - `Shadow Tag`: changes switch options and perish-style endgames.
-- `Sheer Force`, `Fairy Aura`: direct damage modifiers with real KO-range impact.
-- `Infiltrator`, `Mold Breaker`, `Scrappy`, `Stalwart`: targeting, immunity, or defensive-bypass mechanics that can flip matchups.
+- `Gale Wings`, `Skill Link`, `Stamina`, `Protean`: turn order, multi-hit damage, snowball defense, or type-changing mechanics with matchup impact.
+- `Flower Veil`, `Stalwart`, `Mind's Eye`, `No Guard`: support, targeting, immunity, and accuracy mechanics that can flip matchups.
 
 Implemented after this audit:
 - `Prankster`: real battle priority for status moves, with Dark-type immunity on targeted opposing status.
@@ -55,6 +55,12 @@ Implemented after this audit:
 - `Filter`: Showdown-aligned super-effective damage reduction.
 - `Tinted Lens`: Showdown-aligned resisted-hit damage boost.
 - `Earth Eater`: Showdown-aligned Ground immunity and one-quarter max HP recovery on absorbed hits.
+- `Levitate`: Showdown-aligned Ground immunity for non-Flying Levitate users.
+- `Sheer Force`: Showdown-aligned 1.3x secondary-effect move damage boost, with modeled secondary effects suppressed.
+- `Fairy Aura`: Showdown-aligned Fairy damage aura modifier.
+- `Scrappy`: Showdown-aligned Normal/Fighting hits into Ghost targets plus Intimidate immunity.
+- `Infiltrator`: Showdown-aligned screen and Substitute bypass for supported damage/status paths.
+- `Mold Breaker`: Conservative Showdown-aligned bypass for currently modeled defensive ability hooks, defender `Unaware`, `Sturdy`, `Levitate`, and `Earth Eater`.
 
 Lower-priority or no-op examples:
 - `Frisk`: item reveal is effectively already visible in the sim.
@@ -64,16 +70,17 @@ Lower-priority or no-op examples:
 Recommended implementation order:
 1. Priority and targeting control
    - `Shadow Tag`
-2. Damage modifiers with broad shipped-team exposure
-   - `Sheer Force`
-   - `Fairy Aura`
-3. Defensive and board-state mechanics
-   - `Infiltrator`
-   - `Mold Breaker`
-   - `Scrappy`
-4. Support and mitigation mechanics
+2. Turn-order and multi-hit mechanics
+   - `Gale Wings`
+   - `Skill Link`
+3. Defensive and snowball mechanics
+   - `Stamina`
+   - `Innards Out`
+4. Support, accuracy, and targeting mechanics
    - `Flower Veil`
    - `Stalwart`
+   - `Mind's Eye`
+   - `No Guard`
 
 Guardrail:
 - `tests/ability_coverage_audit_tests.js` compares the current unmodeled ability inventory against `tests/fixtures/ability_gap_classification.json`.

--- a/poke-sim/sw.js
+++ b/poke-sim/sw.js
@@ -45,7 +45,7 @@
 // restoring holders that were reduced to 0 HP before faint cleanup.
 // v55-champion-item-sp-gate [2026-06-21] - Positive Champions item allowlist,
 // SP import/export gate, and stale DB-team rejection before selector rebuild.
-const CACHE_NAME = 'champions-sim-v56-ability-damage-parity';
+const CACHE_NAME = 'champions-sim-v57-ability-mechanics-parity';
 const SPRITE_CACHE = 'champions-sprites-v1';
 
 const APP_ASSETS = [

--- a/poke-sim/tests/ability_damage_parity_tests.js
+++ b/poke-sim/tests/ability_damage_parity_tests.js
@@ -190,5 +190,65 @@ T('6. Earth Eater blocks Ground damage and heals the target', function() {
   eq(battle.playerSurvivors, 1, 'Earth Eater holder should survive the Ground hit');
 });
 
+T('7. Mold Breaker bypasses Sturdy survival', function() {
+  const probe = new ctx.Pokemon(member('Magnemite', { ability: 'Sturdy' }), '', 'champions');
+  const battle = ctx.simulateBattle(
+    team([member('Magnemite', { ability: 'Sturdy', hp: probe.maxHp })]),
+    team([member('Haxorus', {
+      ability: 'Mold Breaker',
+      nature: 'Adamant',
+      moves: ['Earthquake'],
+      evs: { hp: 0, atk: 32, def: 0, spa: 0, spd: 0, spe: 32 }
+    })]),
+    { format: 'singles', seed: [41, 42, 43, 44], maxTurns: 1 }
+  );
+  falsy(battle.log.some(line => String(line).includes('Magnemite hung on with Sturdy!')),
+    'Mold Breaker should bypass Sturdy');
+  eq(battle.playerSurvivors, 0, 'Mold Breaker hit should KO through Sturdy');
+});
+
+T('8. Sheer Force suppresses modeled secondary stat drops', function() {
+  const battle = ctx.simulateBattle(
+    team([member('Nidoking', {
+      ability: 'Sheer Force',
+      nature: 'Modest',
+      moves: ['Snarl'],
+      evs: { hp: 0, atk: 0, def: 0, spa: 32, spd: 0, spe: 32 }
+    })]),
+    team([member('Pelipper', {
+      ability: 'Keen Eye',
+      moves: ['Splash'],
+      evs: { hp: 32, atk: 0, def: 0, spa: 32, spd: 32, spe: 0 }
+    })]),
+    { format: 'singles', seed: [45, 46, 47, 48], maxTurns: 1 }
+  );
+  truthy(battle.log.some(line => String(line).includes('Nidoking used Snarl!')),
+    'Sheer Force test should execute Snarl');
+  falsy(battle.log.some(line => String(line).includes("Pelipper's Special Attack fell!")),
+    'Sheer Force should suppress Snarl Special Attack drops');
+});
+
+T('9. Infiltrator damages the target instead of its Substitute', function() {
+  const battle = ctx.simulateBattle(
+    team([member('Chandelure', {
+      ability: 'Infiltrator',
+      nature: 'Modest',
+      moves: ['Shadow Ball'],
+      evs: { hp: 0, atk: 0, def: 0, spa: 32, spd: 0, spe: 32 }
+    })]),
+    team([member('Cresselia', {
+      ability: 'Levitate',
+      substituteHp: 60,
+      moves: ['Splash'],
+      evs: { hp: 32, atk: 0, def: 32, spa: 0, spd: 32, spe: 0 }
+    })]),
+    { format: 'singles', seed: [49, 50, 51, 52], maxTurns: 1 }
+  );
+  truthy(battle.log.some(line => String(line).includes('Chandelure used Shadow Ball!')),
+    'Infiltrator test should execute Shadow Ball');
+  falsy(battle.log.some(line => String(line).includes('Substitute absorbed')),
+    'Infiltrator should not let Substitute absorb the attack');
+});
+
 console.log('\nability damage parity:', pass + ' pass, ' + fail + ' fail\n');
 process.exit(fail ? 1 : 0);

--- a/poke-sim/tests/ability_priority_targeting_tests.js
+++ b/poke-sim/tests/ability_priority_targeting_tests.js
@@ -350,5 +350,31 @@ T('11. Solar Power recoil is logged at end of turn under sun', function() {
     'Solar Power recoil log missing');
 });
 
+T('12. Scrappy ignores Intimidate Attack drops when active on entry', function() {
+  const playerTeam = team([{
+    name: 'Kangaskhan',
+    item: '',
+    ability: 'Scrappy',
+    nature: 'Jolly',
+    level: 50,
+    moves: ['Tackle'],
+    evs: { hp: 0, atk: 32, def: 0, spa: 0, spd: 0, spe: 32 }
+  }]);
+  const oppTeam = team([{
+    name: 'Incineroar',
+    item: '',
+    ability: 'Intimidate',
+    nature: 'Careful',
+    level: 50,
+    moves: ['Protect'],
+    evs: { hp: 32, atk: 0, def: 0, spa: 0, spd: 32, spe: 4 }
+  }]);
+  const battle = ctx.simulateBattle(playerTeam, oppTeam, { format: 'singles', seed: [53, 54, 55, 56], maxTurns: 1 });
+  truthy(battle.log.some(line => String(line).includes('Kangaskhan ignored Intimidate!')),
+    'Scrappy should ignore Intimidate');
+  falsy(battle.log.some(line => String(line).includes("Kangaskhan's Attack fell!")),
+    'Scrappy target should not receive the Intimidate Attack drop');
+});
+
 console.log('\nability priority / targeting:', pass + ' pass, ' + fail + ' fail\n');
 process.exit(fail ? 1 : 0);

--- a/poke-sim/tests/fixtures/ability_gap_classification.json
+++ b/poke-sim/tests/fixtures/ability_gap_classification.json
@@ -22,10 +22,6 @@
       "category": "missing_battle_result_impacting",
       "why": "Accuracy boost changes hit rates for status and utility lines."
     },
-    "Fairy Aura": {
-      "category": "missing_battle_result_impacting",
-      "why": "Field-wide Fairy damage boost changes Mega Floette and partner damage."
-    },
     "Flower Veil": {
       "category": "missing_battle_result_impacting",
       "why": "Protects allied Grass types from stat drops and status in supported lines."
@@ -42,10 +38,6 @@
       "category": "missing_low_impact",
       "why": "End-turn ally status cure can matter, but it is mega-only and relatively narrow."
     },
-    "Infiltrator": {
-      "category": "missing_battle_result_impacting",
-      "why": "Bypasses Substitute and screens, changing damage and status delivery."
-    },
     "Innards Out": {
       "category": "missing_battle_result_impacting",
       "why": "Punishes KOs with reflected HP loss and can swing trades."
@@ -61,10 +53,6 @@
     "Mind's Eye": {
       "category": "missing_battle_result_impacting",
       "why": "Ghost immunity bypass and accuracy behavior affect Ursaluna-Bloodmoon lines."
-    },
-    "Mold Breaker": {
-      "category": "missing_battle_result_impacting",
-      "why": "Ignores defensive abilities and changes interaction outcomes for multiple Megas."
     },
     "Mummy": {
       "category": "missing_low_impact",
@@ -90,17 +78,9 @@
       "category": "missing_low_impact",
       "why": "Weather evasion can matter, but it is narrower and RNG-heavier than core gaps."
     },
-    "Scrappy": {
-      "category": "missing_battle_result_impacting",
-      "why": "Ghost immunity bypass changes Fake Out and Fighting/Normal targeting."
-    },
     "Shadow Tag": {
       "category": "missing_battle_result_impacting",
       "why": "Trapping fundamentally changes switch options and perish-style endgames."
-    },
-    "Sheer Force": {
-      "category": "missing_battle_result_impacting",
-      "why": "Damage boost plus secondary-effect suppression changes Mega Camerupt outputs."
     },
     "Shell Armor": {
       "category": "missing_low_impact",

--- a/poke-sim/tests/fixtures/golden_battles.json
+++ b/poke-sim/tests/fixtures/golden_battles.json
@@ -28,7 +28,7 @@
       ],
       "format": "doubles",
       "description": "Player (speed) vs Sand Bulky Offense — seed 2024",
-      "expected_trace_hash": "356fe4f5eb052f67f7cbe47296b172e239f3a03ede2bbab2676243d6d66ce62d",
+      "expected_trace_hash": "542864461563a7a965226723729dad8943cc3b83e6cd086e1fa0c2cfeb7db346",
       "expected_winner": "win"
     },
     {

--- a/poke-sim/tests/showdown_damage_oracle_tests.js
+++ b/poke-sim/tests/showdown_damage_oracle_tests.js
@@ -725,5 +725,103 @@ T('39. Earth Eater Ground immunity matches Showdown zero damage', () => {
   eqRange(sim, oracle, 'earth eater');
 });
 
+T('40. Levitate Ground immunity matches Showdown zero damage', () => {
+  const sim = simRange(
+    simMon('Garchomp', { nature: 'Adamant', moves: ['Earthquake'], evs: { atk: 252 } }),
+    simMon('Cresselia', { ability: 'Levitate' }),
+    'Earthquake',
+    new Field({ format: 'doubles' })
+  );
+  const oracle = oracleRange(
+    calcMon('Garchomp', { nature: 'Adamant', moves: ['Earthquake'], evs: { atk: 252 } }),
+    calcMon('Cresselia', { ability: 'Levitate' }),
+    'Earthquake',
+    new calc.Field({ gameType: 'Doubles' })
+  );
+  eqRange(sim, oracle, 'levitate');
+});
+
+T('41. Sheer Force damage boost matches Showdown exactly', () => {
+  const sim = simRange(
+    simMon('Nidoking', { nature: 'Modest', moves: ['Sludge Bomb'], evs: { spa: 252 }, ability: 'Sheer Force' }),
+    simMon('Pelipper'),
+    'Sludge Bomb',
+    new Field({ format: 'doubles' })
+  );
+  const oracle = oracleRange(
+    calcMon('Nidoking', { nature: 'Modest', moves: ['Sludge Bomb'], evs: { spa: 252 }, ability: 'Sheer Force' }),
+    calcMon('Pelipper'),
+    'Sludge Bomb',
+    new calc.Field({ gameType: 'Doubles' })
+  );
+  eqRange(sim, oracle, 'sheer force');
+});
+
+T('42. Fairy Aura damage boost matches Showdown exactly', () => {
+  const sim = simRange(
+    simMon('Xerneas', { nature: 'Modest', moves: ['Moonblast'], evs: { spa: 252 }, ability: 'Fairy Aura' }),
+    simMon('Incineroar'),
+    'Moonblast',
+    new Field({ format: 'doubles' })
+  );
+  const oracle = oracleRange(
+    calcMon('Xerneas', { nature: 'Modest', moves: ['Moonblast'], evs: { spa: 252 }, ability: 'Fairy Aura' }),
+    calcMon('Incineroar'),
+    'Moonblast',
+    new calc.Field({ gameType: 'Doubles' })
+  );
+  eqRange(sim, oracle, 'fairy aura');
+});
+
+T('43. Scrappy Normal damage into Ghost matches Showdown exactly', () => {
+  const sim = simRange(
+    simMon('Lopunny-Mega', { nature: 'Adamant', moves: ['Tackle'], evs: { atk: 252 }, ability: 'Scrappy' }),
+    simMon('Gengar'),
+    'Tackle',
+    new Field({ format: 'doubles' })
+  );
+  const oracle = oracleRange(
+    calcMon('Lopunny-Mega', { nature: 'Adamant', moves: ['Tackle'], evs: { atk: 252 }, ability: 'Scrappy' }),
+    calcMon('Gengar'),
+    'Tackle',
+    new calc.Field({ gameType: 'Doubles' })
+  );
+  eqRange(sim, oracle, 'scrappy ghost bypass');
+});
+
+T('44. Infiltrator bypasses Light Screen damage reduction like Showdown', () => {
+  const field = new Field({ format: 'doubles' });
+  field.oppSide.lightScreen = true;
+  const sim = simRange(
+    simMon('Chandelure', { nature: 'Modest', moves: ['Shadow Ball'], evs: { spa: 252 }, ability: 'Infiltrator' }),
+    simMon('Umbreon'),
+    'Shadow Ball',
+    field
+  );
+  const oracle = oracleRange(
+    calcMon('Chandelure', { nature: 'Modest', moves: ['Shadow Ball'], evs: { spa: 252 }, ability: 'Infiltrator' }),
+    calcMon('Umbreon'),
+    'Shadow Ball',
+    new calc.Field({ gameType: 'Doubles', defenderSide: { isLightScreen: true } })
+  );
+  eqRange(sim, oracle, 'infiltrator screens');
+});
+
+T('45. Mold Breaker bypasses Levitate immunity like Showdown', () => {
+  const sim = simRange(
+    simMon('Haxorus', { nature: 'Adamant', moves: ['High Horsepower'], evs: { atk: 252 }, ability: 'Mold Breaker' }),
+    simMon('Cresselia', { ability: 'Levitate' }),
+    'High Horsepower',
+    new Field({ format: 'doubles' })
+  );
+  const oracle = oracleRange(
+    calcMon('Haxorus', { nature: 'Adamant', moves: ['High Horsepower'], evs: { atk: 252 }, ability: 'Mold Breaker' }),
+    calcMon('Cresselia', { ability: 'Levitate' }),
+    'High Horsepower',
+    new calc.Field({ gameType: 'Doubles' })
+  );
+  eqRange(sim, oracle, 'mold breaker levitate');
+});
+
 console.log('\nshowdown damage oracle:', pass + ' pass, ' + fail + ' fail\n');
 process.exit(fail ? 1 : 0);

--- a/poke-sim/tests/sw_local_credentials_tests.js
+++ b/poke-sim/tests/sw_local_credentials_tests.js
@@ -40,7 +40,7 @@ T('3. missing local-credentials.js returns empty JavaScript instead of cached ap
 });
 
 T('4. service worker cache is bumped for stale app-shell release fix', () => {
-  truthy(sw.includes('champions-sim-v56-ability-damage-parity'), 'CACHE_NAME should be v56 ability damage parity');
+  truthy(sw.includes('champions-sim-v57-ability-mechanics-parity'), 'CACHE_NAME should be v57 ability mechanics parity');
 });
 
 T('5. app shell includes pokemon-champion bundle in network-first detection', () => {


### PR DESCRIPTION
Syncs the latest Champion sim parity slice from TheYfactora12 main. Adds Showdown-checked handling for Levitate, Sheer Force, Fairy Aura, Mold Breaker, Scrappy, and Infiltrator; updates coverage reporting; rebuilds the browser bundle; bumps the service worker cache to v57; and refreshes the gb_002 golden battle hash after Levitate correctly prevents Rotom-Wash from being KOed by Earthquake. Validation: full local suite with DB/golden coverage passed; Showdown damage oracle is 45/45; ability damage is 9/9; ability priority/targeting is 12/12; bundle freshness check passed; TheYfactora12 CI and Pages are green for 04adbdd.