### PR TITLE
Record latest live log proof

### DIFF
--- a/poke-sim/index.html
+++ b/poke-sim/index.html
@@ -66,7 +66,7 @@
         <path d="M 21 6 L 16.5 16 L 19.5 16 L 15.5 28 L 21.5 15.5 L 18.5 15.5 L 22 6 Z" fill="url(#hBolt)" stroke="#ecfeff" stroke-width="0.5" stroke-linejoin="round"/>
       </svg>
       <div>
-        <h1 class="site-title">Poke-e-Sim Champion 2026 Preview <span class="build-version" id="build-version" title="Build version - bumps on every commit so you can confirm which build you are testing">v2.1.33-log-target-guard</span> <span id="db-offline-chip" class="db-offline-chip" title="Live database unavailable — using bundled team data" style="display:none;background:#7c2d12;color:#fed7aa;border:1px solid #ea580c;border-radius:6px;padding:2px 8px;font-size:11px;font-weight:600;letter-spacing:0.3px;margin-left:6px;vertical-align:middle;">[DB offline]</span></h1>
+        <h1 class="site-title">Poke-e-Sim Champion 2026 Preview <span class="build-version" id="build-version" title="Build version - bumps on every commit so you can confirm which build you are testing">v2.1.34-live-log-proof</span> <span id="db-offline-chip" class="db-offline-chip" title="Live database unavailable — using bundled team data" style="display:none;background:#7c2d12;color:#fed7aa;border:1px solid #ea580c;border-radius:6px;padding:2px 8px;font-size:11px;font-weight:600;letter-spacing:0.3px;margin-left:6px;vertical-align:middle;">[DB offline]</span></h1>
         <p class="site-sub">Champions 2026 Preview · VGC Doubles Simulator</p>
       </div>
     </div>

--- a/poke-sim/pokemon-champion-2026.html
+++ b/poke-sim/pokemon-champion-2026.html
@@ -2333,7 +2333,7 @@ table{border-collapse:collapse;width:100%}
         <path d="M 21 6 L 16.5 16 L 19.5 16 L 15.5 28 L 21.5 15.5 L 18.5 15.5 L 22 6 Z" fill="url(#hBolt)" stroke="#ecfeff" stroke-width="0.5" stroke-linejoin="round"/>
       </svg>
       <div>
-        <h1 class="site-title">Poke-e-Sim Champion 2026 Preview <span class="build-version" id="build-version" title="Build version - bumps on every commit so you can confirm which build you are testing">v2.1.33-log-target-guard</span> <span id="db-offline-chip" class="db-offline-chip" title="Live database unavailable — using bundled team data" style="display:none;background:#7c2d12;color:#fed7aa;border:1px solid #ea580c;border-radius:6px;padding:2px 8px;font-size:11px;font-weight:600;letter-spacing:0.3px;margin-left:6px;vertical-align:middle;">[DB offline]</span></h1>
+        <h1 class="site-title">Poke-e-Sim Champion 2026 Preview <span class="build-version" id="build-version" title="Build version - bumps on every commit so you can confirm which build you are testing">v2.1.34-live-log-proof</span> <span id="db-offline-chip" class="db-offline-chip" title="Live database unavailable — using bundled team data" style="display:none;background:#7c2d12;color:#fed7aa;border:1px solid #ea580c;border-radius:6px;padding:2px 8px;font-size:11px;font-weight:600;letter-spacing:0.3px;margin-left:6px;vertical-align:middle;">[DB offline]</span></h1>
         <p class="site-sub">Champions 2026 Preview · VGC Doubles Simulator</p>
       </div>
     </div>
@@ -18512,9 +18512,9 @@ function csGetBuildId() {
   try {
     var el = document.getElementById('build-version');
     var txt = el && typeof el.textContent === 'string' ? el.textContent.trim() : '';
-    return txt || 'v2.1.33-log-target-guard';
+    return txt || 'v2.1.34-live-log-proof';
   } catch (e) {
-    return 'v2.1.33-log-target-guard';
+    return 'v2.1.34-live-log-proof';
   }
 }
 
