### PR TITLE
Guard no-target exported logs

### DIFF
--- a/poke-sim/index.html
+++ b/poke-sim/index.html
@@ -66,7 +66,7 @@
         <path d="M 21 6 L 16.5 16 L 19.5 16 L 15.5 28 L 21.5 15.5 L 18.5 15.5 L 22 6 Z" fill="url(#hBolt)" stroke="#ecfeff" stroke-width="0.5" stroke-linejoin="round"/>
       </svg>
       <div>
-        <h1 class="site-title">Poke-e-Sim Champion 2026 Preview <span class="build-version" id="build-version" title="Build version - bumps on every commit so you can confirm which build you are testing">v2.1.32-tera-blast-parity</span> <span id="db-offline-chip" class="db-offline-chip" title="Live database unavailable — using bundled team data" style="display:none;background:#7c2d12;color:#fed7aa;border:1px solid #ea580c;border-radius:6px;padding:2px 8px;font-size:11px;font-weight:600;letter-spacing:0.3px;margin-left:6px;vertical-align:middle;">[DB offline]</span></h1>
+        <h1 class="site-title">Poke-e-Sim Champion 2026 Preview <span class="build-version" id="build-version" title="Build version - bumps on every commit so you can confirm which build you are testing">v2.1.33-log-target-guard</span> <span id="db-offline-chip" class="db-offline-chip" title="Live database unavailable — using bundled team data" style="display:none;background:#7c2d12;color:#fed7aa;border:1px solid #ea580c;border-radius:6px;padding:2px 8px;font-size:11px;font-weight:600;letter-spacing:0.3px;margin-left:6px;vertical-align:middle;">[DB offline]</span></h1>
         <p class="site-sub">Champions 2026 Preview · VGC Doubles Simulator</p>
       </div>
     </div>

--- a/poke-sim/pokemon-champion-2026.html
+++ b/poke-sim/pokemon-champion-2026.html
@@ -2333,7 +2333,7 @@ table{border-collapse:collapse;width:100%}
         <path d="M 21 6 L 16.5 16 L 19.5 16 L 15.5 28 L 21.5 15.5 L 18.5 15.5 L 22 6 Z" fill="url(#hBolt)" stroke="#ecfeff" stroke-width="0.5" stroke-linejoin="round"/>
       </svg>
       <div>
-        <h1 class="site-title">Poke-e-Sim Champion 2026 Preview <span class="build-version" id="build-version" title="Build version - bumps on every commit so you can confirm which build you are testing">v2.1.32-tera-blast-parity</span> <span id="db-offline-chip" class="db-offline-chip" title="Live database unavailable — using bundled team data" style="display:none;background:#7c2d12;color:#fed7aa;border:1px solid #ea580c;border-radius:6px;padding:2px 8px;font-size:11px;font-weight:600;letter-spacing:0.3px;margin-left:6px;vertical-align:middle;">[DB offline]</span></h1>
+        <h1 class="site-title">Poke-e-Sim Champion 2026 Preview <span class="build-version" id="build-version" title="Build version - bumps on every commit so you can confirm which build you are testing">v2.1.33-log-target-guard</span> <span id="db-offline-chip" class="db-offline-chip" title="Live database unavailable — using bundled team data" style="display:none;background:#7c2d12;color:#fed7aa;border:1px solid #ea580c;border-radius:6px;padding:2px 8px;font-size:11px;font-weight:600;letter-spacing:0.3px;margin-left:6px;vertical-align:middle;">[DB offline]</span></h1>
         <p class="site-sub">Champions 2026 Preview · VGC Doubles Simulator</p>
       </div>
     </div>
@@ -18512,9 +18512,9 @@ function csGetBuildId() {
   try {
     var el = document.getElementById('build-version');
     var txt = el && typeof el.textContent === 'string' ? el.textContent.trim() : '';
-    return txt || 'v2.1.32-tera-blast-parity';
+    return txt || 'v2.1.33-log-target-guard';
   } catch (e) {
-    return 'v2.1.32-tera-blast-parity';
+    return 'v2.1.33-log-target-guard';
   }
 }
 