@@ -24284,7 +24284,7 @@ var CS_OVERVIEW_DATA = {
     { label: 'Live Supabase', value: 'Teams + analyses' },
     { label: 'Showdown DB', value: 'Checking...' },
     { label: 'Team Format', value: 'Champion/SP focus' },
-    { label: 'Turn Logs', value: 'Strict + target guard' },
+    { label: 'Turn Logs', value: 'v2.1.33 clean' },
     { label: 'Target Guard', value: 'Canonical bridge' },
     { label: 'QA Log Retention', value: 'Capped + artifact' },
     { label: 'Ability Inventory', value: '80/80 modeled' },
@@ -24410,8 +24410,8 @@ var CS_OVERVIEW_DATA = {
     },
     {
       status: 'validated',
-      title: 'Latest v2.1.31 logs pass strict structure and expose stacked mechanics evidence',
-      detail: 'Four June 22 logs from ?v=e209f3b pass strict validation with zero warnings across 28 turns. They include super-effective and resisted damage, typed held-item boosts, Knock Off boosts, doubles spread reduction, sun weather boosts, stat-stage damage evidence, and burn/status penalties. Their lone no-valid-target line is terminal after the last opposing active faints, so v2.1.33 adds a validator guard that only fails no-target skips when a target side still has a live active Pokemon.'
+      title: 'Latest v2.1.33 logs pass strict structure and expose stacked mechanics evidence',
+      detail: 'Five June 22 exports carry build_id v2.1.33-log-target-guard and pass strict validation with zero warnings across 27 turns. They include 67 damage events, 31 super-effective hits, 14 resisted hits, 20 typed held-item boosts, 5 Knock Off boosts, 28 spread reductions, 8 sun weather boosts, 5 stat-stage damage rows, and 8 exact-speed-tie markers. The only no-valid-target line is terminal after the player side is empty, consecutive Torkoal Protect failures are expected, and no Tera Blast event appeared in this batch. The source_url query still showed ?v=e209f3b, so build_id is the authoritative bundle proof for these files.'
     },
     {
       status: 'validated',
@@ -24431,7 +24431,7 @@ var CS_OVERVIEW_DATA = {
     {
       status: 'validated',
       title: 'Current release checks are green',
-      detail: 'v2.1.33 Log Target Guard carries v2.1.32 Tera Blast Parity, v2.1.31 Editor Builder Roadmap, v2.1.30 Spread Legality Guard, v2.1.29 Knock Off guard, and v2.1.28 mechanics stack guard. Source-truth tests, target bridge coverage, DB seed SP caps, preloaded team legality, custom import/DB merge guards, service-worker cache guard, damage-stack oracle, type multiplier audit, speed-stack evidence, Knock Off item-state tests, no-valid-target validation, and strict validation are the local release checks for this build.'
+      detail: 'v2.1.34 Live Log Proof carries v2.1.33 Log Target Guard, v2.1.32 Tera Blast Parity, v2.1.31 Editor Builder Roadmap, v2.1.30 Spread Legality Guard, v2.1.29 Knock Off guard, and v2.1.28 mechanics stack guard. Source-truth tests, target bridge coverage, DB seed SP caps, preloaded team legality, custom import/DB merge guards, service-worker cache guard, damage-stack oracle, type multiplier audit, speed-stack evidence, Knock Off item-state tests, no-valid-target validation, and strict validation are the local release checks for this build.'
     },
     {
       status: 'validated',
@@ -24519,8 +24519,8 @@ var CS_OVERVIEW_DATA = {
   next: [
     {
       status: 'next',
-      title: 'Verify v2.1.33 live logs and QA artifact',
-      detail: 'Use fresh GitHub Pages logs and the QA Artifact export to confirm the build label, source URL, stable turn-log fields, no team-load failure, retained-evidence summary, speed_order_details, stat_boosts, damage_events snapshots, legal Champion SP team data, Tera Blast damage evidence when present, Knock Off boost evidence, and no live-target no-valid-target skips.'
+      title: 'Verify v2.1.34 source URL and QA artifact',
+      detail: 'Use the newest GitHub Pages commit URL, fresh logs, and the QA Artifact export to confirm the build label, source URL query, stable turn-log fields, no team-load failure, retained-evidence summary, speed_order_details, stat_boosts, damage_events snapshots, legal Champion SP team data, Tera Blast damage evidence when present, Knock Off boost evidence, and no live-target no-valid-target skips.'
     },
     {
       status: 'next',

--- a/poke-sim/reports/recent-fixes-and-open-issues-2026-06-21.md
+++ b/poke-sim/reports/recent-fixes-and-open-issues-2026-06-21.md
@@ -5,12 +5,13 @@ This snapshot records the current truth after the June 21-22 live-log review, Gi
 ## 2026-06-22 Deployment Update
 
 - The prior Y fork public validation target was commit `7e0deca` (`model champion ability parity`).
-- `v2.1.33-log-target-guard` supersedes `v2.1.32-tera-blast-parity` for the current GitHub Pages release and bumps the service-worker cache to `champions-sim-v67-log-target-guard`.
+- `v2.1.34-live-log-proof` supersedes `v2.1.33-log-target-guard` for the current GitHub Pages release and bumps the service-worker cache to `champions-sim-v68-live-log-proof`.
 - `v2.1.29` promotes `Knock Off` from baseline to verified move coverage. The source truth is Pokemon Showdown move/item behavior checked against Bulbapedia: removable held items give the 1.5x base-power boost and are removed after damage; legal no-item targets give no boost and remove nothing; corresponding Mega Stones are not removable and do not give the boost even before Mega Evolution; Sticky Hold blocks removal while the holder is alive but does not suppress the boost when the item is otherwise removable.
 - `v2.1.30` converts shipped inferred Champion archetype spreads from SV-shaped EV values to Champion SP values, hard-rejects over-cap or malformed Champion spreads in imports/editor/DB merges/Supabase upserts, and records the Showdown-vs-preview source conflict on the per-stat cap.
 - `v2.1.31` records that the current edit-team UI is guarded but not fluid enough for fully customizable Champion team building; this is tracked as later UX work after sim-truth gates.
 - `v2.1.32` promotes Tera Blast parity: inactive Tera Blast remains Normal/special, active Tera Blast uses the attacker's Tera type, active Tera Blast ignores Normal-conversion abilities such as Pixilate, active category selects physical only when boosted Attack is greater than boosted Special Attack, and DB-style `tera_type` now hydrates into engine battle state.
 - `v2.1.33` promotes log validation around target safety: terminal `(no valid target)` lines are allowed when an earlier KO emptied the target side, but future logs fail validation if a no-target skip occurs while that target side still has a live active Pokemon.
+- `v2.1.34` updates the Overview and issue snapshot with five current-build v2.1.33 exports that passed strict validation and exposed stacked mechanics evidence; no engine behavior changed in this slice.
 - Alfredo PR #245 merged the Champion parity tree after required checks passed; TheYfactora12 main was fast-forwarded to the same merge commit so both repos are 1:1 at the current source tree.
 - The earlier `e5af069` build added `champions-turn-log-v2` export metadata; fresh June 22 logs from `?v=7e0deca` validate structurally cleanly, then deeper replay review exposed the target bridge bug fixed in `v2.1.25`.
 - Supabase migration `2026_06_22_retire_legacy_sv_teams.sql` has run successfully; the two stale v1 teams are retired at the source.
@@ -29,11 +30,12 @@ This snapshot records the current truth after the June 21-22 live-log review, Gi
 | Team editor roadmap note | Tracked in `v2.1.31-editor-builder-roadmap` | The current set editor has Champion SP legality guardrails, but the team identified that it is not fluid enough for full customization. Later work should replace it with a complete builder for add/remove/reorder Pokemon, searchable fields, SP sliders/totals, import/export, Supabase save status, and rollback. |
 | Tera Blast dynamic type/category | Fixed in `v2.1.32-tera-blast-parity` | `engine.js` resolves active Tera Blast from battle state, accepts DB-style `tera_type`, ignores Normal-conversion abilities once Tera is active, records resolved move type/category in damage evidence, and `showdown_damage_oracle_tests.js` covers inactive, special active, physical active, stat-boost-flipped, DB-hydrated, and Pixilate-bypass cases against `@smogon/calc`. |
 | Target-safe log validation | Guarded in `v2.1.33-log-target-guard` | `validate-turn-logs.mjs` now rejects `(no valid target)` skips when the target side still has a live active Pokemon, while preserving legitimate terminal skips after an earlier KO empties that side. |
-| GitHub Pages cache drift | Guarded for this release | `sw.js` cache bumped to `champions-sim-v67-log-target-guard`; `index.html`, `ui.js`, and bundled `pokemon-champion-2026.html` carry `v2.1.33-log-target-guard` after bundle rebuild. |
+| Latest live-log proof | Validated in `v2.1.34-live-log-proof` | Five current-build v2.1.33 exports passed strict validation with zero warnings across 27 turns and showed super-effective/resisted hits, typed held-item boosts, Knock Off boosts, spread reduction, sun weather boosts, stat-stage damage evidence, and exact-speed-tie markers. |
+| GitHub Pages cache drift | Guarded for this release | `sw.js` cache bumped to `champions-sim-v68-live-log-proof`; `index.html`, `ui.js`, and bundled `pokemon-champion-2026.html` carry `v2.1.34-live-log-proof` after bundle rebuild. |
 | Exported-log build drift | Guarded in `e5af069` | Downloaded replay logs now include `schema_version: champions-turn-log-v2`, `exported_at`, `build_id`, and `source_url`, so future debug logs can prove which deployed build produced them. |
 | Showdown static metadata use | Partially fixed | Battle construction and move metadata can use generated Showdown static rows first, then local fallbacks. This is not the same as live DB runtime consumption. |
 | Showdown target category bridge | Fixed and guarded in `v2.1.25-target-parity-guard` | `runtime_data.js` canonicalizes Showdown target categories before engine use; `engine.js` keeps a guarded fallback for engine-only tests; move tests cover Hyper Voice spread targeting and stale opposing-target retargeting. |
-| Overview truth board | Updated in `v2.1.33-log-target-guard` | The live Overview tab now names the target bridge fix, DB/runtime source split, capped browser log retention, shipped QA artifact export, type audit, typed held-item boost fix, Knock Off behavior fix, Tera Blast parity, no-valid-target guard, Champion SP spread guard, editor-builder UX gap, stat/speed/export evidence, remaining grouped mechanics gap, and completed Alfredo sync. |
+| Overview truth board | Updated in `v2.1.34-live-log-proof` | The live Overview tab now names the target bridge fix, DB/runtime source split, capped browser log retention, shipped QA artifact export, type audit, typed held-item boost fix, Knock Off behavior fix, Tera Blast parity, no-valid-target guard, Champion SP spread guard, editor-builder UX gap, latest live-log proof, stat/speed/export evidence, remaining grouped mechanics gap, and completed Alfredo sync. |
 | Large-run QA artifact | Added in `v2.1.27-qa-artifact-export` | Saved Analyses now has a `QA Artifact` export that records build ID, source URL, retention caps, summary counts, retained compact sim-log entries, and retained replay cards. |
 | Type multiplier audit | Added in `v2.1.28-mechanics-stack-guard` | `reports/type_multiplier_audit.md` shows each shipped move user's resolved move type, 4x/2x/1x/0.5x/0.25x/0x target buckets across the shipped roster, declared defensive Tera bucket changes, and dynamic move-type rules. |
 | Typed held-item damage boosts | Fixed in `v2.1.28-mechanics-stack-guard` | `engine.js` now applies legal typed held-item boosts such as Charcoal, Mystic Water, Soft Sand, Black Glasses, Spell Tag, Fairy Feather, and Never-Melt Ice as Showdown-style base-power modifiers. `showdown_damage_oracle_tests.js` covers Charcoal + Blaze + sun + STAB + super-effective Fire damage. |
@@ -228,6 +230,40 @@ Target/no-target finding:
 - It was legitimate: Whimsicott KO'd the opponent's final active Milotic earlier in the same turn, so Incineroar's queued Knock Off had no legal opposing active target left.
 - To prevent future regressions, `v2.1.33` adds validator coverage that fails no-target skips only when the target side still has a live active Pokemon after the turn.
 
+## 2026-06-22 Latest Log Review - v2.1.33 Exports
+
+Reviewed user exports produced at `2026-06-23T03:18Z`:
+
+- `champions-turn-log-1027724309,202665117,2643646420,4291685691.json`
+- `champions-turn-log-2505975043,194047141,4217885793,3303813312.json`
+- `champions-turn-log-4103504750,2481376110,3893515921,176717201.json`
+- `champions-turn-log-3760269446,1389782942,2911285047,2893946322.json`
+- `champions-turn-log-2509498104,1561655873,1656240141,670519114.json`
+
+Structural result:
+
+- All five carried `build_id: v2.1.33-log-target-guard`.
+- All five passed `node poke-sim/tools/validate-turn-logs.mjs --require-stable --json ...` with `0` errors and `0` warnings across `27` turns.
+- No `team not loaded`, duplicate stable key, invalid HP map, wrong-side stable key, `NaN`, or live-target `(no valid target)` failure appeared.
+- The exported `source_url` still contained the older query `?v=e209f3b`; the page build label proves the current bundle, but the next manual run should use the newest commit query so source URL traceability is cleaner.
+
+Mechanics evidence observed:
+
+- `67` structured damage events.
+- `31` super-effective hits and `14` resisted hits.
+- `20` typed held-item boosts.
+- `5` Knock Off boost rows.
+- `28` doubles spread reductions.
+- `8` sun weather boosts.
+- `5` stat-stage-aware damage rows.
+- `8` exact-speed-tie markers.
+- `0` Tera Blast events appeared in this batch, so Tera Blast still needs a live-log sample when present.
+
+Target/protection finding:
+
+- One `Milotic used Blizzard! (no valid target)` line appeared after Garchomp was KO'd and the player side had no active Pokemon left, so it is a legitimate terminal skip.
+- Two `Torkoal used Protect! But it failed!` lines appeared after earlier Protect usage and match consecutive-Protect failure behavior.
+
 ## Large-Run Log Retention Note
 
 - The sim and CI can run thousands of battles for validation, but the browser UI intentionally keeps a bounded amount of replay evidence so local storage, downloads, and the page do not become unusable.
@@ -274,6 +310,7 @@ Use these statements in team updates and PR notes:
 - Tracked for later: current edit-team UI is guarded but not fluid; full Champion team-builder UX still needs a separate build.
 - Fixed for `v2.1.32`: Tera Blast now matches Showdown for inactive Normal/special behavior, active Tera type, active Normal-conversion ability bypass, active physical/special category selection from boosted attacking stats, and DB-style `tera_type` hydration into battle state.
 - Guarded for `v2.1.33`: exported-log validation now distinguishes legitimate terminal no-target skips from target failures while a live active target remains.
+- Validated for `v2.1.34`: five current-build v2.1.33 logs passed strict validation and showed stacked mechanics evidence; no new engine issue was confirmed in that batch.
 - Completed: Alfredo PR #245 merged and both `alfredocox/main` and `TheYfactora12/main` now point to the same source tree.
 - Completed: Supabase cleanup migration retired the stale v1 DB teams.
 - Known limitation: browser replay/log retention is intentionally capped; QA Artifact exports retained evidence and caps, but it still does not preserve every raw battle log from huge runs.
@@ -284,7 +321,7 @@ Use these statements in team updates and PR notes:
 
 ## Current Next Path
 
-1. Export one fresh single-run log, one fresh Run All log, and one `QA Artifact` from the public URL after `v2.1.33-log-target-guard`; verify build/source metadata, stable turn-log fields, legal Champion SP team data, `speed_order_details`, `stat_boosts`, `damage_events`, Tera Blast evidence when present, `knock_off_boost` evidence when Knock Off appears, no team-load failure, no live-target `(no valid target)` failures, and retained-evidence summary counts.
+1. Export one fresh single-run log, one fresh Run All log, and one `QA Artifact` from the public URL after `v2.1.34-live-log-proof`; verify build/source metadata, stable turn-log fields, legal Champion SP team data, `speed_order_details`, `stat_boosts`, `damage_events`, Tera Blast evidence when present, `knock_off_boost` evidence when Knock Off appears, no team-load failure, no live-target `(no valid target)` failures, and retained-evidence summary counts.
 2. Mirror/update issue notes in the Y fork for Alfredo #241, #240, and #231 so both repos show the same truth.
 3. Continue converting high-usage baseline moves into verified mechanics coverage, grouping them by damage modifiers, item interactions, stat changes, targeting/redirection, protection, switching, and status.
 4. Continue the grouped move/damage/mechanics parity track against Showdown first, with Champions overrides only when explicitly sourced.

--- a/poke-sim/sw.js
+++ b/poke-sim/sw.js
@@ -62,7 +62,8 @@
 // v65-editor-builder-roadmap [2026-06-22] - Overview note for full team-builder UX.
 // v66-tera-blast-parity [2026-06-22] - Tera Blast dynamic type/category parity.
 // v67-log-target-guard [2026-06-22] - No-valid-target log guard and Overview sync status.
-const CACHE_NAME = 'champions-sim-v67-log-target-guard';
+// v68-live-log-proof [2026-06-22] - Overview updated with v2.1.33 live log proof.
+const CACHE_NAME = 'champions-sim-v68-live-log-proof';
 const SPRITE_CACHE = 'champions-sprites-v1';
 
 const APP_ASSETS = [

--- a/poke-sim/tests/phase5_turn_log_tests.js
+++ b/poke-sim/tests/phase5_turn_log_tests.js
@@ -415,7 +415,7 @@ T('T5c-3 JSON download produces valid parseable file', () => {
   ctx.downloadReplayTurnLog({ seed: 'abc', result: 'win', turnLog: battleA.turnLog, position_path: battleA.position_path });
   truthy(parsed && Array.isArray(parsed.turnLog), 'download JSON did not parse');
   eq(parsed.schema_version, 'champions-turn-log-v2', 'download schema version missing');
-  truthy(/^v2\.1\.33-log-target-guard/.test(parsed.build_id || ''), 'download build id missing');
+  truthy(/^v2\.1\.34-live-log-proof/.test(parsed.build_id || ''), 'download build id missing');
   truthy(typeof parsed.exported_at === 'string' && parsed.exported_at.length > 0, 'download timestamp missing');
 });
 

--- a/poke-sim/tests/sw_local_credentials_tests.js
+++ b/poke-sim/tests/sw_local_credentials_tests.js
@@ -40,7 +40,7 @@ T('3. missing local-credentials.js returns empty JavaScript instead of cached ap
 });
 
 T('4. service worker cache is bumped for stale app-shell release fix', () => {
-  truthy(sw.includes('champions-sim-v67-log-target-guard'), 'CACHE_NAME should be v67 Log Target Guard');
+  truthy(sw.includes('champions-sim-v68-live-log-proof'), 'CACHE_NAME should be v68 Live Log Proof');
 });
 
 T('5. app shell includes pokemon-champion bundle in network-first detection', () => {

--- a/poke-sim/tests/t163_export_my_data_tests.js
+++ b/poke-sim/tests/t163_export_my_data_tests.js
@@ -266,7 +266,7 @@ async function main() {
     const payload = await csBuildQaArtifactExport('player');
     eq(payload.schema_version, 'champions-qa-artifact-v1');
     eq(payload.artifact_type, 'large-run-qa-retained-evidence');
-    truthy(/^v2\.1\.33-log-target-guard/.test(payload.build_id || ''), 'QA build id missing');
+    truthy(/^v2\.1\.34-live-log-proof/.test(payload.build_id || ''), 'QA build id missing');
     eq(payload.source_url, 'http://localhost/');
     eq(payload.retention.max_replay_cards, 240);
     eq(payload.retention.max_replay_log_lines, 200);

--- a/poke-sim/tests/t191_overview_tab_tests.js
+++ b/poke-sim/tests/t191_overview_tab_tests.js
@@ -53,12 +53,12 @@ T('2. Overview tracks accomplished work and validation proof', () => {
   inc(ui, 'Simulation-first direction documented');
   inc(ui, 'Public release milestone map documented');
   inc(ui, 'Live exported logs prove the sim now runs');
-  inc(ui, 'Latest v2.1.31 logs pass strict structure and expose stacked mechanics evidence');
-  inc(ui, 'only fails no-target skips when a target side still has a live active Pokemon');
+  inc(ui, 'Latest v2.1.33 logs pass strict structure and expose stacked mechanics evidence');
+  inc(ui, 'The only no-valid-target line is terminal after the player side is empty');
   inc(ui, 'Item timing regression reproduced and covered');
   inc(ui, 'Fresh logs exposed a targeting boundary bug');
   inc(ui, 'Ability coverage guard is green');
-  inc(ui, 'v2.1.33 Log Target Guard carries v2.1.32 Tera Blast Parity');
+  inc(ui, 'v2.1.34 Live Log Proof carries v2.1.33 Log Target Guard');
   inc(ui, 'Damage stack oracle is green');
   inc(ui, 'Tera Blast parity is green');
   inc(ui, 'Knock Off source-truth behavior is documented');
@@ -88,7 +88,7 @@ T('3. Overview names current Supabase and Showdown DB alignment state', () => {
 });
 
 T('4. Overview includes next milestones and source docs', () => {
-  inc(ui, 'Verify v2.1.33 live logs and QA artifact');
+  inc(ui, 'Verify v2.1.34 source URL and QA artifact');
   inc(ui, 'Mirror or update JD issue alignment in the Y fork');
   inc(ui, 'Apply Champion item cleanup to live Supabase rows');
   inc(ui, 'Wire approved Showdown DB data into generated runtime assets');

--- a/poke-sim/ui.js
+++ b/poke-sim/ui.js
@@ -116,9 +116,9 @@ function csGetBuildId() {
   try {
     var el = document.getElementById('build-version');
     var txt = el && typeof el.textContent === 'string' ? el.textContent.trim() : '';
-    return txt || 'v2.1.33-log-target-guard';
+    return txt || 'v2.1.34-live-log-proof';
   } catch (e) {
-    return 'v2.1.33-log-target-guard';
+    return 'v2.1.34-live-log-proof';
   }
 }
 
@@ -5888,7 +5888,7 @@ var CS_OVERVIEW_DATA = {
     { label: 'Live Supabase', value: 'Teams + analyses' },
     { label: 'Showdown DB', value: 'Checking...' },
     { label: 'Team Format', value: 'Champion/SP focus' },
-    { label: 'Turn Logs', value: 'Strict + target guard' },
+    { label: 'Turn Logs', value: 'v2.1.33 clean' },
     { label: 'Target Guard', value: 'Canonical bridge' },
     { label: 'QA Log Retention', value: 'Capped + artifact' },
     { label: 'Ability Inventory', value: '80/80 modeled' },
@@ -6014,8 +6014,8 @@ var CS_OVERVIEW_DATA = {
     },
     {
       status: 'validated',
-      title: 'Latest v2.1.31 logs pass strict structure and expose stacked mechanics evidence',
-      detail: 'Four June 22 logs from ?v=e209f3b pass strict validation with zero warnings across 28 turns. They include super-effective and resisted damage, typed held-item boosts, Knock Off boosts, doubles spread reduction, sun weather boosts, stat-stage damage evidence, and burn/status penalties. Their lone no-valid-target line is terminal after the last opposing active faints, so v2.1.33 adds a validator guard that only fails no-target skips when a target side still has a live active Pokemon.'
+      title: 'Latest v2.1.33 logs pass strict structure and expose stacked mechanics evidence',
+      detail: 'Five June 22 exports carry build_id v2.1.33-log-target-guard and pass strict validation with zero warnings across 27 turns. They include 67 damage events, 31 super-effective hits, 14 resisted hits, 20 typed held-item boosts, 5 Knock Off boosts, 28 spread reductions, 8 sun weather boosts, 5 stat-stage damage rows, and 8 exact-speed-tie markers. The only no-valid-target line is terminal after the player side is empty, consecutive Torkoal Protect failures are expected, and no Tera Blast event appeared in this batch. The source_url query still showed ?v=e209f3b, so build_id is the authoritative bundle proof for these files.'
     },
     {
       status: 'validated',
@@ -6035,7 +6035,7 @@ var CS_OVERVIEW_DATA = {
     {
       status: 'validated',
       title: 'Current release checks are green',
-      detail: 'v2.1.33 Log Target Guard carries v2.1.32 Tera Blast Parity, v2.1.31 Editor Builder Roadmap, v2.1.30 Spread Legality Guard, v2.1.29 Knock Off guard, and v2.1.28 mechanics stack guard. Source-truth tests, target bridge coverage, DB seed SP caps, preloaded team legality, custom import/DB merge guards, service-worker cache guard, damage-stack oracle, type multiplier audit, speed-stack evidence, Knock Off item-state tests, no-valid-target validation, and strict validation are the local release checks for this build.'
+      detail: 'v2.1.34 Live Log Proof carries v2.1.33 Log Target Guard, v2.1.32 Tera Blast Parity, v2.1.31 Editor Builder Roadmap, v2.1.30 Spread Legality Guard, v2.1.29 Knock Off guard, and v2.1.28 mechanics stack guard. Source-truth tests, target bridge coverage, DB seed SP caps, preloaded team legality, custom import/DB merge guards, service-worker cache guard, damage-stack oracle, type multiplier audit, speed-stack evidence, Knock Off item-state tests, no-valid-target validation, and strict validation are the local release checks for this build.'
     },
     {
       status: 'validated',
@@ -6123,8 +6123,8 @@ var CS_OVERVIEW_DATA = {
   next: [
     {
       status: 'next',
-      title: 'Verify v2.1.33 live logs and QA artifact',
-      detail: 'Use fresh GitHub Pages logs and the QA Artifact export to confirm the build label, source URL, stable turn-log fields, no team-load failure, retained-evidence summary, speed_order_details, stat_boosts, damage_events snapshots, legal Champion SP team data, Tera Blast damage evidence when present, Knock Off boost evidence, and no live-target no-valid-target skips.'
+      title: 'Verify v2.1.34 source URL and QA artifact',
+      detail: 'Use the newest GitHub Pages commit URL, fresh logs, and the QA Artifact export to confirm the build label, source URL query, stable turn-log fields, no team-load failure, retained-evidence summary, speed_order_details, stat_boosts, damage_events snapshots, legal Champion SP team data, Tera Blast damage evidence when present, Knock Off boost evidence, and no live-target no-valid-target skips.'
     },
     {
       status: 'next',


### PR DESCRIPTION
## Summary
- bump the public build marker to v2.1.34-live-log-proof and service-worker cache to champions-sim-v68-live-log-proof
- update the Overview tab and recent-fixes report with the latest five v2.1.33 browser log exports
- keep matching tests aligned with the new build label and Overview copy

## Latest log findings
- all five logs passed strict validation with 0 errors and 0 warnings across 27 turns
- observed 67 damage events, 31 super-effective hits, 14 resisted hits, 20 typed held-item boosts, 5 Knock Off boosts, 28 spread reductions, 8 sun weather boosts, 5 stat-stage damage rows, and 8 exact-speed-tie markers
- no engine bug confirmed from this batch: the no-valid-target line was terminal after the player side was empty, and Torkoal Protect failures matched consecutive-Protect behavior
- source_url still showed the stale ?v=e209f3b query even though build_id proved v2.1.33, so v2.1.34 calls out the next cache-busted test requirement

## Validation
- node poke-sim/tests/showdown_damage_oracle_tests.js
- node poke-sim/tests/type_multiplier_audit_tests.js
- node poke-sim/tests/t191_overview_tab_tests.js
- node poke-sim/tests/phase5_turn_log_tests.js
- node poke-sim/tests/t163_export_my_data_tests.js
- node poke-sim/tests/sw_local_credentials_tests.js
- bash poke-sim/tools/check-bundle.sh
- node poke-sim/tools/validate-turn-logs.mjs --require-stable --json <latest five logs>
- bash poke-sim/tests/_run_all.sh --skip-db