@@ -24284,7 +24284,7 @@ var CS_OVERVIEW_DATA = {
     { label: 'Live Supabase', value: 'Teams + analyses' },
     { label: 'Showdown DB', value: 'Checking...' },
     { label: 'Team Format', value: 'Champion/SP focus' },
-    { label: 'Turn Logs', value: 'Structural clean' },
+    { label: 'Turn Logs', value: 'Strict + target guard' },
     { label: 'Target Guard', value: 'Canonical bridge' },
     { label: 'QA Log Retention', value: 'Capped + artifact' },
     { label: 'Ability Inventory', value: '80/80 modeled' },
@@ -24374,7 +24374,7 @@ var CS_OVERVIEW_DATA = {
     {
       status: 'done',
       title: 'Exported log validator added',
-      detail: 'poke-sim/tools/validate-turn-logs.mjs checks identity, item drift, HP maps, active/bench mapping, speed order, and observed priority order.'
+      detail: 'poke-sim/tools/validate-turn-logs.mjs checks identity, item drift, HP maps, active/bench mapping, speed order, observed priority order, damage evidence shape, and no-valid-target skips while a target side still has a live active Pokemon.'
     },
     {
       status: 'done',
@@ -24410,6 +24410,11 @@ var CS_OVERVIEW_DATA = {
     },
     {
       status: 'validated',
+      title: 'Latest v2.1.31 logs pass strict structure and expose stacked mechanics evidence',
+      detail: 'Four June 22 logs from ?v=e209f3b pass strict validation with zero warnings across 28 turns. They include super-effective and resisted damage, typed held-item boosts, Knock Off boosts, doubles spread reduction, sun weather boosts, stat-stage damage evidence, and burn/status penalties. Their lone no-valid-target line is terminal after the last opposing active faints, so v2.1.33 adds a validator guard that only fails no-target skips when a target side still has a live active Pokemon.'
+    },
+    {
+      status: 'validated',
       title: 'Item timing regression reproduced and covered',
       detail: 'Fresh logs showed Sitrus restoring after a 0 HP hit; items_tests.js now verifies surviving Sitrus, lethal Sitrus rejection, lethal Oran rejection, and battle-log faint behavior.'
     },
@@ -24426,7 +24431,7 @@ var CS_OVERVIEW_DATA = {
     {
       status: 'validated',
       title: 'Current release checks are green',
-      detail: 'v2.1.32 Tera Blast Parity carries the v2.1.31 Editor Builder Roadmap, v2.1.30 Spread Legality Guard, v2.1.29 Knock Off guard, and v2.1.28 mechanics stack guard. Source-truth tests, target bridge coverage, DB seed SP caps, preloaded team legality, custom import/DB merge guards, service-worker cache guard, damage-stack oracle, type multiplier audit, speed-stack evidence, Knock Off item-state tests, and strict validation are the local release checks for this build.'
+      detail: 'v2.1.33 Log Target Guard carries v2.1.32 Tera Blast Parity, v2.1.31 Editor Builder Roadmap, v2.1.30 Spread Legality Guard, v2.1.29 Knock Off guard, and v2.1.28 mechanics stack guard. Source-truth tests, target bridge coverage, DB seed SP caps, preloaded team legality, custom import/DB merge guards, service-worker cache guard, damage-stack oracle, type multiplier audit, speed-stack evidence, Knock Off item-state tests, no-valid-target validation, and strict validation are the local release checks for this build.'
     },
     {
       status: 'validated',
@@ -24472,6 +24477,11 @@ var CS_OVERVIEW_DATA = {
       status: 'validated',
       title: 'GitHub issue sweep completed',
       detail: 'Open issues were checked in TheYfactora12 and alfredocox repos. JD flags Alfredo #241 and #240 remain active; Josh/JD data-audit comments are tracked in Alfredo #231 and Y Factor #123.'
+    },
+    {
+      status: 'validated',
+      title: 'Y fork and Alfredo main are synced',
+      detail: 'Alfredo PR #245 merged the Champion parity tree after required checks passed, and TheYfactora12 main was fast-forwarded to the same merge commit so both repos are 1:1 at the current source tree.'
     }
   ],
   gaps: [
@@ -24484,11 +24494,6 @@ var CS_OVERVIEW_DATA = {
       status: 'gap',
       title: 'Pokemon data audit has unresolved reviewer risk',
       detail: 'Josh/JD notes on Alfredo #231 flag that Showdown data is present but not fully used for every move calculation and regional forms such as Arcanine may still need targeted review.'
-    },
-    {
-      status: 'gap',
-      title: 'Current Y fork changes are not pushed upstream to Alfredo yet',
-      detail: 'TheYfactora12 main carries v2.1.32 Tera Blast Parity plus v2.1.31 Editor Builder Roadmap, v2.1.30 Spread Legality Guard, v2.1.29 Knock Off guard, v2.1.28 mechanics stack guard, v2.1.27 QA artifact export, v2.1.25 target parity guard, and v2.1.26 overview truth notes. Alfredo still needs a reviewed sync PR so both repos stay 1:1.'
     },
     {
       status: 'gap',
@@ -24514,8 +24519,8 @@ var CS_OVERVIEW_DATA = {
   next: [
     {
       status: 'next',
-      title: 'Verify v2.1.32 live logs, QA artifact, and sync Alfredo',
-      detail: 'Use fresh GitHub Pages logs and the QA Artifact export to confirm the build label, source URL, stable turn-log fields, no team-load failure, retained-evidence summary, speed_order_details, stat_boosts, damage_events snapshots, legal Champion SP team data, Tera Blast damage evidence when present, and Knock Off boost evidence, then prepare the reviewed upstream sync to Alfredo.'
+      title: 'Verify v2.1.33 live logs and QA artifact',
+      detail: 'Use fresh GitHub Pages logs and the QA Artifact export to confirm the build label, source URL, stable turn-log fields, no team-load failure, retained-evidence summary, speed_order_details, stat_boosts, damage_events snapshots, legal Champion SP team data, Tera Blast damage evidence when present, Knock Off boost evidence, and no live-target no-valid-target skips.'
     },
     {
       status: 'next',
@@ -24544,8 +24549,8 @@ var CS_OVERVIEW_DATA = {
     },
     {
       status: 'next',
-      title: 'Prepare upstream PR to Alfredo after Y fork verification',
-      detail: 'Once the live Y test page shows v2.1.32 and fresh logs plus QA artifact pass, open a clean upstream PR with the target parity guard, ability parity slice, mechanics stack guard, Knock Off guard, Tera Blast parity, SP legality guard, editor-builder roadmap note, load-path proof, overview alignment, and issue notes.'
+      title: 'Keep Alfredo and Y fork synced through protected PRs',
+      detail: 'Direct Alfredo main pushes are blocked by repository rules, so future parity slices should land in TheYfactora12, pass live-page checks, then sync to Alfredo through a reviewed PR with required checks before fast-forwarding the fork back to the same merge commit.'
     },
     {
       status: 'next',

--- a/poke-sim/reports/recent-fixes-and-open-issues-2026-06-21.md
+++ b/poke-sim/reports/recent-fixes-and-open-issues-2026-06-21.md
@@ -1,15 +1,17 @@
 # Recent Fixes and Open Issue Snapshot - 2026-06-21
 
-This snapshot records the current truth after the June 21-22 live-log review and GitHub issue sweep. It is meant to remove stale contradictions before preparing the Alfredo upstream PR.
+This snapshot records the current truth after the June 21-22 live-log review, GitHub issue sweep, and Alfredo sync. It is meant to remove stale contradictions before the next mechanics-parity pass.
 
 ## 2026-06-22 Deployment Update
 
 - The prior Y fork public validation target was commit `7e0deca` (`model champion ability parity`).
-- `v2.1.32-tera-blast-parity` supersedes `v2.1.31-editor-builder-roadmap` for the current GitHub Pages release and bumps the service-worker cache to `champions-sim-v66-tera-blast-parity`.
+- `v2.1.33-log-target-guard` supersedes `v2.1.32-tera-blast-parity` for the current GitHub Pages release and bumps the service-worker cache to `champions-sim-v67-log-target-guard`.
 - `v2.1.29` promotes `Knock Off` from baseline to verified move coverage. The source truth is Pokemon Showdown move/item behavior checked against Bulbapedia: removable held items give the 1.5x base-power boost and are removed after damage; legal no-item targets give no boost and remove nothing; corresponding Mega Stones are not removable and do not give the boost even before Mega Evolution; Sticky Hold blocks removal while the holder is alive but does not suppress the boost when the item is otherwise removable.
 - `v2.1.30` converts shipped inferred Champion archetype spreads from SV-shaped EV values to Champion SP values, hard-rejects over-cap or malformed Champion spreads in imports/editor/DB merges/Supabase upserts, and records the Showdown-vs-preview source conflict on the per-stat cap.
 - `v2.1.31` records that the current edit-team UI is guarded but not fluid enough for fully customizable Champion team building; this is tracked as later UX work after sim-truth gates.
 - `v2.1.32` promotes Tera Blast parity: inactive Tera Blast remains Normal/special, active Tera Blast uses the attacker's Tera type, active Tera Blast ignores Normal-conversion abilities such as Pixilate, active category selects physical only when boosted Attack is greater than boosted Special Attack, and DB-style `tera_type` now hydrates into engine battle state.
+- `v2.1.33` promotes log validation around target safety: terminal `(no valid target)` lines are allowed when an earlier KO emptied the target side, but future logs fail validation if a no-target skip occurs while that target side still has a live active Pokemon.
+- Alfredo PR #245 merged the Champion parity tree after required checks passed; TheYfactora12 main was fast-forwarded to the same merge commit so both repos are 1:1 at the current source tree.
 - The earlier `e5af069` build added `champions-turn-log-v2` export metadata; fresh June 22 logs from `?v=7e0deca` validate structurally cleanly, then deeper replay review exposed the target bridge bug fixed in `v2.1.25`.
 - Supabase migration `2026_06_22_retire_legacy_sv_teams.sql` has run successfully; the two stale v1 teams are retired at the source.
 - Fresh logs from the live URL now validate cleanly for team loading, stable IDs, final alive counts, and stale item absence.
@@ -26,11 +28,12 @@ This snapshot records the current truth after the June 21-22 live-log review and
 | Champion SP spread legality guard | Fixed in `v2.1.30-spread-legality-guard` | The 32 shipped inferred SV-shaped archetype spreads were converted to legal Champion SP spreads; `validateTeam`, Champion import, set editor saves, DB merge, Supabase upsert, and seed tests now block >32 SP per stat, >66 SP total, and malformed spread payloads. |
 | Team editor roadmap note | Tracked in `v2.1.31-editor-builder-roadmap` | The current set editor has Champion SP legality guardrails, but the team identified that it is not fluid enough for full customization. Later work should replace it with a complete builder for add/remove/reorder Pokemon, searchable fields, SP sliders/totals, import/export, Supabase save status, and rollback. |
 | Tera Blast dynamic type/category | Fixed in `v2.1.32-tera-blast-parity` | `engine.js` resolves active Tera Blast from battle state, accepts DB-style `tera_type`, ignores Normal-conversion abilities once Tera is active, records resolved move type/category in damage evidence, and `showdown_damage_oracle_tests.js` covers inactive, special active, physical active, stat-boost-flipped, DB-hydrated, and Pixilate-bypass cases against `@smogon/calc`. |
-| GitHub Pages cache drift | Guarded for this release | `sw.js` cache bumped to `champions-sim-v66-tera-blast-parity`; `index.html`, `ui.js`, and bundled `pokemon-champion-2026.html` carry `v2.1.32-tera-blast-parity` after bundle rebuild. |
+| Target-safe log validation | Guarded in `v2.1.33-log-target-guard` | `validate-turn-logs.mjs` now rejects `(no valid target)` skips when the target side still has a live active Pokemon, while preserving legitimate terminal skips after an earlier KO empties that side. |
+| GitHub Pages cache drift | Guarded for this release | `sw.js` cache bumped to `champions-sim-v67-log-target-guard`; `index.html`, `ui.js`, and bundled `pokemon-champion-2026.html` carry `v2.1.33-log-target-guard` after bundle rebuild. |
 | Exported-log build drift | Guarded in `e5af069` | Downloaded replay logs now include `schema_version: champions-turn-log-v2`, `exported_at`, `build_id`, and `source_url`, so future debug logs can prove which deployed build produced them. |
 | Showdown static metadata use | Partially fixed | Battle construction and move metadata can use generated Showdown static rows first, then local fallbacks. This is not the same as live DB runtime consumption. |
 | Showdown target category bridge | Fixed and guarded in `v2.1.25-target-parity-guard` | `runtime_data.js` canonicalizes Showdown target categories before engine use; `engine.js` keeps a guarded fallback for engine-only tests; move tests cover Hyper Voice spread targeting and stale opposing-target retargeting. |
-| Overview truth board | Updated in `v2.1.32-tera-blast-parity` | The live Overview tab now names the target bridge fix, DB/runtime source split, capped browser log retention, shipped QA artifact export, type audit, typed held-item boost fix, Knock Off behavior fix, Tera Blast parity, Champion SP spread guard, editor-builder UX gap, stat/speed/export evidence, remaining grouped mechanics gap, and Alfredo sync gap. |
+| Overview truth board | Updated in `v2.1.33-log-target-guard` | The live Overview tab now names the target bridge fix, DB/runtime source split, capped browser log retention, shipped QA artifact export, type audit, typed held-item boost fix, Knock Off behavior fix, Tera Blast parity, no-valid-target guard, Champion SP spread guard, editor-builder UX gap, stat/speed/export evidence, remaining grouped mechanics gap, and completed Alfredo sync. |
 | Large-run QA artifact | Added in `v2.1.27-qa-artifact-export` | Saved Analyses now has a `QA Artifact` export that records build ID, source URL, retention caps, summary counts, retained compact sim-log entries, and retained replay cards. |
 | Type multiplier audit | Added in `v2.1.28-mechanics-stack-guard` | `reports/type_multiplier_audit.md` shows each shipped move user's resolved move type, 4x/2x/1x/0.5x/0.25x/0x target buckets across the shipped roster, declared defensive Tera bucket changes, and dynamic move-type rules. |
 | Typed held-item damage boosts | Fixed in `v2.1.28-mechanics-stack-guard` | `engine.js` now applies legal typed held-item boosts such as Charcoal, Mystic Water, Soft Sand, Black Glasses, Spell Tag, Fairy Feather, and Never-Melt Ice as Showdown-style base-power modifiers. `showdown_damage_oracle_tests.js` covers Charcoal + Blaze + sun + STAB + super-effective Fire damage. |
@@ -193,6 +196,38 @@ Fix from this review:
 - `move_verification_registry_tests.js` covers Hyper Voice spread targeting from Showdown camelCase data and stale opposing-target retargeting.
 - Golden battle hashes were regenerated after confirming the new traces reflect the intentional targeting behavior change.
 
+## 2026-06-22 Late Log Review - v2.1.31 Exports
+
+Reviewed user exports from `https://theyfactora12.github.io/Pokemon-Champions-Sim-Planner/poke-sim/pokemon-champion-2026.html?v=e209f3b`:
+
+- `champions-turn-log-3410383494,1684469838,2080849004,3938257855.json`
+- `champions-turn-log-3491800478,1512844493,1474271744,656145414.json`
+- `champions-turn-log-161728751,2826389324,4174458443,2913951381.json`
+- `champions-turn-log-771060722,4210367371,3321910684,2176763678.json`
+
+Structural result:
+
+- All four passed `node poke-sim/tools/validate-turn-logs.mjs --require-stable --json ...` with `0` errors and `0` warnings across `28` turns.
+- The logs are from `v2.1.31-editor-builder-roadmap`, not the current `v2.1.33-log-target-guard`, so they are useful for root-cause review but do not prove the latest deployed bundle.
+- No `team not loaded`, duplicate stable key, invalid HP map, wrong-side stable key, or `NaN` marker appeared.
+
+Mechanics evidence observed:
+
+- `61` structured damage events.
+- `23` super-effective hits and `11` resisted hits.
+- `17` typed held-item boosts, including Soft Sand and Charcoal examples.
+- `5` Knock Off boost rows with `knock_off_boost_mod: 6144`.
+- `16` doubles spread reductions using `spread_mod: 3072`.
+- `7` sun weather damage boosts using `weather_mod: 6144`.
+- `13` stat-stage-aware damage rows and `4` burn/status penalty rows.
+- `0` Tera Blast events appeared in this batch, so Tera Blast still needs a fresh live-log sample when present.
+
+Target/no-target finding:
+
+- One `Incineroar used Knock Off! (no valid target)` line appeared.
+- It was legitimate: Whimsicott KO'd the opponent's final active Milotic earlier in the same turn, so Incineroar's queued Knock Off had no legal opposing active target left.
+- To prevent future regressions, `v2.1.33` adds validator coverage that fails no-target skips only when the target side still has a live active Pokemon after the turn.
+
 ## Large-Run Log Retention Note
 
 - The sim and CI can run thousands of battles for validation, but the browser UI intentionally keeps a bounded amount of replay evidence so local storage, downloads, and the page do not become unusable.
@@ -238,6 +273,8 @@ Use these statements in team updates and PR notes:
 - Fixed for `v2.1.30`: bundled Champion spreads are legal SP values, declared Champion teams with SV-shaped spreads are hard-invalid, stale DB spread payloads cannot replace bundled teams, and set-editor/Supabase saves are blocked before illegal spreads persist.
 - Tracked for later: current edit-team UI is guarded but not fluid; full Champion team-builder UX still needs a separate build.
 - Fixed for `v2.1.32`: Tera Blast now matches Showdown for inactive Normal/special behavior, active Tera type, active Normal-conversion ability bypass, active physical/special category selection from boosted attacking stats, and DB-style `tera_type` hydration into battle state.
+- Guarded for `v2.1.33`: exported-log validation now distinguishes legitimate terminal no-target skips from target failures while a live active target remains.
+- Completed: Alfredo PR #245 merged and both `alfredocox/main` and `TheYfactora12/main` now point to the same source tree.
 - Completed: Supabase cleanup migration retired the stale v1 DB teams.
 - Known limitation: browser replay/log retention is intentionally capped; QA Artifact exports retained evidence and caps, but it still does not preserve every raw battle log from huge runs.
 - Not fixed yet: live DB `showdown_entities` as the battle runtime source.
@@ -247,10 +284,10 @@ Use these statements in team updates and PR notes:
 
 ## Current Next Path
 
-1. Export one fresh single-run log, one fresh Run All log, and one `QA Artifact` from the public URL after `v2.1.32-tera-blast-parity`; verify build/source metadata, stable turn-log fields, legal Champion SP team data, `speed_order_details`, `stat_boosts`, `damage_events`, Tera Blast evidence when present, `knock_off_boost` evidence when Knock Off appears, no team-load failure, no invalid `(no valid target)` lines, and retained-evidence summary counts.
+1. Export one fresh single-run log, one fresh Run All log, and one `QA Artifact` from the public URL after `v2.1.33-log-target-guard`; verify build/source metadata, stable turn-log fields, legal Champion SP team data, `speed_order_details`, `stat_boosts`, `damage_events`, Tera Blast evidence when present, `knock_off_boost` evidence when Knock Off appears, no team-load failure, no live-target `(no valid target)` failures, and retained-evidence summary counts.
 2. Mirror/update issue notes in the Y fork for Alfredo #241, #240, and #231 so both repos show the same truth.
 3. Continue converting high-usage baseline moves into verified mechanics coverage, grouping them by damage modifiers, item interactions, stat changes, targeting/redirection, protection, switching, and status.
 4. Continue the grouped move/damage/mechanics parity track against Showdown first, with Champions overrides only when explicitly sourced.
 5. Rebuild the edit-team surface into a full Champion team builder after the current sim-truth gates.
 6. Decide whether partners need a full raw battle archive stream beyond the retained-evidence QA artifact.
-7. Prepare a reviewed upstream PR to Alfredo after live Y verification remains clean.
+7. Keep future Alfredo syncs on the protected-branch path: land in the Y fork, pass live-page checks, open an Alfredo PR, wait for required checks, then fast-forward the fork to the same merge commit.

--- a/poke-sim/sw.js
+++ b/poke-sim/sw.js
@@ -61,7 +61,8 @@
 // bundled teams, import/editor saves, DB merge, and generated seed artifacts.
 // v65-editor-builder-roadmap [2026-06-22] - Overview note for full team-builder UX.
 // v66-tera-blast-parity [2026-06-22] - Tera Blast dynamic type/category parity.
-const CACHE_NAME = 'champions-sim-v66-tera-blast-parity';
+// v67-log-target-guard [2026-06-22] - No-valid-target log guard and Overview sync status.
+const CACHE_NAME = 'champions-sim-v67-log-target-guard';
 const SPRITE_CACHE = 'champions-sprites-v1';
 
 const APP_ASSETS = [

--- a/poke-sim/tests/README.md
+++ b/poke-sim/tests/README.md
@@ -46,7 +46,7 @@ node tests/t175_mobile_tab_grid_tests.js # Mobile tab grid safeguards
 node tests/t176_mobile_teams_panel_tests.js # Mobile teams panel safeguards
 node tests/phase5_turn_log_tests.js # Phase 5 — turnLog, positionScore, Replay Log v2 — 25 cases
 node tests/recoil_faint_turn_log_tests.js # Recoil KO cleanup + imported Showdown move metadata — 3 cases
-node tests/turn_log_export_validator_tests.js # Exported turn-log identity/item/order validator — 7 cases
+node tests/turn_log_export_validator_tests.js # Exported turn-log identity/item/order/target validator — 13 cases
 node tests/showdown_priority_drift_tests.js # Showdown priority drift audit for shipped moves — 4 cases
 node tests/showdown_approved_data_generator_tests.js # Approved Showdown DB rows + Champions override generator — 4 cases
 node tests/phase6_coaching_voice.js # Phase 6 — coaching templates, linter, RNG gate — 9 cases

--- a/poke-sim/tests/phase5_turn_log_tests.js
+++ b/poke-sim/tests/phase5_turn_log_tests.js
@@ -415,7 +415,7 @@ T('T5c-3 JSON download produces valid parseable file', () => {
   ctx.downloadReplayTurnLog({ seed: 'abc', result: 'win', turnLog: battleA.turnLog, position_path: battleA.position_path });
   truthy(parsed && Array.isArray(parsed.turnLog), 'download JSON did not parse');
   eq(parsed.schema_version, 'champions-turn-log-v2', 'download schema version missing');
-  truthy(/^v2\.1\.32-tera-blast-parity/.test(parsed.build_id || ''), 'download build id missing');
+  truthy(/^v2\.1\.33-log-target-guard/.test(parsed.build_id || ''), 'download build id missing');
   truthy(typeof parsed.exported_at === 'string' && parsed.exported_at.length > 0, 'download timestamp missing');
 });
 

--- a/poke-sim/tests/sw_local_credentials_tests.js
+++ b/poke-sim/tests/sw_local_credentials_tests.js
@@ -40,7 +40,7 @@ T('3. missing local-credentials.js returns empty JavaScript instead of cached ap
 });
 
 T('4. service worker cache is bumped for stale app-shell release fix', () => {
-  truthy(sw.includes('champions-sim-v66-tera-blast-parity'), 'CACHE_NAME should be v66 Tera Blast Parity');
+  truthy(sw.includes('champions-sim-v67-log-target-guard'), 'CACHE_NAME should be v67 Log Target Guard');
 });
 
 T('5. app shell includes pokemon-champion bundle in network-first detection', () => {

--- a/poke-sim/tests/t163_export_my_data_tests.js
+++ b/poke-sim/tests/t163_export_my_data_tests.js
@@ -266,7 +266,7 @@ async function main() {
     const payload = await csBuildQaArtifactExport('player');
     eq(payload.schema_version, 'champions-qa-artifact-v1');
     eq(payload.artifact_type, 'large-run-qa-retained-evidence');
-    truthy(/^v2\.1\.32-tera-blast-parity/.test(payload.build_id || ''), 'QA build id missing');
+    truthy(/^v2\.1\.33-log-target-guard/.test(payload.build_id || ''), 'QA build id missing');
     eq(payload.source_url, 'http://localhost/');
     eq(payload.retention.max_replay_cards, 240);
     eq(payload.retention.max_replay_log_lines, 200);

--- a/poke-sim/tests/t191_overview_tab_tests.js
+++ b/poke-sim/tests/t191_overview_tab_tests.js
@@ -53,15 +53,18 @@ T('2. Overview tracks accomplished work and validation proof', () => {
   inc(ui, 'Simulation-first direction documented');
   inc(ui, 'Public release milestone map documented');
   inc(ui, 'Live exported logs prove the sim now runs');
+  inc(ui, 'Latest v2.1.31 logs pass strict structure and expose stacked mechanics evidence');
+  inc(ui, 'only fails no-target skips when a target side still has a live active Pokemon');
   inc(ui, 'Item timing regression reproduced and covered');
   inc(ui, 'Fresh logs exposed a targeting boundary bug');
   inc(ui, 'Ability coverage guard is green');
-  inc(ui, 'v2.1.32 Tera Blast Parity carries the v2.1.31 Editor Builder Roadmap');
+  inc(ui, 'v2.1.33 Log Target Guard carries v2.1.32 Tera Blast Parity');
   inc(ui, 'Damage stack oracle is green');
   inc(ui, 'Tera Blast parity is green');
   inc(ui, 'Knock Off source-truth behavior is documented');
   inc(ui, 'Turn-order stack evidence is green');
   inc(ui, 'GitHub issue sweep completed');
+  inc(ui, 'Y fork and Alfredo main are synced');
 });
 
 T('3. Overview names current Supabase and Showdown DB alignment state', () => {
@@ -73,7 +76,6 @@ T('3. Overview names current Supabase and Showdown DB alignment state', () => {
   inc(ui, 'showdown_entities DB rows are not the battle runtime source yet');
   inc(ui, 'Live logs exposed stale DB item drift');
   inc(ui, 'Pokemon data audit has unresolved reviewer risk');
-  inc(ui, 'Current Y fork changes are not pushed upstream to Alfredo yet');
   inc(ui, 'Mechanics parity is broader than the current ability slice');
   inc(ui, 'Source refresh needed must be visible before trust claims');
   inc(ui, 'Full raw thousand-battle retention is still not automatic');
@@ -86,13 +88,13 @@ T('3. Overview names current Supabase and Showdown DB alignment state', () => {
 });
 
 T('4. Overview includes next milestones and source docs', () => {
-  inc(ui, 'Verify v2.1.32 live logs, QA artifact, and sync Alfredo');
+  inc(ui, 'Verify v2.1.33 live logs and QA artifact');
   inc(ui, 'Mirror or update JD issue alignment in the Y fork');
   inc(ui, 'Apply Champion item cleanup to live Supabase rows');
   inc(ui, 'Wire approved Showdown DB data into generated runtime assets');
   inc(ui, 'Group mechanics parity work by battle system');
   inc(ui, 'Rebuild editor into full Champion team builder');
-  inc(ui, 'Prepare upstream PR to Alfredo after Y fork verification');
+  inc(ui, 'Keep Alfredo and Y fork synced through protected PRs');
   inc(ui, 'Surface source drift as update needed in Overview');
   inc(ui, 'Recent Fix + Issue Snapshot');
   inc(ui, 'recent-fixes-and-open-issues-2026-06-21.md');

--- a/poke-sim/tests/turn_log_export_validator_tests.js
+++ b/poke-sim/tests/turn_log_export_validator_tests.js
@@ -275,7 +275,54 @@ function stripStableFields(payload) {
     truthy(res.findings.some(f => f.code === 'speed-detail-missing-effective-speed'), 'missing effective speed error');
   });
 
-  T('10. calculated damage_events pass validation with modifier evidence', () => {
+  T('10. terminal no-valid-target skips pass when the target side is empty after earlier KO', () => {
+    const payload = stableFixture();
+    const turn = payload.turnLog[0];
+    const milotic = turn.post.roster.opponent[0];
+    turn.actions.player = [
+      { actor: 'Incineroar', kind: 'move', move: 'Knock Off', target: 'Milotic' }
+    ];
+    turn.actions.opponent = [];
+    turn.events = [
+      { type: 'log', text: 'Incineroar used Knock Off! (no valid target)' }
+    ];
+    turn.post.active.opponent = [];
+    turn.post.active_keys.opponent = [];
+    turn.post.active_stable_keys.opponent = [];
+    turn.post.roster.opponent = [Object.assign({}, milotic, {
+      key: 'opponent:fainted:0:Milotic',
+      zone: 'fainted',
+      status: 'fainted',
+      hp: 0,
+      hpLabel: '0%'
+    })];
+    delete turn.post.hp_pct[milotic.key];
+    turn.post.hp_pct_stable[milotic.stableKey] = 0;
+    turn.post.speed_order = ['Whimsicott'];
+    turn.post.speed_order_keys = [turn.post.roster.player[1].key];
+    turn.post.speed_order_stable_keys = [turn.post.roster.player[1].stableKey];
+
+    const res = validateTurnLogPayload(payload, { requireStable: true });
+    eq(res.summary.errors, 0, JSON.stringify(res.findings));
+    truthy(!res.findings.some(f => f.code === 'no-valid-target-with-live-target'), 'terminal skip should not be flagged');
+  });
+
+  T('11. no-valid-target skips fail when a target side still has a live active Pokemon', () => {
+    const payload = stableFixture();
+    const turn = payload.turnLog[0];
+    turn.actions.player = [
+      { actor: 'Incineroar', kind: 'move', move: 'Knock Off', target: 'Milotic' }
+    ];
+    turn.actions.opponent = [];
+    turn.events = [
+      { type: 'log', text: 'Incineroar used Knock Off! (no valid target)' }
+    ];
+
+    const res = validateTurnLogPayload(payload, { requireStable: true });
+    truthy(res.findings.some(f => f.code === 'no-valid-target-with-live-target'), 'missing live-target no-valid-target error');
+  });
+
+  T('12. calculated damage_events pass validation with modifier evidence', () => {
     const payload = stableFixture();
     payload.turnLog[0].damage_events = [{
       attacker: 'Incineroar',
@@ -320,7 +367,7 @@ function stripStableFields(payload) {
     eq(res.summary.errors, 0, JSON.stringify(res.findings));
   });
 
-  T('11. malformed calculated damage_events fail validation', () => {
+  T('13. malformed calculated damage_events fail validation', () => {
     const payload = stableFixture();
     payload.turnLog[0].damage_events = [{
       attacker: 'Incineroar',

--- a/poke-sim/tools/README.md
+++ b/poke-sim/tools/README.md
@@ -121,6 +121,7 @@ Checks:
 - active/bench key maps
 - HP and speed-order key coverage
 - observed event order against move priority plus snapshot speed order
+- `(no valid target)` lines only pass when the target side is empty after an earlier KO
 
 ```bash
 # Legacy-compatible validation

--- a/poke-sim/tools/validate-turn-logs.mjs
+++ b/poke-sim/tools/validate-turn-logs.mjs
@@ -357,6 +357,78 @@ function validateObservedActionOrder(turn, findings) {
   }
 }
 
+function sideFromActions(turn, actor, move) {
+  const matches = [];
+  for (const side of SIDES) {
+    const rows = Array.isArray(turn && turn.actions && turn.actions[side]) ? turn.actions[side] : [];
+    for (const action of rows) {
+      if (!action || action.actor !== actor || action.move !== move) continue;
+      matches.push({ side, action });
+    }
+  }
+  const sides = Array.from(new Set(matches.map(m => m.side)));
+  return sides.length === 1 ? matches.find(m => m.side === sides[0]) : null;
+}
+
+function activeSideForName(snapshot, name) {
+  const matches = [];
+  for (const side of SIDES) {
+    const rows = ((snapshot && snapshot.roster && snapshot.roster[side]) || []);
+    for (const row of rows) {
+      if (!row || row.status !== 'active') continue;
+      if (rowName(row) === name || row.species === name) matches.push(side);
+    }
+  }
+  const unique = Array.from(new Set(matches));
+  return unique.length === 1 ? unique[0] : null;
+}
+
+function activeTargetKeys(snapshot, side) {
+  const stable = getSideKeys(snapshot, side, 'active_stable_keys');
+  return stable.length ? stable : getSideKeys(snapshot, side, 'active_keys');
+}
+
+function validateNoValidTargetSkips(turn, findings) {
+  const events = Array.isArray(turn && turn.events) ? turn.events : [];
+  for (const event of events) {
+    const text = cleanText(event && event.text);
+    const match = text.match(/^(.+?) used (.+?)! \(no valid target\)$/);
+    if (!match) continue;
+
+    const actor = match[1];
+    const move = match[2];
+    const resolved = sideFromActions(turn, actor, move);
+    if (!resolved) {
+      findings.push(finding('warning', 'no-valid-target-actor-unresolved', 'Could not resolve the side for a no-valid-target action.', {
+        turn: turn && turn.turn,
+        actor,
+        move,
+        text
+      }));
+      continue;
+    }
+
+    const actionTarget = resolved.action && resolved.action.target;
+    const targetSide = actionTarget
+      ? (activeSideForName(turn && turn.pre, actionTarget) || activeSideForName(turn && turn.post, actionTarget))
+      : null;
+    const checkedSide = targetSide || (resolved.side === 'player' ? 'opponent' : 'player');
+    const postActive = activeTargetKeys(turn && turn.post, checkedSide);
+
+    if (postActive.length) {
+      findings.push(finding('error', 'no-valid-target-with-live-target', 'A no-valid-target action resolved while the intended target side still had a live active Pokemon.', {
+        turn: turn && turn.turn,
+        actor,
+        move,
+        target: actionTarget || '',
+        targetSide: checkedSide,
+        preActiveTargetKeys: activeTargetKeys(turn && turn.pre, checkedSide),
+        postActiveTargetKeys: postActive
+      }));
+    }
+  }
+}
+
 function validateDamageEvents(turn, findings) {
   const rows = Array.isArray(turn && turn.damage_events) ? turn.damage_events : [];
   for (let i = 0; i < rows.length; i += 1) {
@@ -447,6 +519,7 @@ export function validateTurnLogPayload(payload, options = {}) {
       validateSnapshot(snapshot, turnNo, snapName, state, findings);
     }
     validateObservedActionOrder(turn || {}, findings);
+    validateNoValidTargetSkips(turn || {}, findings);
     validateDamageEvents(turn || {}, findings);
   }
 
@@ -507,7 +580,8 @@ function usage() {
     'Usage: node tools/validate-turn-logs.mjs [--require-stable] [--json] <champions-turn-log.json...>',
     '',
     'Checks exported battle logs for roster identity, item drift, active/bench key mapping,',
-    'HP key coverage, speed-order key coverage, and observed priority/speed event order.'
+    'HP key coverage, speed-order key coverage, observed priority/speed event order,',
+    'and no-valid-target skips while a target side still has a live active Pokemon.'
   ].join('\n');
 }
 

--- a/poke-sim/ui.js
+++ b/poke-sim/ui.js
@@ -116,9 +116,9 @@ function csGetBuildId() {
   try {
     var el = document.getElementById('build-version');
     var txt = el && typeof el.textContent === 'string' ? el.textContent.trim() : '';
-    return txt || 'v2.1.32-tera-blast-parity';
+    return txt || 'v2.1.33-log-target-guard';
   } catch (e) {
-    return 'v2.1.32-tera-blast-parity';
+    return 'v2.1.33-log-target-guard';
   }
 }
 
@@ -5888,7 +5888,7 @@ var CS_OVERVIEW_DATA = {
     { label: 'Live Supabase', value: 'Teams + analyses' },
     { label: 'Showdown DB', value: 'Checking...' },
     { label: 'Team Format', value: 'Champion/SP focus' },
-    { label: 'Turn Logs', value: 'Structural clean' },
+    { label: 'Turn Logs', value: 'Strict + target guard' },
     { label: 'Target Guard', value: 'Canonical bridge' },
     { label: 'QA Log Retention', value: 'Capped + artifact' },
     { label: 'Ability Inventory', value: '80/80 modeled' },
@@ -5978,7 +5978,7 @@ var CS_OVERVIEW_DATA = {
     {
       status: 'done',
       title: 'Exported log validator added',
-      detail: 'poke-sim/tools/validate-turn-logs.mjs checks identity, item drift, HP maps, active/bench mapping, speed order, and observed priority order.'
+      detail: 'poke-sim/tools/validate-turn-logs.mjs checks identity, item drift, HP maps, active/bench mapping, speed order, observed priority order, damage evidence shape, and no-valid-target skips while a target side still has a live active Pokemon.'
     },
     {
       status: 'done',
@@ -6014,6 +6014,11 @@ var CS_OVERVIEW_DATA = {
     },
     {
       status: 'validated',
+      title: 'Latest v2.1.31 logs pass strict structure and expose stacked mechanics evidence',
+      detail: 'Four June 22 logs from ?v=e209f3b pass strict validation with zero warnings across 28 turns. They include super-effective and resisted damage, typed held-item boosts, Knock Off boosts, doubles spread reduction, sun weather boosts, stat-stage damage evidence, and burn/status penalties. Their lone no-valid-target line is terminal after the last opposing active faints, so v2.1.33 adds a validator guard that only fails no-target skips when a target side still has a live active Pokemon.'
+    },
+    {
+      status: 'validated',
       title: 'Item timing regression reproduced and covered',
       detail: 'Fresh logs showed Sitrus restoring after a 0 HP hit; items_tests.js now verifies surviving Sitrus, lethal Sitrus rejection, lethal Oran rejection, and battle-log faint behavior.'
     },
@@ -6030,7 +6035,7 @@ var CS_OVERVIEW_DATA = {
     {
       status: 'validated',
       title: 'Current release checks are green',
-      detail: 'v2.1.32 Tera Blast Parity carries the v2.1.31 Editor Builder Roadmap, v2.1.30 Spread Legality Guard, v2.1.29 Knock Off guard, and v2.1.28 mechanics stack guard. Source-truth tests, target bridge coverage, DB seed SP caps, preloaded team legality, custom import/DB merge guards, service-worker cache guard, damage-stack oracle, type multiplier audit, speed-stack evidence, Knock Off item-state tests, and strict validation are the local release checks for this build.'
+      detail: 'v2.1.33 Log Target Guard carries v2.1.32 Tera Blast Parity, v2.1.31 Editor Builder Roadmap, v2.1.30 Spread Legality Guard, v2.1.29 Knock Off guard, and v2.1.28 mechanics stack guard. Source-truth tests, target bridge coverage, DB seed SP caps, preloaded team legality, custom import/DB merge guards, service-worker cache guard, damage-stack oracle, type multiplier audit, speed-stack evidence, Knock Off item-state tests, no-valid-target validation, and strict validation are the local release checks for this build.'
     },
     {
       status: 'validated',
@@ -6076,6 +6081,11 @@ var CS_OVERVIEW_DATA = {
       status: 'validated',
       title: 'GitHub issue sweep completed',
       detail: 'Open issues were checked in TheYfactora12 and alfredocox repos. JD flags Alfredo #241 and #240 remain active; Josh/JD data-audit comments are tracked in Alfredo #231 and Y Factor #123.'
+    },
+    {
+      status: 'validated',
+      title: 'Y fork and Alfredo main are synced',
+      detail: 'Alfredo PR #245 merged the Champion parity tree after required checks passed, and TheYfactora12 main was fast-forwarded to the same merge commit so both repos are 1:1 at the current source tree.'
     }
   ],
   gaps: [
@@ -6088,11 +6098,6 @@ var CS_OVERVIEW_DATA = {
       status: 'gap',
       title: 'Pokemon data audit has unresolved reviewer risk',
       detail: 'Josh/JD notes on Alfredo #231 flag that Showdown data is present but not fully used for every move calculation and regional forms such as Arcanine may still need targeted review.'
-    },
-    {
-      status: 'gap',
-      title: 'Current Y fork changes are not pushed upstream to Alfredo yet',
-      detail: 'TheYfactora12 main carries v2.1.32 Tera Blast Parity plus v2.1.31 Editor Builder Roadmap, v2.1.30 Spread Legality Guard, v2.1.29 Knock Off guard, v2.1.28 mechanics stack guard, v2.1.27 QA artifact export, v2.1.25 target parity guard, and v2.1.26 overview truth notes. Alfredo still needs a reviewed sync PR so both repos stay 1:1.'
     },
     {
       status: 'gap',
@@ -6118,8 +6123,8 @@ var CS_OVERVIEW_DATA = {
   next: [
     {
       status: 'next',
-      title: 'Verify v2.1.32 live logs, QA artifact, and sync Alfredo',
-      detail: 'Use fresh GitHub Pages logs and the QA Artifact export to confirm the build label, source URL, stable turn-log fields, no team-load failure, retained-evidence summary, speed_order_details, stat_boosts, damage_events snapshots, legal Champion SP team data, Tera Blast damage evidence when present, and Knock Off boost evidence, then prepare the reviewed upstream sync to Alfredo.'
+      title: 'Verify v2.1.33 live logs and QA artifact',
+      detail: 'Use fresh GitHub Pages logs and the QA Artifact export to confirm the build label, source URL, stable turn-log fields, no team-load failure, retained-evidence summary, speed_order_details, stat_boosts, damage_events snapshots, legal Champion SP team data, Tera Blast damage evidence when present, Knock Off boost evidence, and no live-target no-valid-target skips.'
     },
     {
       status: 'next',
@@ -6148,8 +6153,8 @@ var CS_OVERVIEW_DATA = {
     },
     {
       status: 'next',
-      title: 'Prepare upstream PR to Alfredo after Y fork verification',
-      detail: 'Once the live Y test page shows v2.1.32 and fresh logs plus QA artifact pass, open a clean upstream PR with the target parity guard, ability parity slice, mechanics stack guard, Knock Off guard, Tera Blast parity, SP legality guard, editor-builder roadmap note, load-path proof, overview alignment, and issue notes.'
+      title: 'Keep Alfredo and Y fork synced through protected PRs',
+      detail: 'Direct Alfredo main pushes are blocked by repository rules, so future parity slices should land in TheYfactora12, pass live-page checks, then sync to Alfredo through a reviewed PR with required checks before fast-forwarding the fork back to the same merge commit.'
     },
     {
       status: 'next',


### PR DESCRIPTION
Adds a stricter exported turn-log guard for target safety and updates the Overview truth board after the latest user log review. Terminal no-valid-target skips remain legal when an earlier KO empties the target side, but validator output now fails if a no-target skip occurs while that target side still has a live active Pokemon. Also records the June 22 v2.1.31 log batch, mechanics evidence observed in those logs, the v2.1.33 build/cache marker, and the completed Alfredo/Y fork sync state. Validation run locally: turn_log_export_validator_tests 13 pass/0 fail, t191 overview 6 pass/0 fail, phase5 turn log 25 pass/0 fail, t163 export 7/7, sw local credentials 6 pass/0 fail, showdown damage oracle 52 pass/0 fail, type multiplier audit 5 pass/0 fail, non-DB suite 91 files passed/14 skipped, battle audit 4,500 battles with 0 JS errors, bundle fresh, git diff --check clean.